### PR TITLE
fix: make editor text selection clearly visible

### DIFF
--- a/frontend/src/components/CodeEditor/theme.ts
+++ b/frontend/src/components/CodeEditor/theme.ts
@@ -20,7 +20,7 @@ const chalky = "#e5c07b",
   highlightBackground = "#2c313a",
   background = "#282c34",
   tooltipBackground = "#353a42",
-  selection = "#3E4451",
+  selection = "rgba(124, 140, 255, 0.35)",
   cursor = "#528bff";
 
 /// The colors used in the theme, as CSS color strings.
@@ -53,22 +53,18 @@ const oneDarkTheme = EditorView.theme(
 
     ".cm-scroller": {
       overflow: "auto",
+      backgroundColor: "rgba(15, 15, 15, 0.4)",
     },
 
     ".cm-content": {
       caretColor: cursor,
-      backgroundColor: `rgba(15, 15, 15, 0.4)`,
-    },
-
-    ".cm-readonly .cm-content": {
-      backgroundColor: "rgba(5, 5, 5, 0.7)",
     },
 
     ".cm-cursor, .cm-dropCursor": { borderLeftColor: cursor },
 
     // --- Selection handling ---
     ".cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
-      backgroundColor: "unset",
+      backgroundColor: "rgba(124, 140, 255, 0.18)",
     },
 
     "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground":

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7,6 +7,9 @@
     -webkit-user-select: none; /* Safari */
     user-select: none;
   }
+  ::selection {
+    background-color: rgba(124, 140, 255, 0.4);
+  }
   @font-face {
     font-family: "Mona Sans";
     font-weight: 200 900;


### PR DESCRIPTION
## Summary
Selected text in the payload viewer (CodeEditor) was nearly invisible, and vanished completely once the editor lost focus. This fixes both by restructuring how the editor's dimming overlay is layered and switching the selection color to a translucent app-accent blue.

Root cause: `drawSelection` (pulled in via `basicSetup`) paints the selection layer *below* `.cm-content`, and the theme gave `.cm-content` a semi-opaque `rgba(15, 15, 15, 0.4)` overlay that dimmed the selection underneath it. On top of that, the One Dark slate `#3E4451` had ~5% effective contrast, and a blur rule set the selection background to `unset`, making it disappear entirely when focus moved (the "copy and paste kind of weird" complaint).

## Changes
- `frontend/src/components/CodeEditor/theme.ts`
  - Moved the translucent `rgba(15, 15, 15, 0.4)` overlay from `.cm-content` to `.cm-scroller`. The selection layer is a `z-index: -1` child of `.cm-scroller`, so it now paints above the dimming background but below the text. Gutters keep their own opaque background — unaffected.
  - Changed the `selection` constant from `#3E4451` to `rgba(124, 140, 255, 0.35)` (translucent primary accent — matches `#7c8cff` in tailwind.config.js and the existing blue cursor `#528bff`).
  - Changed the blurred-selection rule from `backgroundColor: "unset"` to `rgba(124, 140, 255, 0.18)` so selection stays faintly visible when focus moves elsewhere.
  - Deleted the dead `.cm-readonly .cm-content` rule (`EditorView.theme` scopes rules under the generated theme class, but `cm-readonly` sits on a wrapper *outside* `.cm-editor`, so the rule never matched — zero visual change).
- `frontend/src/style.css`
  - Added `::selection { background-color: rgba(124, 140, 255, 0.4); }` in the `@layer base` block so native inputs match the editor (CodeMirror overrides this internally at higher precedence — no conflict).

## Decisions made
- **Selection color**: used a translucent primary-accent blue instead of brightening the One Dark slate, so selection ties into the app's existing accent (`#7c8cff` primary, `#528bff` cursor) rather than staying theme-faithful to One Dark.
- **Blur behavior**: selection now stays faintly visible (0.18 alpha) when the editor loses focus instead of disappearing — conventional editor behavior, and it helps copy/paste flows.
- **Dead readonly rule**: the never-matching `.cm-readonly .cm-content` darkening rule was deleted rather than re-implemented at the correct scope, since removing it is a zero-visual-change cleanup.

## Test plan
Ran locally (all passing):
- `go build ./...` and `go vet ./...`
- `cd frontend && pnpm run check` — 0 errors, 35 warnings (matches baseline)
- `cd frontend && pnpm run test:run` — 4 files, 12 tests passed
- `cd frontend && pnpm run build`
- `cd frontend && pnpm run ds:validate` — passed (87 components)

Not run: backend/mqtt and backend/app broker-dependent tests (no broker on localhost:1883), and backend/update tests (pre-existing 404 failures against a live server). No backend code was touched.

Needs manual verification (visual change): select text in the payload viewer / CodeEditor Storybook stories and confirm (1) selection is clearly visible while focused, (2) selection stays faintly visible after clicking elsewhere, (3) gutters and overall editor contrast look unchanged.

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)