### PR TITLE
fix: remember right panel width across close/reopen

### DIFF
--- a/frontend/src/components/ResizableContainer/ResizableContainer.svelte
+++ b/frontend/src/components/ResizableContainer/ResizableContainer.svelte
@@ -24,17 +24,11 @@
       panelSizes.updatePanelSize(id, size, !collapsed);
     })();
 
-  // let defaultSize = $panelSizes.resizablePanelSizes[id] || minSize;
-  let defaultSize = minSize;
+  let defaultSize = $panelSizes.resizablePanelSizes[id]?.size || minSize;
   if (defaultSize < minSize) defaultSize = minSize;
   if (defaultSize > maxSize) defaultSize = maxSize;
   let edgeHovered = false;
   let size = defaultSize;
-
-  // $: $panelSizes.resizablePanelSizes[id],
-  //   (() => {
-  //     size = $panelSizes.resizablePanelSizes[id];
-  //   })();
 
   let resizing = false;
   let linuxFirstMovementX = -999;


### PR DESCRIPTION
## Summary
The right (selected-topic) panel forgot its width whenever it was closed and reopened, snapping back to the 275px minimum. The persistence pipeline (svelte store -> `UpdatePanelSize` -> gorm -> sqlite `panel_sizes` table) already wrote rows for `selected-topic-panel`, but `ResizableContainer.svelte` never read the persisted size on mount: the restore line was commented out and `defaultSize` was hardcoded to `minSize`. The left panel only appeared to remember because it never unmounts (collapse is a prop), while the right panel sits inside an `{#if isSelectedTopicPanelOpen}` block in `DataView.svelte` and remounts fresh each time.

## Changes
- `frontend/src/components/ResizableContainer/ResizableContainer.svelte`
  - Initialize `defaultSize` from the persisted store value: `$panelSizes.resizablePanelSizes[id]?.size || minSize` (the old commented-out line predated the store's `{size, isOpen}` value shape, hence the explicit `?.size`).
  - Kept the existing min/max clamps directly below, which handle stale persisted widths.
  - Removed the adjacent dead commented-out store-sync `$:` block.

Timing is safe: `App.svelte` awaits `initialization.init()` (which runs `panelSizes.init()`) before rendering, so the store is populated before any `ResizableContainer` mounts.

## Decisions made
- **Both panels now also restore their width across app restarts** (previously neither did, since nothing read the persisted size). This is a side effect of the fix and matches the issue intent, but it does change left-panel behavior on launch — override before merging if undesired.
- **Removed adjacent dead commented-out code** (the stale store-sync block) rather than leaving it, since it referenced the pre-`{size, isOpen}` store shape and could mislead future edits.

## Test plan
Ran locally (macOS):
- `go build ./...` and `go vet ./...` — pass
- `cd frontend && pnpm run check` — 0 errors, 35 warnings (matches baseline)
- `cd frontend && pnpm run test:run` — 4 files, 12 tests, all pass
- `cd frontend && pnpm run build` — pass
- `cd frontend && pnpm run ds:validate` — pass (87 components); the timestamp-only `component-index.json` regeneration was intentionally not committed
- Backend tests needing a live broker on localhost:1883 were skipped (no broker running; `nc -z localhost 1883` failed). `backend/update` tests are known to fail with 404s against a live server — pre-existing, not run.

Needs manual testing in the running app:
- Open a connection, widen the right panel, deselect/reselect a topic — width should persist instead of reverting to 275px.
- Restart the app — both panels should come back at their last widths, clamped to min/max.

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)