### PR TITLE
fix: enable arrow-key navigation in message timeline

### DIFF
--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/MessageTimeline.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/MessageTimeline.svelte
@@ -256,35 +256,41 @@
     timeline.zoomOut(1);
   };
 
-  $: onKeypress = (
+  $: onKeydown = (
     event: KeyboardEvent & {
       currentTarget: EventTarget;
     }
   ) => {
-    if (event.code === "KeyD" || event.code === "ArrowRight") {
-      selectNextOrPreviousMessage("next");
-    } else if (event.code === "KeyA" || event.code === "ArrowLeft") {
-      selectNextOrPreviousMessage("previous");
-    } else if (event.code === "KeyW" || event.code === "ArrowUp") {
-      zoomIn();
-    } else if (event.code === "KeyS" || event.code === "ArrowDown") {
-      zoomOut();
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return;
     }
-    if (
-      event.code === "KeyA" ||
-      event.code === "ArrowLeft" ||
-      event.code === "KeyD" ||
-      event.code === "ArrowRight"
-    ) {
-      isAutoSelectingMostRecent = false;
+    switch (event.code) {
+      case "KeyD":
+      case "ArrowRight":
+        selectNextOrPreviousMessage("next");
+        isAutoSelectingMostRecent = false;
+        break;
+      case "KeyA":
+      case "ArrowLeft":
+        selectNextOrPreviousMessage("previous");
+        isAutoSelectingMostRecent = false;
+        break;
+      case "KeyW":
+      case "ArrowUp":
+        zoomIn();
+        break;
+      case "KeyS":
+      case "ArrowDown":
+        zoomOut();
+        break;
+      default:
+        return;
     }
     event.preventDefault();
     event.stopPropagation();
-    return true;
   };
 </script>
 
-<!-- <svelte:window on:keypress={onKeypress} /> -->
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <section
   autofocus
@@ -298,7 +304,7 @@
   on:blur={() => {
     timelineIsFocused = false;
   }}
-  on:keypress={onKeypress}
+  on:keydown={onKeydown}
   id="timeline"
   class={`
     py-[1px]
@@ -314,7 +320,7 @@
   >
     <Tooltip
       closeOnPointerDown={false}
-      text="Use W-A-S-D to select messages and zoom"
+      text="Use W-A-S-D or arrow keys to select messages and zoom"
     >
       <Icon type="info" />
     </Tooltip>


### PR DESCRIPTION
## Summary
The message timeline advertised arrow-key support (the `Arrow*` branches existed in the handler), but the handler was bound via `on:keypress` — a DOM event that never fires for arrow keys — so only W-A-S-D worked. This rebinds the handler to `on:keydown` and tightens it so it only intercepts keys it actually handles.

## Changes
All in `frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/MessageTimeline.svelte`:
- Changed `on:keypress={onKeypress}` to `on:keydown={onKeydown}` and renamed the handler.
- Restructured the handler as a `switch` on `event.code`: `KeyD`/`ArrowRight` selects next message, `KeyA`/`ArrowLeft` selects previous (both disable auto-select-most-recent), `KeyW`/`ArrowUp` zooms in, `KeyS`/`ArrowDown` zooms out.
- `preventDefault()`/`stopPropagation()` now run only for handled keys. Unhandled keys hit the `default: return` path, and an early return skips any event with meta/ctrl/alt held — previously they ran unconditionally, which would be dangerous under `keydown`.
- Updated the tooltip text to "Use W-A-S-D or arrow keys to select messages and zoom".
- Deleted the stale commented-out `svelte:window on:keypress` line.

## Decisions made
- **Arrow keys do timeline navigation instead of page scroll while the timeline section is focused.** This is the intended behavior per the issue; scroll is only affected while the timeline has focus.
- **Unhandled keys now pass through.** Tab (focus navigation) and Escape are no longer blocked even in theory — the old handler called `preventDefault` unconditionally. Modifier combos (cmd/ctrl/alt + anything) early-return so app/system shortcuts aren't hijacked.

## Test plan
Ran from the worktree:
- `go build ./...` and `go vet ./...` — pass.
- `cd frontend && pnpm run check` — 0 errors, 35 warnings (matches baseline).
- `pnpm run test:run` — 4 files, 12 tests, all pass.
- `pnpm run build` — succeeds.
- `pnpm run ds:validate` — passes (87 components). Note: it regenerates a timestamp in `component-index.json`; that churn was reverted and not committed.
- Backend tests needing a live broker on localhost:1883 were skipped (no broker running; `nc -z localhost 1883` failed). `backend/update` tests are a known pre-existing 404 baseline and were not chased.

Needs manual testing (no automated coverage exists for this component):
- Click the timeline to focus it, then verify ArrowLeft/ArrowRight select previous/next message and ArrowUp/ArrowDown zoom, alongside the existing W-A-S-D behavior.
- Verify Tab still moves focus out of the timeline and cmd/ctrl shortcuts still work while the timeline is focused.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)