### PR TITLE
fix: display UTF-8 payloads correctly

### DIFF
--- a/frontend/src/components/CodeEditor/codec.test.ts
+++ b/frontend/src/components/CodeEditor/codec.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+import { base64ToUtf8, decodePayload, encodePayload } from "./codec";
+
+test("base64ToUtf8 decodes multibyte utf-8 payloads", () => {
+  const text = "héllo 中文 🚀";
+  const b64 = btoa(String.fromCharCode(...new TextEncoder().encode(text)));
+  expect(base64ToUtf8(b64)).toBe(text);
+});
+
+test("base64ToUtf8 decodes plain ascii payloads", () => {
+  expect(base64ToUtf8(btoa("hello world"))).toBe("hello world");
+});
+
+test("base64ToUtf8 falls back to latin-1 for invalid utf-8 bytes", () => {
+  const b64 = btoa(String.fromCharCode(0xff, 0xfe));
+  expect(base64ToUtf8(b64)).toBe("ÿþ");
+});
+
+test("base64 codec round-trips non-latin-1 text", () => {
+  const text = "héllo 中文 🚀";
+  const encoded = encodePayload(text, "base64");
+  expect(decodePayload(encoded, "base64")).toBe(text);
+});
+
+test("hex codec round-trips non-latin-1 text", () => {
+  const text = "héllo 中文 🚀";
+  const encoded = encodePayload(text, "hex");
+  expect(decodePayload(encoded, "hex")).toBe(text);
+});

--- a/frontend/src/components/CodeEditor/codec.ts
+++ b/frontend/src/components/CodeEditor/codec.ts
@@ -1,5 +1,31 @@
 export type SupportedCodeEditorCodec = "none" | "base64" | "hex";
 
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+const bytesToUtf8 = (bytes: Uint8Array, fallback: string): string => {
+  try {
+    return utf8Decoder.decode(bytes);
+  } catch {
+    return fallback;
+  }
+};
+
+export const base64ToUtf8 = (b64: string): string => {
+  const binary = atob(b64);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return bytesToUtf8(bytes, binary);
+};
+
+const utf8ToBinaryString = (payload: string): string => {
+  const bytes = new TextEncoder().encode(payload);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return binary;
+};
+
 export const encodePayload = (
   payload: string,
   codec: SupportedCodeEditorCodec
@@ -9,13 +35,12 @@ export const encodePayload = (
   }
 
   if (codec === "base64") {
-    return btoa(payload);
+    return btoa(utf8ToBinaryString(payload));
   }
 
   if (codec === "hex") {
-    return payload
-      .split("")
-      .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
+    return Array.from(new TextEncoder().encode(payload))
+      .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
   }
 
@@ -32,7 +57,7 @@ export const decodePayload = (
 
   if (codec === "base64") {
     try {
-      return atob(payload);
+      return base64ToUtf8(payload);
     } catch (e) {
       throw e;
     }
@@ -40,11 +65,13 @@ export const decodePayload = (
 
   if (codec === "hex") {
     try {
-      return payload
+      const binary = payload
         .split(/(\w\w)/g)
         .filter((p) => !!p)
         .map((c) => String.fromCharCode(parseInt(c, 16)))
         .join("");
+      const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+      return bytesToUtf8(bytes, binary);
     } catch (e) {
       throw e;
     }

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/mqtt-data.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/mqtt-data.ts
@@ -1,6 +1,7 @@
 import { get, writable } from "svelte/store";
 import type { events, mqtt } from "wailsjs/go/models";
 import { EventsOn } from "wailsjs/runtime/runtime";
+import { base64ToUtf8 } from "@/components/CodeEditor/codec";
 import type { HighlightedMqttTopicsStore } from "./highlighted-topics";
 
 export type MqttData = {
@@ -53,7 +54,7 @@ export const createMqttDataStore = (
         }
       }
       const timestamp = new Date(message.timeMs);
-      const decodedMessage = atob(message.payload as unknown as string);
+      const decodedMessage = base64ToUtf8(message.payload as unknown as string);
       const isDecodedProto = message?.middlewareProperties?.IsDecodedProto;
       update((mqttData) => {
         return insertMqttMessage(

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/HeadersTab.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/HeadersTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { mqtt } from "wailsjs/go/models";
+  import { base64ToUtf8 } from "@/components/CodeEditor/codec";
   import HeaderRow from "./shared/HeaderRow.svelte";
   import { getSortedObjectDiffs } from "./shared/diff-helpers";
 
@@ -37,7 +38,7 @@
   const getKeyValuePair = (key: string, value?: string) => {
     // Correlation data comes through as an encoded string
     if (key === "correlationData") {
-      const decodedValue = value ? atob(value) : "";
+      const decodedValue = value ? base64ToUtf8(value) : "";
       return [key, decodedValue];
     }
     if (key === "payloadFormat") {

--- a/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
+++ b/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
@@ -3,7 +3,10 @@ import type { mqtt } from "wailsjs/go/models";
 import { GetMessageHistory } from "wailsjs/go/app/App";
 import { EventsOn } from "wailsjs/runtime/runtime";
 import type { events } from "wailsjs/go/models";
-import type { SupportedCodeEditorCodec } from "@/components/CodeEditor/codec";
+import {
+  base64ToUtf8,
+  type SupportedCodeEditorCodec,
+} from "@/components/CodeEditor/codec";
 import type { SupportedCodeEditorFormat } from "@/components/CodeEditor/formatting";
 
 export type MqttHistoryMessage = Omit<
@@ -65,7 +68,7 @@ export const createSelectedTopicStore = (
           const decodedNewMessages = newMessagesForSelectedTopic.map((m) => {
             return {
               ...m,
-              payload: atob(m.payload as unknown as string),
+              payload: base64ToUtf8(m.payload as unknown as string),
             };
           });
           if (onNewMessages !== null) {
@@ -96,7 +99,7 @@ export const createSelectedTopicStore = (
     const decocdedHistory = history.map((m) => {
       return {
         ...m,
-        payload: atob(m.payload as unknown as string),
+        payload: base64ToUtf8(m.payload as unknown as string),
       };
     });
     update((store) => {


### PR DESCRIPTION
## Summary
Non-ASCII (UTF-8) MQTT payloads displayed as mojibake (e.g. "é" rendered as "Ã©"). Payload bytes arrive base64-encoded from the Go backend, and the frontend decoded them with bare `atob()`, which produces a Latin-1 binary string and mangles multi-byte UTF-8. This PR decodes payloads as UTF-8 with a byte-for-byte Latin-1 fallback for anything that is not valid UTF-8.

## Changes
- `frontend/src/components/CodeEditor/codec.ts`: new exported `base64ToUtf8` helper — `atob` to bytes, then `TextDecoder("utf-8", { fatal: true })`; on decode failure it returns the original Latin-1 binary string, so true binary payloads render exactly as before.
- Replaced the bare `atob()` payload decodes with `base64ToUtf8()` at the four affected sites:
  - `MqttDataPanel/stores/mqtt-data.ts` (`processMessages`)
  - `DataView/stores/selected-topic-store.ts` (message listener and `selectTopic` history load)
  - `SelectedTopicPanel/components/HeadersTab.svelte` (correlation data display)
- User-selectable codecs in `codec.ts` made UTF-8-correct:
  - `decodePayload` "base64" branch routes through `base64ToUtf8`; "hex" branch decodes bytes through the same TextDecoder-with-fallback pattern.
  - `encodePayload` "base64" and "hex" branches now encode the UTF-8 bytes of the input (chunked `String.fromCharCode` to avoid call-stack limits on large payloads), so publishing non-Latin-1 text with the Base64 codec no longer throws `InvalidCharacterError`.
- New `frontend/src/components/CodeEditor/codec.test.ts` covering multibyte UTF-8, ASCII, invalid-UTF-8 fallback, and base64/hex round-trips with non-Latin-1 text.

## Decisions made
- **Non-UTF-8 payloads keep the exact current Latin-1 rendering** (no U+FFFD replacement characters): `fatal: true` plus fallback makes the change strictly additive — valid UTF-8 improves, true binary and Latin-1 devices render byte-for-byte as today. Override if you'd rather show replacement characters for invalid bytes.
- **Fix extends to the Base64/Hex codec decode AND encode paths**, since the same bug class applies there (and base64-encoding non-Latin-1 text previously threw). This changes what bytes the Base64/Hex codecs produce for non-ASCII input (UTF-8 bytes instead of Latin-1 code units / an exception). Override if you want the codec paths left untouched.

Note: a sibling PR adds a hex view format whose byte extraction is already written to handle real-UTF-8 strings; no coordination needed.

## Test plan
Ran locally (all passing):
- `go build ./... && go vet ./...`
- `cd frontend && pnpm run check` — 0 errors, 35 warnings (matches baseline)
- `cd frontend && pnpm run test:run` — 17 tests passed, including the 5 new codec tests
- `cd frontend && pnpm run build`
- `cd frontend && pnpm run ds:validate` — passed (87 components)

Not run: backend tests needing a live broker on localhost:1883 (no broker running; `nc -z localhost 1883` failed) and the backend/update tests that hit a live server (pre-existing 404 failures). Neither is affected by this frontend-only change.

Manual testing suggested: publish a UTF-8 payload (e.g. "héllo 中文 🚀") and confirm it displays correctly in the topic tree, payload tab, and correlation-data header; confirm a binary payload still renders as before; publish non-ASCII text with the Base64 codec selected.

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)