### PR TITLE
fix: make db migrations atomic and clean stale sqlite sidecar files

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -32,6 +32,13 @@ func NewDb(resourcePath string, options *NewDbOptions) (*DB, error) {
 	var err error
 
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		// remove stale sidecar files left behind by a deleted db so they
+		// can't be replayed into the new empty file
+		for _, sfx := range []string{"-journal", "-wal", "-shm"} {
+			if os.Remove(dbPath+sfx) == nil {
+				slog.Warn("removed stale sqlite sidecar file " + dbPath + sfx)
+			}
+		}
 		slog.Info("creating db file at " + dbPath)
 		file, err := os.Create(dbPath)
 		if err != nil {
@@ -70,7 +77,7 @@ func NewDb(resourcePath string, options *NewDbOptions) (*DB, error) {
 			loggerConfig,
 		)
 	}
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+	db, err := gorm.Open(sqlite.Open(dbPath+"?_pragma=busy_timeout(5000)"), &gorm.Config{
 		Logger: newLogger,
 	})
 	if err != nil {

--- a/backend/db/migrate.go
+++ b/backend/db/migrate.go
@@ -17,7 +17,9 @@ var migrationsDir embed.FS
 
 func (db *DB) Migrate() error {
 	slog.Info("running migrations")
-	db.AutoMigrate(&models.Migration{})
+	if err := db.AutoMigrate(&models.Migration{}); err != nil {
+		return err
+	}
 	migrations, err := migrationsDir.ReadDir("migrations")
 	if err != nil {
 		return err
@@ -29,35 +31,50 @@ func (db *DB) Migrate() error {
 	}
 
 	migrationsApplied := 0
-	for _, migration := range migrations {
-		// ignore non-sql files
-		if !strings.HasSuffix(migration.Name(), ".sql") {
-			continue
-		}
-		filename := strings.Replace(migration.Name(), ".sql", "", 1)
-		if _, ok := appliedMigrations[filename]; ok {
-			continue
-		}
-		migrationContent, err := migrationsDir.ReadFile("migrations/" + migration.Name())
-		if err != nil {
+	// Pin a single connection so the foreign_keys pragma applies to every
+	// migration transaction (SQLite ignores it inside an open transaction).
+	err = db.Connection(func(conn *gorm.DB) error {
+		if err := conn.Exec("PRAGMA foreign_keys = OFF").Error; err != nil {
 			return err
 		}
-		if err := db.Exec(string(migrationContent)).Error; err != nil {
-			return err
-		}
-		if err := db.Create(&models.Migration{MigrationFileName: filename}).Error; err != nil {
-			return err
-		}
-		migrationsApplied++
-		slog.Info("applied migration " + filename)
-
-		// special case to encrypt existing plaintext passwords
-		if migration.Name() == "20250320051532_add-global-and-encrypt-passwords.sql" {
-			slog.Info("encrypting existing passwords")
-			if err := db.encryptExistingPasswords(); err != nil {
+		for _, migration := range migrations {
+			// ignore non-sql files
+			if !strings.HasSuffix(migration.Name(), ".sql") {
+				continue
+			}
+			filename := strings.Replace(migration.Name(), ".sql", "", 1)
+			if _, ok := appliedMigrations[filename]; ok {
+				continue
+			}
+			migrationContent, err := migrationsDir.ReadFile("migrations/" + migration.Name())
+			if err != nil {
 				return err
 			}
+			// Apply the migration and record it atomically so a failure can
+			// never leave the schema ahead of the migrations table.
+			if err := conn.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Exec(string(migrationContent)).Error; err != nil {
+					return err
+				}
+				return tx.Create(&models.Migration{MigrationFileName: filename}).Error
+			}); err != nil {
+				return fmt.Errorf("applying migration %s: %w", filename, err)
+			}
+			migrationsApplied++
+			slog.Info("applied migration " + filename)
+
+			// special case to encrypt existing plaintext passwords
+			if migration.Name() == "20250320051532_add-global-and-encrypt-passwords.sql" {
+				slog.Info("encrypting existing passwords")
+				if err := db.encryptExistingPasswords(); err != nil {
+					return err
+				}
+			}
 		}
+		return conn.Exec("PRAGMA foreign_keys = ON").Error
+	})
+	if err != nil {
+		return err
 	}
 	slog.Info("applied " + fmt.Sprint(migrationsApplied) + " migrations")
 	return nil

--- a/backend/db/migrate_test.go
+++ b/backend/db/migrate_test.go
@@ -1,0 +1,69 @@
+package db
+
+import (
+	"mqtt-viewer/backend/models"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestMigrateIsIdempotent(t *testing.T) {
+	testDb, err := NewDb(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer closeDb(t, testDb)
+
+	if err := testDb.Migrate(); err != nil {
+		t.Fatalf("expected no error on first migrate, got %v", err)
+	}
+	if err := testDb.Migrate(); err != nil {
+		t.Fatalf("expected no error on second migrate, got %v", err)
+	}
+
+	migrationFiles, err := migrationsDir.ReadDir("migrations")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	expectedCount := int64(0)
+	for _, file := range migrationFiles {
+		if strings.HasSuffix(file.Name(), ".sql") {
+			expectedCount++
+		}
+	}
+
+	var appliedCount int64
+	if err := testDb.Model(&models.Migration{}).Count(&appliedCount).Error; err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if appliedCount != expectedCount {
+		t.Errorf("expected %d applied migrations, got %d", expectedCount, appliedCount)
+	}
+}
+
+func TestNewDbRemovesStaleSidecarFiles(t *testing.T) {
+	dir := t.TempDir()
+	journalPath := path.Join(dir, "MqttViewer.db-journal")
+	if err := os.WriteFile(journalPath, []byte("stale journal"), 0644); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	testDb, err := NewDb(dir, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer closeDb(t, testDb)
+
+	if _, err := os.Stat(journalPath); !os.IsNotExist(err) {
+		t.Errorf("expected stale journal file to be removed, stat err: %v", err)
+	}
+}
+
+func closeDb(t *testing.T, testDb *DB) {
+	sqlDb, err := testDb.DB.DB()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	sqlDb.Close()
+}


### PR DESCRIPTION
## Summary
Deleting MqttViewer.db then relaunching could permanently poison the new db ("table publish_histories already exists" on every launch) until another delete plus a lucky clean run. Root cause: `(*DB).Migrate` was non-atomic — it ran each migration file via `db.Exec` and then recorded it with a separate `db.Create`, all in autocommit mode. Any transient failure between the schema statements and the bookkeeping insert (e.g. a Windows AV file lock) left the schema ahead of the migrations table, so every relaunch re-ran the file and died. Stale sqlite sidecar files from the deleted db and the lack of a busy_timeout made this easier to hit.

## Changes
- `backend/db/migrate.go`: each pending migration now runs inside a single transaction together with its migrations-table insert, so a failure rolls back both and relaunch retries cleanly. The whole run is pinned to one connection (`db.Connection`) which sets `PRAGMA foreign_keys = OFF` before the loop and restores `ON` after — SQLite silently ignores this pragma inside an open transaction, and the two table-rebuild migrations (`20241003123229`, `20250405054934`) rely on it (the in-file `PRAGMA foreign_keys = off/on` statements remain but are harmless no-ops inside the transaction). Migration failures are wrapped with the offending filename. The previously discarded `AutoMigrate` error is now returned.
- `backend/db/db.go`: before creating a fresh db file, `NewDb` removes stale `-journal`/`-wal`/`-shm` sidecars left behind by a deleted db (a hot journal could otherwise be rolled back into the new empty file). The db is opened with `?_pragma=busy_timeout(5000)` so pooled connections wait out transient locks instead of failing instantly.
- `backend/db/migrate_test.go` (new): asserts NewDb + Migrate runs twice cleanly against a temp dir with exactly one migrations-table row per embedded .sql file (counted dynamically), and that NewDb removes a stale `-journal` sidecar when no db file exists.

## Decisions made
- **Already-poisoned DBs are NOT auto-healed.** Affected users delete the db once more; this time the rebuild is atomic so one delete suffices. Auto-heal/baseline-skip logic was judged riskier than this minimal fix. Override before merging if you want healing logic.
- **busy_timeout(5000) added in scope** to harden against the transient-lock trigger, not just its symptom.
- **No changes to the .sql migration files or atlas.sum** — the conn-level pragma governs FK enforcement; the in-file pragmas execute harmlessly.
- **encryptExistingPasswords special case unchanged** — still runs right after its migration commits, same semantics as before.

## Test plan
Ran locally (macOS):
- `go build ./...` and `go vet ./...` — clean
- `go test ./backend/db/...` — PASS, including the two new tests; all 9 embedded migrations (including both FK-toggle table rebuilds) apply under the new transactional path, twice, idempotently
- Broker-independent `backend/app` tests (`TestGetTestApp`, `TestNewConnection*`, `TestUpdatePanelSize*`, `TestAppConnectionIdMap*`, `TestCreateAppConnectionFromConnectionModel`, `TestMakePublishProperties`) — PASS; these exercise NewDb + Migrate end-to-end via app startup
- Pre-existing failures confirmed unchanged: `TestGetSeededTestApp`, `TestGetSavedConnectionsReturnsAllConnections`, `TestTabs*` fail identically on the unmodified base commit (ec0ad08), so they are unrelated to this change. Broker-dependent `backend/mqtt`/`backend/app` tests were skipped — no broker on localhost:1883. `backend/update` tests are a known baseline failure (hit a live server).
- Frontend: `pnpm run check` — 0 errors / 35 warnings (matches baseline); `pnpm run test:run` — 12/12 pass; `pnpm run build` — OK (no frontend files touched)

Needs manual testing:
- On Windows: delete MqttViewer.db while sidecar files exist, relaunch, confirm clean rebuild
- Simulated mid-migration failure leaves db usable on next launch (schema and migrations table roll back together)

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)