### PR TITLE
feat: add hex payload view format

### DIFF
--- a/frontend/src/components/CodeEditor/CodeEditor.spec.json
+++ b/frontend/src/components/CodeEditor/CodeEditor.spec.json
@@ -26,7 +26,7 @@
         "none",
         "json",
         "json-prettier",
-        "xml"
+        "hex"
       ],
       "default": "none"
     },

--- a/frontend/src/components/CodeEditor/CodeEditorConfigBar.spec.json
+++ b/frontend/src/components/CodeEditor/CodeEditorConfigBar.spec.json
@@ -43,7 +43,7 @@
         "none",
         "json",
         "json-prettier",
-        "xml"
+        "hex"
       ],
       "default": "none"
     },

--- a/frontend/src/components/CodeEditor/CodeEditorConfigBar.svelte
+++ b/frontend/src/components/CodeEditor/CodeEditorConfigBar.svelte
@@ -75,7 +75,9 @@
   <CodeEditorConfigBarOption
     name="format"
     bind:setValue={setFormat}
-    options={isReadyOnly ? ["none", "json", "json-prettier"] : ["none", "json"]}
+    options={isReadyOnly
+      ? ["none", "json", "json-prettier", "hex"]
+      : ["none", "json"]}
     defaultValue={format}
     onChange={(value) => {
       if (value !== undefined) {
@@ -91,6 +93,8 @@
           return "JSON";
         case "json-prettier":
           return "JSONp";
+        case "hex":
+          return "Hex";
         default:
           return "";
       }
@@ -103,6 +107,8 @@
           return "JSON";
         case "json-prettier":
           return "JSON Pretty";
+        case "hex":
+          return "View as hex";
         default:
           return "";
       }

--- a/frontend/src/components/CodeEditor/DiffCodeEditor.spec.json
+++ b/frontend/src/components/CodeEditor/DiffCodeEditor.spec.json
@@ -20,7 +20,7 @@
         "none",
         "json",
         "json-prettier",
-        "xml"
+        "hex"
       ],
       "default": "json"
     },

--- a/frontend/src/components/CodeEditor/extensions.ts
+++ b/frontend/src/components/CodeEditor/extensions.ts
@@ -20,5 +20,6 @@ export const LANG_EXTENSIONS: {
 } = {
   json: [json(), linter(jsonParseLinter()), lintGutter()],
   "json-prettier": [json(), linter(jsonParseLinter()), lintGutter()],
+  hex: [],
   none: [],
 };

--- a/frontend/src/components/CodeEditor/formatting.test.ts
+++ b/frontend/src/components/CodeEditor/formatting.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { formatPayload } from "./formatting";
+
+test("hex formats a binary string into space-separated hex bytes", () => {
+  const payload = String.fromCharCode(0x00, 0x01, 0x7f, 0x80, 0xff);
+
+  const result = formatPayload(payload, "hex");
+  expect(result).toBe("00 01 7f 80 ff");
+});
+
+test("hex uses utf-8 bytes when the string contains chars above 0xff", () => {
+  const payload = "€";
+
+  const result = formatPayload(payload, "hex");
+  expect(result).toBe("e2 82 ac");
+});
+
+test("hex wraps output at 16 bytes per line", () => {
+  const payload = String.fromCharCode(...Array.from({ length: 20 }, (_, i) => i));
+
+  const result = formatPayload(payload, "hex");
+  expect(result).toBe(
+    "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f\n10 11 12 13"
+  );
+});
+
+test("none and json formats return the payload unchanged", () => {
+  const payload = '{"a":1}';
+
+  expect(formatPayload(payload, "none")).toBe(payload);
+  expect(formatPayload(payload, "json")).toBe(payload);
+});

--- a/frontend/src/components/CodeEditor/formatting.ts
+++ b/frontend/src/components/CodeEditor/formatting.ts
@@ -1,4 +1,8 @@
-export type SupportedCodeEditorFormat = "none" | "json" | "json-prettier";
+export type SupportedCodeEditorFormat =
+  | "none"
+  | "json"
+  | "json-prettier"
+  | "hex";
 
 export const formatPayload = (
   payload: string,
@@ -14,6 +18,22 @@ export const formatPayload = (
     } catch (e) {
       return payload;
     }
+  }
+
+  if (format === "hex") {
+    const hasWideChars = [...payload].some((c) => c.codePointAt(0)! > 0xff);
+    const bytes = hasWideChars
+      ? new TextEncoder().encode(payload)
+      : Uint8Array.from(payload, (c) => c.charCodeAt(0));
+    const lines: string[] = [];
+    for (let i = 0; i < bytes.length; i += 16) {
+      lines.push(
+        Array.from(bytes.subarray(i, i + 16), (b) =>
+          b.toString(16).padStart(2, "0")
+        ).join(" ")
+      );
+    }
+    return lines.join("\n");
   }
 
   return payload;

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-06-11T14:11:30.709Z",
+  "generatedAt": "2026-06-12T00:22:37.889Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -859,7 +859,7 @@
             "none",
             "json",
             "json-prettier",
-            "xml"
+            "hex"
           ],
           "default": "json"
         },

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-05-26T08:34:31.191Z",
+  "generatedAt": "2026-06-11T14:11:30.709Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -662,7 +662,7 @@
             "none",
             "json",
             "json-prettier",
-            "xml"
+            "hex"
           ],
           "default": "none"
         },
@@ -732,7 +732,7 @@
             "none",
             "json",
             "json-prettier",
-            "xml"
+            "hex"
           ],
           "default": "none"
         },

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/SelectedTopicPanel.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/SelectedTopicPanel.svelte
@@ -46,6 +46,9 @@
         if (selectedMessagePayload === null) {
           return null;
         }
+        if ($selectedTopicStore.options.format === "hex") {
+          return null;
+        }
         JSON.parse(selectedMessagePayload);
         // It's valid JSON
         $selectedTopicStore.options.format = "json-prettier";

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.svelte
@@ -27,9 +27,7 @@
         console.error("error decoding payload", e);
       }
     }
-    if (format === "json-prettier") {
-      p = formatPayload(p, "json-prettier");
-    }
+    p = formatPayload(p, format);
     return p;
   };
 


### PR DESCRIPTION
## Summary

Adds a "Hex" entry to the read-only payload format dropdown so binary message payloads can be viewed as a hex dump. This is a view-as-hex formatter, distinct from the existing codec dropdown's Hex entry (which decodes payloads that are themselves hex text) — the two compose, so e.g. base64-decode-then-view-as-hex works.

## Changes

- `frontend/src/components/CodeEditor/formatting.ts`: extends `SupportedCodeEditorFormat` with `"hex"` and adds a `formatPayload` branch emitting 16 space-separated lowercase 2-digit hex bytes per line. Byte extraction is robust to both payload representations: binary strings (charCodes 0-255) use `charCodeAt`, while strings containing any char > 0xFF (real UTF-8 decoded payloads, per the in-flight UTF-8 PR) use `TextEncoder` for a lossless round-trip to wire bytes.
- `frontend/src/components/CodeEditor/extensions.ts`: adds `hex: []` to `LANG_EXTENSIONS` (required by the mapped type / `langCompartment.reconfigure`).
- `frontend/src/components/CodeEditor/CodeEditorConfigBar.svelte`: adds "hex" to the read-only format options with display "Hex" and label "View as hex".
- `PayloadTab.svelte`: `processPayload` now calls `formatPayload(p, format)` for all formats (identity for none/json — behavior otherwise unchanged; codec decode still runs first).
- `SelectedTopicPanel.svelte`: the auto-format-on-arrival block early-returns while the format is "hex" so arriving messages don't clobber the user's hex selection.
- `CodeEditor.spec.json` / `CodeEditorConfigBar.spec.json` + regenerated `component-index.json`: format enum synced with the code ("hex" added; stale "xml" entry replaced since it doesn't exist in code).
- New `formatting.test.ts` covering the hex formatter and identity formats.

## Decisions made

- **Dump style**: plain 16-bytes-per-line hex dump, no xxd-style offsets/ASCII gutter — keeps copy/diff output clean. Easy to extend later if offsets are wanted.
- **Auto-JSON-detect suppression**: applies only while hex is selected (minimal scope); switching back off hex restores the existing auto-detect behavior on the next message.
- **Publish editor**: format dropdown unchanged (hex is read-only view formatting only).
- **Copy button**: copies the hex dump text, consistent with the existing copy-the-processed-text behavior.
- **Spec "xml" entry**: replaced with "hex" in both CodeEditor specs to match the actual `SupportedCodeEditorFormat` union ("xml" was never a real option); `ds:validate` stays green.

## Test plan

Ran locally (all green):

- `go build ./... && go vet ./...`
- `cd frontend && pnpm run check` — 0 errors, 35 warnings (matches baseline)
- `cd frontend && pnpm run test:run` — 16 tests passed, including 4 new tests in `formatting.test.ts` (binary-string hex, >0xFF TextEncoder path, 16-bytes-per-line wrapping, none/json identity)
- `cd frontend && pnpm run build`
- `cd frontend && pnpm run ds:validate` — passed, 87 components

Not run: backend/mqtt and backend/app live-broker tests (no broker on localhost:1883); backend/update tests are known-failing against a live server. Neither is touched by this frontend-only change.

Manual testing suggested: open a connection, select a topic with a binary payload, choose Format → Hex and confirm the dump renders, copy copies the dump, the selection survives new message arrivals, and codec Base64 + format Hex compose.

Note: the Design System CI "Check generated files" step regenerates `component-index.json` with a fresh `generatedAt` timestamp on every run, so it diffs non-empty regardless of content — pre-existing issue, flagged separately.

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)