### PR TITLE
feat: auto-reconnect to broker on unexpected connection loss

### DIFF
--- a/backend/app/startup.go
+++ b/backend/app/startup.go
@@ -169,6 +169,7 @@ func (a *App) createAppConnectionFromConnectionModel(conn *models.Connection, ev
 				}
 			},
 			OnConnectionUp: func() {
+				appConnection.MqttManager.MessageBuffer.StopHandlingBuffer()
 				appConnection.MqttManager.MessageBuffer.StartHandlingBuffer(MQTT_BUFFER_EMIT_INTERVAL, func(messages []mqtt.MqttMessage) {
 					if len(messages) == 0 {
 						return

--- a/backend/mqtt/connect.go
+++ b/backend/mqtt/connect.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/eclipse/paho.golang/autopaho"
@@ -43,6 +44,11 @@ func (mm *MqttManager) Connect(connectionDetails MqttConnectionDetails, subscrip
 
 	if mm.ConnectionState == ConnectionStates.Connecting {
 		slog.WarnContext(mm.ctx, "attempted connection while already connecting")
+		return nil
+	}
+
+	if mm.ConnectionState == ConnectionStates.Reconnecting {
+		slog.WarnContext(mm.ctx, "attempted connection while reconnecting")
 		return nil
 	}
 
@@ -106,26 +112,38 @@ func (mm *MqttManager) connectV5(ctx context.Context, connectionDetails MqttConn
 	mm.pinger = newPingerV5(mm.ctx, mm.onNewLatencyMs)
 	clientId := connectionDetails.ClientId
 	connectErrChan := make(chan error)
+	var initialOnce sync.Once
 	config := autopaho.ClientConfig{
 		// Debug:                         NewMqttLogger(),
 		// PahoDebug:                     NewMqttLogger(),
 		CleanStartOnInitialConnection: true,
 		BrokerUrls:                    []*url.URL{broker},
 		KeepAlive:                     30,
-		ConnectRetryDelay:             10 * time.Second,
+		ConnectRetryDelay:             3 * time.Second,
 		ConnectTimeout:                CONNECTION_TIMEOUT,
 		OnConnectionUp: func(cm *autopaho.ConnectionManager, c *paho.Connack) {
 			err := subscribeV5(ctx, mm.ctx, cm, subscriptions)
 			if err != nil {
 				slog.ErrorContext(mm.ctx, err.Error())
-				connectErrChan <- err
+				initialOnce.Do(func() {
+					connectErrChan <- err
+				})
 				return
 			}
 			mm.SetConnectionState(ConnectionStates.Connected, nil)
-			connectErrChan <- nil
+			initialOnce.Do(func() {
+				connectErrChan <- nil
+			})
 		},
 		OnConnectError: func(err error) {
-			connectErrChan <- err
+			sent := false
+			initialOnce.Do(func() {
+				connectErrChan <- err
+				sent = true
+			})
+			if !sent {
+				slog.ErrorContext(mm.ctx, "connect error while reconnecting: "+err.Error())
+			}
 		},
 		ClientConfig: paho.ClientConfig{
 			PingHandler: mm.pinger,
@@ -141,13 +159,17 @@ func (mm *MqttManager) connectV5(ctx context.Context, connectionDetails MqttConn
 				}},
 			OnClientError: func(err error) {
 				err = errors.New("client error: " + err.Error())
-				mm.Disconnect(&err)
+				if mm.ConnectionState == ConnectionStates.Connected {
+					mm.SetConnectionState(ConnectionStates.Reconnecting, &err)
+				}
 			},
 			OnServerDisconnect: func(d *paho.Disconnect) {
 
 				errString := "server disconnected: " + d.Properties.ReasonString
 				err := errors.New(errString)
-				mm.Disconnect(&err)
+				if mm.ConnectionState == ConnectionStates.Connected {
+					mm.SetConnectionState(ConnectionStates.Reconnecting, &err)
+				}
 			},
 		},
 	}
@@ -197,21 +219,30 @@ func (mm *MqttManager) connectV3(ctx context.Context, connectionDetails MqttConn
 		opts.SetTLSConfig(connectionDetails.TlsConfig)
 	}
 	opts.SetAutoReconnect(true)
+	opts.SetMaxReconnectInterval(30 * time.Second)
 	opts.SetConnectRetry(false)
 	opts.SetOrderMatters(false)
 	opts.SetConnectionLostHandler(func(c mqttV3.Client, err error) {
-		mm.Disconnect(&err)
+		if mm.ConnectionState == ConnectionStates.Connected {
+			mm.SetConnectionState(ConnectionStates.Reconnecting, &err)
+		}
 	})
 
 	subErrChan := make(chan error)
+	var initialOnce sync.Once
 	opts.SetOnConnectHandler(func(c mqttV3.Client) {
 		err := subscribeV3(mm.ctx, c, subscriptions)
 		if err != nil {
 			slog.Error(err.Error())
-			subErrChan <- err
+			initialOnce.Do(func() {
+				subErrChan <- err
+			})
+			return
 		}
 		mm.SetConnectionState(ConnectionStates.Connected, nil)
-		subErrChan <- nil
+		initialOnce.Do(func() {
+			subErrChan <- nil
+		})
 	})
 	opts.SetConnectTimeout(CONNECTION_TIMEOUT)
 	opts.SetKeepAlive(20 * time.Second)

--- a/frontend/src/views/Connection/components/ConnectionHeaderBar.svelte
+++ b/frontend/src/views/Connection/components/ConnectionHeaderBar.svelte
@@ -82,7 +82,7 @@
         connection.latencyMs !== undefined
           ? `(${connection.latencyMs} ms)`
           : ""}
-        {#if connection.connectionState === "connected" || connection.connectionState === "connecting"}
+        {#if connection.connectionState === "connected" || connection.connectionState === "connecting" || connection.connectionState === "reconnecting"}
           <Tooltip text="Disconnect">
             <Button on:click={disconnect} disabled={!connectionIsValid}
               ><Icon type="disconnect" /></Button


### PR DESCRIPTION
## Summary

Both MQTT client libraries already auto-reconnect, but the app was actively defeating them: the v5 `OnClientError`/`OnServerDisconnect` callbacks and the v3 connection-lost handler all called `Disconnect(&err)`, tearing the client down on any unexpected drop (suspend/resume, network blips, broker restarts). This PR replaces those teardowns with a guarded transition into the existing — previously dead — `Reconnecting` state pipeline (backend enum/callback/event, frontend store handler, toast, yellow status circle were all already wired up end-to-end) and lets the libraries reconnect on their own. Intentional disconnects are unaffected: both libraries suppress loss callbacks for user-initiated `Disconnect`.

## Changes

- **backend/mqtt/connect.go (`connectV5`)**: `OnClientError`/`OnServerDisconnect` now set `Reconnecting` (guarded on current state being `Connected`) instead of calling `Disconnect`. autopaho's `ConnectionManager` reconnects on its own and re-fires `OnConnectionUp`, which re-subscribes and restores `Connected`. The initial-connect result channel is unbuffered and read exactly once, and autopaho invokes `OnConnectionUp`/`OnConnectError` synchronously in its mainLoop, so any later send would deadlock the reconnect loop — sends are now wrapped in a shared `sync.Once` (later connect errors are logged via slog instead). `ConnectRetryDelay` lowered 10s -> 3s.
- **backend/mqtt/connect.go (`connectV3`)**: same guarded `Reconnecting` transition in `SetConnectionLostHandler`; `SetMaxReconnectInterval(30s)` (library default is 10 minutes); `subErrChan` sends in the on-connect handler wrapped in `sync.Once` (previously each reconnect would have leaked a goroutine blocked on the unbuffered channel). Also added a `return` after the subscribe-error send so a failed re-subscribe no longer falls through to `SetConnectionState(Connected)` — observed in testing when a reconnect races a user disconnect.
- **backend/mqtt/connect.go (`Connect`)**: no-ops (warn + return nil) when state is `Reconnecting`, so a Connect click during a reconnect can't create a second client.
- **backend/app/startup.go (`OnConnectionUp`)**: calls `StopHandlingBuffer()` before `StartHandlingBuffer` — on a `Reconnecting -> Connected` transition `OnConnectionDown` never runs, so this prevents a leaked buffer ticker goroutine per reconnect (`StopHandlingBuffer` is a safe no-op when not running).
- **frontend/src/views/Connection/components/ConnectionHeaderBar.svelte**: the Disconnect button is also shown while `reconnecting`, so users can cancel a reconnect loop.

## Decisions made

- **Retry policy**: reconnect retries forever (matches the autopaho model); no give-up cap.
- **Retry timing**: v5 fixed 3s retry delay; v3 exponential backoff capped at 30s.
- **Toasts**: one error toast per drop via the existing `mqttReconnecting` frontend handler (the `Connected`-state guard prevents a double toast when autopaho fires both callbacks for one drop).
- **Cancel**: Disconnect button shown during reconnecting; backend `Disconnect` already handles cancel-mid-retry for both libraries (verified in smoke test).
- **Home screen**: the connection list card (`HomeConnectionListItem.svelte`) still only shows the status circle for connected/connecting — left unchanged as out of scope; while reconnecting it shows the last-connected line instead. Easy follow-up if you want the yellow circle there too.

Known behavior notes: retained messages are re-delivered each reconnect cycle and add history entries; the app stays yellow "Reconnecting" indefinitely while the broker is down; flappy networks may repeat toasts.

## Test plan

Ran locally (macOS, mosquitto 2 in Docker with TCP :1883 + websockets :9001):

- `go build ./... && go vet ./...` — pass.
- `go test ./backend/mqtt/...` — all pass against the live broker (including websocket connect tests).
- End-to-end reconnect smoke test (temporary uncommitted test against a dedicated broker container, both v3 and v5): connect -> `docker restart` broker -> exactly one `connected -> reconnecting` transition -> automatic `reconnecting -> connected` with re-subscribe; then broker stopped -> `reconnecting` -> user `Disconnect()` mid-retry -> `disconnected`, with no zombie reconnect for 8s after the broker came back. Both subtests passed.
- `go test ./backend/app/...` — 7 pre-existing failures (`TestMqttV5PubsAndSubs*`, `TestGetSeededTestApp`, `TestGetSavedConnections*`, `TestTabs*`); verified byte-for-byte identical failures on base `ec0ad08` with the same broker (test DB seeding returns 0 connections / FK constraint failures), so unrelated to this change. `backend/update` tests not run (known to hit a live server).
- Frontend: `pnpm run check` (0 errors, 35 warnings — matches baseline), `pnpm run test:run` (12/12 pass), `pnpm run build` (pass), `pnpm run ds:validate` (pass, 87 components).

Needs manual verification: real suspend/resume (laptop lid close/open) against a remote broker, and the in-app UX of the yellow Reconnecting header state + Disconnect-while-reconnecting button.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)