### PR TITLE
fix: make Design System CI workflow pass

### DIFF
--- a/.github/workflows/design-system.yml
+++ b/.github/workflows/design-system.yml
@@ -28,6 +28,8 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
       - name: Validate registry
         run: pnpm ds:validate
       - name: Test Storybook stories

--- a/frontend/.storybook/build-registry.mjs
+++ b/frontend/.storybook/build-registry.mjs
@@ -1,11 +1,7 @@
-import {
-  buildIndex,
-  componentIndexPath,
-  writeJson,
-} from "./design-system-utils.mjs";
+import { buildIndex, writeComponentIndex } from "./design-system-utils.mjs";
 
 const index = buildIndex();
-writeJson(componentIndexPath, index);
+writeComponentIndex(index);
 console.log(
   `Wrote ${index.components.length} components to src/design-system/component-index.json`
 );

--- a/frontend/.storybook/design-system-utils.mjs
+++ b/frontend/.storybook/design-system-utils.mjs
@@ -76,6 +76,20 @@ export const writeJson = (filePath, data) => {
   fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
 };
 
+// Keep the previous generatedAt when nothing else changed, so regenerating
+// the index is a no-op for git (CI diffs these files).
+export const writeComponentIndex = (index) => {
+  if (fs.existsSync(componentIndexPath)) {
+    const existing = readJson(componentIndexPath);
+    const stripTimestamp = (value) =>
+      JSON.stringify({ ...value, generatedAt: null });
+    if (stripTimestamp(existing) === stripTimestamp(index)) {
+      index = { ...index, generatedAt: existing.generatedAt };
+    }
+  }
+  writeJson(componentIndexPath, index);
+};
+
 export const walkFiles = (dir, predicate) => {
   if (!fs.existsSync(dir)) return [];
   const result = [];

--- a/frontend/.storybook/validate-registry.mjs
+++ b/frontend/.storybook/validate-registry.mjs
@@ -17,7 +17,7 @@ import {
   storyPathFor,
   storyTitleFor,
   writeChecklist,
-  writeJson,
+  writeComponentIndex,
 } from "./design-system-utils.mjs";
 
 const run = (command, args) => {
@@ -27,7 +27,7 @@ const run = (command, args) => {
 
 run("node", [".storybook/extract-tokens.mjs"]);
 const index = buildIndex();
-writeJson(componentIndexPath, index);
+writeComponentIndex(index);
 
 const ajv = new Ajv({
   allErrors: true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.28.0",
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "esbuild",
+      "svelte-preprocess"
+    ]
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary

The `validate` job of the Design System workflow has failed on every run since it landed (including the push to main that added it), so all open PRs show a red check. Three independent problems, all fixed here.

## Changes

1. **`pnpm install --frozen-lockfile` fails with `ERR_PNPM_IGNORED_BUILDS`.** `corepack enable` with no pinned version resolves a pnpm that hard-fails on CI when dependency build scripts are ignored without explicit config. Pinned `"packageManager": "pnpm@10.28.0"` in `frontend/package.json` and declared `ignoredBuiltDependencies: ["esbuild", "svelte-preprocess"]` — the exact set local installs have always skipped (everything builds and tests green without their postinstall scripts).
2. **`pnpm test-storybook` needs a browser.** The Storybook vitest project runs in chromium via Playwright; the runner has none installed. Added a `pnpm exec playwright install --with-deps chromium` step.
3. **The `git diff --exit-code` check on generated files would fail every run.** `buildIndex()` stamps a fresh `generatedAt` timestamp into `component-index.json` on every regeneration, so the file is always dirty after `ds:validate`. The new `writeComponentIndex` helper keeps the previous timestamp when the content is otherwise unchanged, making regeneration a git no-op (verified: `ds:validate` + `ds:registry` leave a clean tree).

## Test plan

- `CI=true GITHUB_ACTIONS=true pnpm install --frozen-lockfile` on a fresh `node_modules`: passes, no ignored-builds warning
- `pnpm ds:validate` then `pnpm ds:registry`: clean `git status` (previously dirtied `component-index.json`)
- `pnpm test-storybook`: 88/88 pass locally
- `pnpm build-storybook`: succeeds
- The real proof is this PR's own check run

🤖 Generated with [Claude Code](https://claude.com/claude-code)