### PR TITLE
fix: drop subscription identifier from client publishes; correct proto test counts

### DIFF
--- a/backend/app/mqtt.go
+++ b/backend/app/mqtt.go
@@ -210,10 +210,9 @@ func makePublishProperties(properties *PublishProperties) (*mqtt.MessageProperti
 		publishProperties.CorrelationData = correlationData
 	}
 
-	if properties.SubscriptionIdentifier > -1 {
-		subscriptionIdentifier := int(properties.SubscriptionIdentifier)
-		publishProperties.SubscriptionIdentifier = &subscriptionIdentifier
-	}
+	// properties.SubscriptionIdentifier is intentionally ignored — it is a
+	// broker-to-client property and must not appear in a client PUBLISH
+	// [MQTT-3.3.4-6].
 
 	if properties.UserProperties != nil {
 		publishProperties.UserProperties = properties.UserProperties

--- a/backend/app/mqtt_test.go
+++ b/backend/app/mqtt_test.go
@@ -321,8 +321,9 @@ func TestMakePublishProperties(t *testing.T) {
 	if *messageProperties.TopicAlias != 1 {
 		t.Errorf("Expected TopicAlias 1, got %v", *messageProperties.TopicAlias)
 	}
-	if *messageProperties.SubscriptionIdentifier != 2 {
-		t.Errorf("Expected SubscriptionIdentifier 2, got %v", *messageProperties.SubscriptionIdentifier)
+	// Subscription identifiers must never be set on outgoing publishes [MQTT-3.3.4-6]
+	if messageProperties.SubscriptionIdentifier != nil {
+		t.Errorf("Expected SubscriptionIdentifier to be nil, got %v", *messageProperties.SubscriptionIdentifier)
 	}
 	if len(messageProperties.UserProperties) != 1 {
 		t.Errorf("Expected 1 user property, got %v", len(messageProperties.UserProperties))

--- a/backend/mqtt/publish.go
+++ b/backend/mqtt/publish.go
@@ -77,6 +77,10 @@ func (mm *MqttManager) publishV5(params MqttPublishParams) error {
 	}
 	var publishProperties *paho.PublishProperties
 	if params.Properties != nil {
+		// SubscriptionIdentifier is deliberately not forwarded: a PUBLISH sent
+		// from a client to a server must not contain one [MQTT-3.3.4-6], and
+		// spec-enforcing brokers (e.g. mosquitto >= 2.1) disconnect with a
+		// protocol error if it is present.
 		publishProperties = &paho.PublishProperties{
 			CorrelationData: params.Properties.CorrelationData,
 			ContentType:     params.Properties.ContentType,
@@ -84,10 +88,6 @@ func (mm *MqttManager) publishV5(params MqttPublishParams) error {
 			PayloadFormat:   params.Properties.PayloadFormat,
 			MessageExpiry:   params.Properties.MessageExpiry,
 			TopicAlias:      params.Properties.TopicAlias,
-		}
-
-		if params.Properties.SubscriptionIdentifier != nil && *params.Properties.SubscriptionIdentifier != 0 {
-			publishProperties.SubscriptionIdentifier = params.Properties.SubscriptionIdentifier
 		}
 
 		if params.Properties.UserProperties != nil {

--- a/backend/protobuf/registry_test.go
+++ b/backend/protobuf/registry_test.go
@@ -15,11 +15,11 @@ func TestRegistryLoadsCorrectly(t *testing.T) {
 		t.Errorf("Expected no error, got %v", err)
 		return
 	}
-	if len(*registry.LoadedDescriptors) != 4 {
-		t.Errorf("Expected 4 descriptors, got %v", len(*registry.LoadedDescriptors))
+	if len(*registry.LoadedDescriptors) != 7 {
+		t.Errorf("Expected 7 descriptors, got %v", len(*registry.LoadedDescriptors))
 	}
-	if len(*registry.LoadedFiles) != 2 {
-		t.Errorf("Expected 2 file names, got %v", len(registry.LoadedFileNames))
+	if len(*registry.LoadedFiles) != 3 {
+		t.Errorf("Expected 3 file names, got %v", len(*registry.LoadedFiles))
 	}
 	if !(*registry.LoadedDescriptors)[0].FullName().IsValid() {
 		t.Errorf("Expected first descriptor to have a valid full name, got %v", (*registry.LoadedDescriptors)[0].FullName())
@@ -30,8 +30,8 @@ func TestRegistryLoadsCorrectly(t *testing.T) {
 	if !(*registry.LoadedDescriptors)[2].FullName().IsValid() {
 		t.Errorf("Expected third descriptor to have a valid full name, got %v", (*registry.LoadedDescriptors)[0].FullName())
 	}
-	if len(*registry.LoadedDescriptorsNameMap) != 4 {
-		t.Errorf("Expected 4 descriptors in name map, got %v", len(*registry.LoadedDescriptorsNameMap))
+	if len(*registry.LoadedDescriptorsNameMap) != 7 {
+		t.Errorf("Expected 7 descriptors in name map, got %v", len(*registry.LoadedDescriptorsNameMap))
 	}
 }
 


### PR DESCRIPTION
Fixes two pre-existing test failures on `main`.

## MQTT5 publish-with-all-properties EOF
`TestMqttV5PubsAndSubsCorrectlyWithAllProperties` (and `...WithNoAlias`) failed against spec-enforcing brokers. The app was forwarding a `SubscriptionIdentifier` on outgoing PUBLISH packets, but per **[MQTT-3.3.4-6]** a subscription identifier is a broker-to-client property and must not appear in a client PUBLISH. mosquitto >= 2.1 rejects it with a protocol error, surfacing as `client error: EOF` / `publish: context deadline exceeded`. (A stale local mosquitto 2.0.x image masked this — it tolerated the violation.)

Fix: stop setting `SubscriptionIdentifier` in `publishV5` (`backend/mqtt/publish.go`) and `makePublishProperties` (`backend/app/mqtt.go`); update `TestMakePublishProperties` to assert it stays `nil`.

## Protobuf registry test counts stale
`TestRegistryLoadsCorrectly` asserted the `test-protos-good` fixture held 2 files / 4 descriptors, but the fixture has grown to 3 files / 7 message descriptors (counts stale since the public-repo migration). Updated the expected counts and fixed a wrong field referenced in one error message.

## Verification
All `backend/mqtt` and `backend/app/...TestMqttV*` tests pass against mosquitto 2.1.2 (TCP 1883 + websockets 9001); `backend/protobuf` green.

Pre-existing failures left untouched (environment-only): `backend/update` (live update server), `backend/cloud` (localhost:8090), and flaky seeded-app tests (separate fix tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)