### PR TITLE
fix(chart): support quoted & bare numeric payloads (#77, #78)

### DIFF
--- a/frontend/src/stories/fixtures.ts
+++ b/frontend/src/stories/fixtures.ts
@@ -354,7 +354,7 @@ export const createMockChartSeriesStore = () =>
   ]);
 
 export const mockPayloadTree = payloadTree(
-  '{"temp":24.6,"humidity":61,"sensor":{"rssi":-72},"status":"ok"}'
+  '{"temp":24.6,"humidity":61,"pressure":"1013.2","sensor":{"rssi":-72},"status":"ok"}'
 );
 
 export const createMockCollectionsStore = () => {

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/SelectedTopicPanel.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/SelectedTopicPanel.svelte
@@ -48,6 +48,13 @@
   $: chartTabIndex = mqttVersion === "3" ? 1 : 3;
   $: isChartTabActive = activeTabIndex === chartTabIndex;
   const viewChart = () => tabsRef?.setTab(chartTabIndex);
+  // Opens the payload field picker and switches to the Payload tab, so
+  // "Add value from payload" lands the user on a ready-to-pick control.
+  let showPayloadFieldPicker = false;
+  const addFromPayload = () => {
+    showPayloadFieldPicker = true;
+    tabsRef?.setTab(0);
+  };
   const popOut = () =>
     openChartWindow?.(
       $selectedTopicStore.selectedTopic ?? "",
@@ -228,6 +235,7 @@
             <PayloadTab
               bind:codec={$selectedTopicStore.options.decoding}
               bind:format={$selectedTopicStore.options.format}
+              bind:showFieldPicker={showPayloadFieldPicker}
               {isComparing}
               payload={selectedMessagePayload}
               payloadB64={selectedMessagePayloadB64}
@@ -242,7 +250,7 @@
             {selectedTopicStore}
             {chartSeriesStore}
             topic={selectedTopicString ?? ""}
-            onAddFromPayload={() => tabsRef?.setTab(0)}
+            onAddFromPayload={addFromPayload}
             onPopOut={openChartWindow ? popOut : null}
           />
         </div>
@@ -264,6 +272,7 @@
             <PayloadTab
               bind:codec={$selectedTopicStore.options.decoding}
               bind:format={$selectedTopicStore.options.format}
+              bind:showFieldPicker={showPayloadFieldPicker}
               {isComparing}
               payload={selectedMessagePayload}
               payloadB64={selectedMessagePayloadB64}
@@ -297,7 +306,7 @@
             {selectedTopicStore}
             {chartSeriesStore}
             topic={selectedTopicString ?? ""}
-            onAddFromPayload={() => tabsRef?.setTab(0)}
+            onAddFromPayload={addFromPayload}
             onPopOut={openChartWindow ? popOut : null}
           />
         </div>

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/FieldPicker.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/FieldPicker.svelte
@@ -10,7 +10,8 @@
 
   $: indent = depth * 14;
   $: isContainer = node.type === "object" || node.type === "array";
-  $: isNumber = node.type === "number";
+  // Numbers and quoted numerics (e.g. "24.6") can both be charted.
+  $: isChartable = node.chartable === true;
   $: color = selected.get(node.path);
   $: open = node.type === "array" ? "[" : "{";
   $: close = node.type === "array" ? "]" : "}";
@@ -51,20 +52,20 @@
 {:else}
   <div
     class={`flex items-center font-mono text-base py-[2px] pr-1 rounded ${
-      isNumber ? "hover:bg-hovered cursor-pointer" : ""
+      isChartable ? "hover:bg-hovered cursor-pointer" : ""
     }`}
     style:padding-left={`${indent}px`}
-    on:click={isNumber ? () => onToggle(node.path) : undefined}
-    role={isNumber ? "button" : undefined}
-    tabindex={isNumber ? 0 : undefined}
-    on:keydown={isNumber
+    on:click={isChartable ? () => onToggle(node.path) : undefined}
+    role={isChartable ? "button" : undefined}
+    tabindex={isChartable ? 0 : undefined}
+    on:keydown={isChartable
       ? (e) => (e.key === "Enter" || e.key === " ") && onToggle(node.path)
       : undefined}
   >
     {#if depth > 0}<span class="text-secondary-text">{node.key}:&nbsp;</span>{/if}
     <span class={valueClass}>{valueText}</span>
     <div class="grow"></div>
-    {#if isNumber}
+    {#if isChartable}
       <span
         class="size-4 min-w-4 rounded-[3px] border flex items-center justify-center"
         style:border-color={color ?? "var(--color-secondary-text)"}

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.test.ts
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.test.ts
@@ -34,10 +34,28 @@ describe("numericFields", () => {
     expect(numericFields("42.5")).toEqual([{ path: "", value: 42.5 }]);
   });
 
-  it("excludes strings, booleans, and null", () => {
+  it("excludes non-numeric strings, booleans, and null", () => {
     expect(numericFields('{"a":1,"b":"x","c":true,"d":null}')).toEqual([
       { path: "a", value: 1 },
     ]);
+  });
+
+  it("casts quoted numerics to numbers", () => {
+    expect(numericFields('{"temp":"24.6","rssi":"-72","load":"1e3"}')).toEqual([
+      { path: "temp", value: 24.6 },
+      { path: "rssi", value: -72 },
+      { path: "load", value: 1000 },
+    ]);
+  });
+
+  it("charts a bare quoted numeric payload with empty path", () => {
+    expect(numericFields('"42.5"')).toEqual([{ path: "", value: 42.5 }]);
+  });
+
+  it("excludes strings that are not purely numeric", () => {
+    expect(
+      numericFields('{"a":"24C","b":"","c":"0x1f","d":"1,000","e":"NaN"}')
+    ).toEqual([]);
   });
 
   it("returns [] for non-JSON payloads", () => {
@@ -58,6 +76,10 @@ describe("valueAtPath", () => {
   it("reads a bare numeric payload at empty path", () => {
     expect(valueAtPath("42.5", "")).toBe(42.5);
   });
+  it("reads quoted numeric values as numbers", () => {
+    expect(valueAtPath('{"temp":"24.6"}', "temp")).toBe(24.6);
+    expect(valueAtPath('"42.5"', "")).toBe(42.5);
+  });
   it("returns null when path is missing or non-numeric", () => {
     expect(valueAtPath('{"a":1}', "b")).toBeNull();
     expect(valueAtPath('{"a":"x"}', "a")).toBeNull();
@@ -77,6 +99,21 @@ describe("payloadTree", () => {
     expect(sensor?.children?.[0].path).toBe("sensor.rssi");
     const name = tree?.children?.find((c) => c.key === "name");
     expect(name?.type).toBe("string");
+    expect(name?.chartable).toBeUndefined();
+  });
+  it("marks numeric-string leaves as chartable but keeps string type", () => {
+    const tree = payloadTree('{"temp":"24.6","name":"kitchen"}');
+    const temp = tree?.children?.find((c) => c.key === "temp");
+    expect(temp?.type).toBe("string");
+    expect(temp?.value).toBe("24.6");
+    expect(temp?.chartable).toBe(true);
+    const name = tree?.children?.find((c) => c.key === "name");
+    expect(name?.chartable).toBeUndefined();
+  });
+  it("marks numeric leaves as chartable", () => {
+    const tree = payloadTree('{"temp":24.6}');
+    const temp = tree?.children?.find((c) => c.key === "temp");
+    expect(temp?.chartable).toBe(true);
   });
   it("returns null for non-JSON", () => {
     expect(payloadTree("nope")).toBeNull();
@@ -95,5 +132,6 @@ describe("hasNumericFields", () => {
     expect(hasNumericFields('{"a":"x"}')).toBe(false);
     expect(hasNumericFields("42")).toBe(true);
     expect(hasNumericFields("text")).toBe(false);
+    expect(hasNumericFields('{"a":"3.14"}')).toBe(true);
   });
 });

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.ts
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.ts
@@ -20,6 +20,7 @@ export interface PayloadNode {
   path: string; // dotted/indexed path from root
   type: PayloadNodeType;
   value?: number | string | boolean | null; // for leaves
+  chartable?: boolean; // leaf can be charted (a number, or a numeric string)
   children?: PayloadNode[];
 }
 
@@ -48,17 +49,40 @@ const typeOf = (v: unknown): PayloadNodeType => {
 const isFiniteNumber = (v: unknown): v is number =>
   typeof v === "number" && Number.isFinite(v);
 
+// A string that is a plain decimal/scientific number and nothing else. Rejects
+// empty/whitespace, hex ("0x1f"), Infinity/NaN, and unit-suffixed values ("24C").
+const NUMERIC_STRING = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+
 /**
- * Returns the numeric leaf fields of a payload. A bare numeric payload yields a
- * single field with path "". Non-JSON (and JSON with no numbers) yields [].
+ * Coerces a leaf value to a finite number for charting. Numbers pass through;
+ * quoted numerics (e.g. "24.6", "-72") are cast to float. Everything else
+ * (non-numeric strings, booleans, null, objects) yields null.
+ */
+const coerceNumber = (v: unknown): number | null => {
+  if (isFiniteNumber(v)) return v;
+  if (typeof v === "string") {
+    const trimmed = v.trim();
+    if (NUMERIC_STRING.test(trimmed)) {
+      const n = Number(trimmed);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+};
+
+/**
+ * Returns the numeric leaf fields of a payload. Numbers and quoted numerics
+ * (e.g. "24.6") both count. A bare numeric payload yields a single field with
+ * path "". Non-JSON (and JSON with no numbers) yields [].
  */
 export function numericFields(payload: string): NumericField[] {
   const parsed = parse(payload);
   if (parsed === undefined) return [];
   const out: NumericField[] = [];
   const walk = (value: unknown, path: string) => {
-    if (isFiniteNumber(value)) {
-      out.push({ path, value });
+    const num = coerceNumber(value);
+    if (num !== null) {
+      out.push({ path, value: num });
       return;
     }
     if (Array.isArray(value)) {
@@ -86,7 +110,7 @@ export function valueAtPath(payload: string, path: string): number | null {
       current = (current as Record<string, unknown>)[segment];
     }
   }
-  return isFiniteNumber(current) ? current : null;
+  return coerceNumber(current);
 }
 
 /**
@@ -118,7 +142,14 @@ export function payloadTree(payload: string): PayloadNode | null {
         ),
       };
     }
-    return { key, path, type, value: value as number | string | boolean | null };
+    const leaf: PayloadNode = {
+      key,
+      path,
+      type,
+      value: value as number | string | boolean | null,
+    };
+    if (coerceNumber(value) !== null) leaf.chartable = true;
+    return leaf;
   };
   return build(parsed, "value", "");
 }

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.stories.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.stories.svelte
@@ -3,6 +3,7 @@
   import Component from "./PayloadTab.svelte";
   import StoryRender from "@/stories/StoryRender.svelte";
   import { getStoryArgTypes, getStoryArgs } from "@/stories/fixtures";
+  import { createChartSeriesStore } from "./Chart/chart-series-store";
 
   const componentName = "PayloadTab";
   const storyId = "Views/Connection/DataView/SelectedTopicPanel/PayloadTab";
@@ -36,6 +37,22 @@
     payload: "PNG…",
     payloadB64: TINY_PNG,
     format: "none",
+  }}
+  {template}
+/>
+
+<!-- A bare numeric payload is chartable; "Add value from payload" opens this
+     picker directly on the value (issue #78). -->
+<Story
+  name="Chart fields (bare number)"
+  args={{
+    ...storyArgs,
+    isComparing: false,
+    payload: "19",
+    payloadB64: null,
+    format: "none",
+    chartSeriesStore: createChartSeriesStore([]),
+    showFieldPicker: true,
   }}
   {template}
 />

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.svelte
@@ -32,8 +32,9 @@
   // Optional: when present, a "Chart fields" toggle reveals the numeric picker.
   export let chartSeriesStore: ChartSeriesStore | null = null;
   export let onViewChart: (() => void) | null = null;
+  // Bindable so the Chart tab's "Add value from payload" can open the picker.
+  export let showFieldPicker = false;
 
-  let showFieldPicker = false;
   let showRawImageBytes = false;
   // Reset the raw-bytes escape hatch when switching messages.
   $: payloadB64, (showRawImageBytes = false);


### PR DESCRIPTION
Two charting fixes for numeric payloads.

---

## 1. Quoted-numeric payload fields — Closes #77

Numeric JSON values are frequently wrapped in quotes (e.g. `{"temp":"24.6"}`), which previously excluded them from charting.

- **`coerceNumber()`** casts numbers and numeric strings. A strict regex (`/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/`) keeps this conservative: it rejects empty/whitespace, hex (`"0x1f"`), `Infinity`/`NaN`, thousands separators (`"1,000"`), and unit-suffixed values (`"24C"`).
- `numericFields`, `valueAtPath`, and `payloadTree` all route through it, so extraction, plotting, and the picker agree.
- `PayloadNode` gains a `chartable` flag. The picker keeps a quoted numeric's **string** styling (quotes + green) but makes it selectable. Non-numeric strings (`"ok"`), booleans, and null remain excluded.

**Before** — `"1013.2"` has no checkbox, so it can't be charted:

![before](https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/pr-assets/issue-77/before.png)

**After** — `"1013.2"` is now selectable, while `"ok"` is still correctly excluded:

![after](https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/pr-assets/issue-77/after.png)

---

## 2. "Add value from payload" now opens the picker — addresses discussion #78

For bare numeric payloads (the whole payload is a number, e.g. `19`) the value *was* chartable, but the Chart tab's **"Add value from payload"** button only switched to the Payload tab — leaving the user on the raw payload with no obvious control, having to spot the subtle "Chart fields" toggle. It now opens the field picker directly, so the selectable value and its checkbox are right there.

- `PayloadTab`'s `showFieldPicker` is now a bindable prop.
- `SelectedTopicPanel` binds it; `addFromPayload()` opens the picker before switching tabs.
- Added a "Chart fields (bare number)" PayloadTab story.

**After** — a bare `19` payload shows a selectable value…

![picker open](https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/pr-assets/issue-77/d78-open.png)

…and clicking it adds the series:

![picker selected](https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/pr-assets/issue-77/d78-selected.png)

---

## Tests

Extended `payload-fields.test.ts` (quoted-numeric casting, bare quoted payloads, rejecting `"24C"`/`""`/`"0x1f"`/`"1,000"`/`"NaN"`, `chartable` flag). Full unit suite green: **73/73**. `svelte-check` clean; `pnpm ds:validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)