### PR TITLE
feat(changelog): tabbed 'What's new', /release + /changelog skills, house style (no emojis, no em dashes)

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: changelog
+description: Add or update the in-app "What's new" changelog for MQTT Viewer. Use when the user says "update the changelog", "add a changelog entry", "record this in what's new", "note this for the next release", after merging a user-facing PR, or when promoting the unreleased notes at release time.
+---
+
+# Update the changelog
+
+The changelog is the in-app "What's new" dialog. It lives in one file:
+`frontend/src/changelog.ts`. This skill adds new changes to the unreleased
+staging entry, and (at release time) promotes that entry to a version.
+
+**Read `docs/WRITING_STYLE.md` first and follow it.** The hard rules: warm and
+first person, British spelling, concise, and NO em dashes (none, not even one).
+It must not read like an AI wrote it.
+
+## How the changelog is structured
+
+- `CHANGELOG` is an array of entries, newest first.
+- The top entry can be a staging entry with `released: false` and
+  `version: "unreleased"`. It gathers changes for the next release and only
+  shows on dev builds, so users never read half-finished notes.
+- Released entries have `released: true`, a bare semver `version` (e.g.
+  `"1.0.0"`), and a `date` like `"July 2026"`.
+- Each entry has `headline`, `intro`, `sections` (each `{ emoji, title, body }`),
+  and an optional `outro`.
+
+## Adding changes (the common case)
+
+1. **Find what changed and is worth mentioning.** Look at what shipped since the
+   last release: `git log v<last-release>..HEAD --oneline`, and the merged PRs.
+   Include only things a user would notice: new features, behaviour changes,
+   fixes to visible bugs, platform/packaging fixes. Skip pure chores, refactors,
+   tests, CI, and docs.
+
+2. **Make sure the staging entry exists.** If the top of `CHANGELOG` isn't an
+   unreleased entry, add one:
+   ```ts
+   {
+     version: "unreleased",
+     released: false,
+     date: "In development",
+     headline: "In the next update",
+     intro: "Here's what's landed since <last version>. I'll tidy these notes up and give them a version when the update ships.",
+     sections: [],
+   }
+   ```
+
+3. **Write the sections.** Group related changes into one section each. A section
+   is one emoji, a short benefit-first title, and one or two sentences of body.
+   Lead with what the user can now do. Follow the style guide. Reuse or extend an
+   existing section rather than adding a near-duplicate.
+
+4. **Validate.** `cd frontend && pnpm test:run changelog` (checks shape and the
+   no-em-dash guard) and `pnpm check`. Both must pass. Optionally preview it in
+   Storybook: the `WhatsNewContent` "With unreleased tab" story.
+
+## Promoting at release time
+
+When cutting release `vX.Y.Z` (see `docs/RELEASING.md`):
+
+1. Turn the staging entry into a released one: set `released: true`, set
+   `version` to the bare semver (`"X.Y.Z"`, no leading `v`), and set `date` to
+   the release month (`"Month YYYY"`).
+2. Give it a proper `headline` if it still has the placeholder one.
+3. Do NOT decide the version number before release. The bump (patch vs minor) is
+   evaluated at release time based on everything that landed.
+4. Leave no empty `unreleased` entry behind; the next change re-creates it.
+5. Re-run the validation from step 4 above.
+
+## What NOT to do
+
+- No em dashes. The changelog test fails if any slip in.
+- No version guessing ahead of release. Keep changes in the staging entry.
+- No marketing voice. See `docs/WRITING_STYLE.md`.
+- Don't hand-edit `frontend/src/design-system/component-index.json`.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -10,8 +10,8 @@ The changelog is the in-app "What's new" dialog. It lives in one file:
 staging entry, and (at release time) promotes that entry to a version.
 
 **Read `docs/WRITING_STYLE.md` first and follow it.** The hard rules: warm and
-first person, British spelling, concise, and NO em dashes (none, not even one).
-It must not read like an AI wrote it.
+first person, British spelling, concise, NO em dashes, and NO emojis. It must
+not read like an AI wrote it.
 
 ## How the changelog is structured
 
@@ -21,8 +21,8 @@ It must not read like an AI wrote it.
   shows on dev builds, so users never read half-finished notes.
 - Released entries have `released: true`, a bare semver `version` (e.g.
   `"1.0.0"`), and a `date` like `"July 2026"`.
-- Each entry has `headline`, `intro`, `sections` (each `{ emoji, title, body }`),
-  and an optional `outro`.
+- Each entry has `headline`, `intro`, `sections` (each `{ title, body }`), and
+  an optional `outro`.
 
 ## Adding changes (the common case)
 
@@ -46,7 +46,7 @@ It must not read like an AI wrote it.
    ```
 
 3. **Write the sections.** Group related changes into one section each. A section
-   is one emoji, a short benefit-first title, and one or two sentences of body.
+   is a short benefit-first title (no emoji) and one or two sentences of body.
    Lead with what the user can now do. Follow the style guide. Reuse or extend an
    existing section rather than adding a near-duplicate.
 
@@ -69,7 +69,7 @@ When cutting release `vX.Y.Z` (see `docs/RELEASING.md`):
 
 ## What NOT to do
 
-- No em dashes. The changelog test fails if any slip in.
+- No em dashes and no emojis. The changelog test fails if any slip in.
 - No version guessing ahead of release. Keep changes in the staging entry.
 - No marketing voice. See `docs/WRITING_STYLE.md`.
 - Don't hand-edit `frontend/src/design-system/component-index.json`.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: release
+description: Publish a MQTT Viewer release end to end. Use when the user says "release", "cut a release", "publish vX.Y.Z", "ship it", or "do a release". Promotes the changelog, creates the GitHub release that triggers the mac/windows/linux build+sign+portal workflows, watches them, and hands off the final go-live step.
+---
+
+# Release MQTT Viewer
+
+Drives the runbook in `docs/RELEASING.md`. One release is one annotated GitHub
+release on `main`; publishing it fires three workflows (mac / windows / linux)
+that build, sign, upload assets, and register the version with the portal.
+Nothing reaches users until the `released` toggle is flipped in the portal.
+
+Creating a GitHub release is outward-facing and hard to undo. **Confirm the
+version with the user and get an explicit go-ahead before step 4.**
+
+## Inputs
+
+- `VERSION`: the tag, `vX.Y.Z` (or `vX.Y.Z-beta1` for a dry run). If the user
+  didn't give one, ask. Decide the bump (patch vs minor vs major) now, from what
+  actually landed since the last release. Do not pre-empt it earlier.
+- `PREV`: the previous release tag, for release notes. Get it with
+  `gh release list --limit 5` or `git tag --sort=-v:refname | head`.
+
+## 1. Pre-flight
+
+- `git fetch --all --tags`.
+- Confirm `develop` is the integration branch and is green (latest CI passing).
+- Confirm `main` can fast-forward from `origin/develop`
+  (`git merge-base --is-ancestor origin/main origin/develop`). If it can't, stop
+  and tell the user: `main` has diverged and `just release` will fail its
+  `--ff-only` merge.
+- Working tree clean, `gh auth status` OK.
+
+## 2. Promote the changelog (this is what makes updates show notes)
+
+The shipped binary carries its own changelog, matched to its version at runtime.
+If you skip this, users who update see no "What's new". So:
+
+- In `frontend/src/changelog.ts`, take the top `released: false` staging entry
+  and promote it: set `released: true`, `version` to the bare semver
+  (`"X.Y.Z"`, no `v`, must match `VERSION`), and `date` to `"Month YYYY"`.
+- Give it a real `headline` if it still has the placeholder.
+- Follow `docs/WRITING_STYLE.md`: warm, first person, British spelling, no em
+  dashes, no emojis.
+- If there's no staging entry or it has no sections, run the `/changelog` skill
+  first to gather what shipped since `PREV`.
+
+Then validate and land it on `develop`:
+
+```sh
+cd frontend && pnpm test:run changelog && pnpm check
+git add -A && git commit -m "chore(changelog): notes for VERSION"
+git push origin develop
+```
+
+The commit must be on `develop` and pushed before step 4, because `just release`
+fast-forwards `main` from `origin/develop`.
+
+## 3. Dry run (recommended for risky releases)
+
+```sh
+just release vX.Y.Z-beta1 PREV --prerelease
+just release-status   # watch the three workflows
+```
+
+Fix any CI issues and use `just release-retry` (delete + recreate the tag, so
+workflows run from the fixed commit) rather than a plain re-run.
+
+## 4. The real release (confirm first)
+
+```sh
+just release VERSION PREV
+```
+
+This merges `develop` into `main`, pushes, and runs `gh release create` with
+generated notes from `PREV`. Then watch:
+
+```sh
+just release-status
+gh run list --limit 6
+```
+
+Expected assets (see `docs/RELEASING.md` for the full list): darwin arm64/amd64
+zips, windows zip + installer.exe, linux zip/AppImage/deb/rpm, each with a
+`.sha256`.
+
+## 5. Go live (manual, human gate)
+
+The workflows POST each artifact to the portal, creating one `release_v3` record
+with `released=false`. It reaches users only when someone flips `released=true`.
+
+- Tell the user to open the PocketBase admin at https://cloud.mqttviewer.app/_/,
+  find the new `release_v3` record, confirm all platform artifacts merged into
+  it, and flip `released` when happy. The in-app updater
+  (`POST /api/cv1/updates/v3/check`) only serves `released=true`.
+- This step is the user's to do. Do not attempt to flip it yourself.
+
+## Notes
+
+- Signing (Apple gon/notarytool, Azure Trusted Signing) and portal auth all run
+  from CI secrets; see the table in `docs/RELEASING.md` for where each breaks.
+- After go-live, verify an update check picks up the new version.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,6 +5,10 @@ fires three workflows (mac / windows / linux) that build, sign, upload assets,
 and register the version with the portal. Nothing reaches users until you flip
 the `released` toggle in the portal admin.
 
+The `/release` skill drives this whole runbook (changelog promotion, release
+creation, workflow watching, and the go-live handoff). This doc is the
+reference it follows.
+
 ## TL;DR
 
 ```sh

--- a/docs/WRITING_STYLE.md
+++ b/docs/WRITING_STYLE.md
@@ -1,0 +1,70 @@
+# Writing style
+
+How MQTT Viewer sounds in anything a user reads: the changelog / "What's new"
+notes, dialog copy, empty states, tooltips, README, release notes. The goal is
+simple. It should read like a real person who built the app wrote it, because
+one did. It should never read like it came out of a template or a language
+model.
+
+If you are an AI writing copy for this app, this file is the brief. Follow it.
+
+## Voice in one line
+
+Warm, direct, and a little dry. First person. Talks to one user, not a crowd.
+
+## The rules
+
+1. **First person singular.** It's "I", not "we". One person builds MQTT Viewer,
+   so feedback "comes straight to me", not "to our team". Address the reader as
+   "you".
+
+2. **British spelling.** visualise, colour, behaviour, favourite, licence (noun),
+   customise, catalogue. Match the rest of the app.
+
+3. **No em dashes. None.** This is the fastest tell that a machine wrote it, and
+   it is a hard rule here. Where you reach for one, use a full stop, a comma, a
+   colon, or brackets instead. "It's fast, and it stays fast." not "It's
+   fast — and it stays fast." This applies to en dashes used as connectors too;
+   a hyphen inside a compound word (built-in, opt-in, pop-out) is fine.
+
+4. **Concise.** Short sentences. Cut the throat-clearing. Say the thing, then
+   stop. If a sentence still works with a word removed, remove it.
+
+5. **Plain words over corporate ones.** No "seamless", "leverage", "elevate",
+   "unleash", "robust", "powerful", "revolutionary", "delve", "supercharge",
+   "unlock", "empower". Say what it does in the words you'd use out loud.
+
+6. **Concrete, not abstract.** "Tick a numeric field and watch it plot" beats
+   "enables real-time data visualisation". Name the button, the payload, the
+   actual thing on screen.
+
+7. **A bit of warmth is good.** A wink is fine ("But wait, there's more"). Thank
+   people. Admit when something was overdue. Do not force jokes and do not gush.
+
+8. **No hedging filler.** Drop "simply", "just", "easily", "of course", "in
+   order to", "please note that". They add nothing.
+
+9. **Honest, never hype.** Don't oversell. "This should fix it" is more honest
+   than "completely eliminates all issues". Milestones are milestones, not
+   finish lines.
+
+## Changelog specifics
+
+- Group changes into a few sections, each led by a single emoji, a short title,
+  and one or two sentences of body. See `frontend/src/changelog.ts`.
+- Section titles are benefit-first and plain: "Chart your data, live", not
+  "Charting improvements".
+- Write for someone mid-task who just updated and wants to know what changed.
+  Lead with what they can now do.
+- Keep the whole entry skimmable. Nobody reads a wall of text in a dialog.
+
+## Quick before / after
+
+- No: "We've completely revamped the charting experience — unlocking powerful
+  new real-time visualisation capabilities."
+- Yes: "You can now chart values that arrive as text, like a quoted `\"24.6\"`.
+  They plot just like plain numbers."
+
+- No: "Simply click the button in order to seamlessly add your value."
+- Yes: "Click 'Add value from payload' and the picker opens on the value, ready
+  to tick."

--- a/docs/WRITING_STYLE.md
+++ b/docs/WRITING_STYLE.md
@@ -24,34 +24,40 @@ Warm, direct, and a little dry. First person. Talks to one user, not a crowd.
 3. **No em dashes. None.** This is the fastest tell that a machine wrote it, and
    it is a hard rule here. Where you reach for one, use a full stop, a comma, a
    colon, or brackets instead. "It's fast, and it stays fast." not "It's
-   fast — and it stays fast." This applies to en dashes used as connectors too;
-   a hyphen inside a compound word (built-in, opt-in, pop-out) is fine.
+   fast [em dash] and it stays fast." This applies to en dashes used as
+   connectors too; a hyphen inside a compound word (built-in, opt-in, pop-out)
+   is fine.
 
-4. **Concise.** Short sentences. Cut the throat-clearing. Say the thing, then
+4. **No emojis. None.** Standing rule. No emoji in the changelog, dialog copy,
+   UI text, or docs. Let the words carry it. If you need to separate or lead
+   items, use a heading, a title, or plain punctuation, never a picture.
+
+5. **Concise.** Short sentences. Cut the throat-clearing. Say the thing, then
    stop. If a sentence still works with a word removed, remove it.
 
-5. **Plain words over corporate ones.** No "seamless", "leverage", "elevate",
+6. **Plain words over corporate ones.** No "seamless", "leverage", "elevate",
    "unleash", "robust", "powerful", "revolutionary", "delve", "supercharge",
    "unlock", "empower". Say what it does in the words you'd use out loud.
 
-6. **Concrete, not abstract.** "Tick a numeric field and watch it plot" beats
+7. **Concrete, not abstract.** "Tick a numeric field and watch it plot" beats
    "enables real-time data visualisation". Name the button, the payload, the
    actual thing on screen.
 
-7. **A bit of warmth is good.** A wink is fine ("But wait, there's more"). Thank
+8. **A bit of warmth is good.** A wink is fine ("But wait, there's more"). Thank
    people. Admit when something was overdue. Do not force jokes and do not gush.
 
-8. **No hedging filler.** Drop "simply", "just", "easily", "of course", "in
+9. **No hedging filler.** Drop "simply", "just", "easily", "of course", "in
    order to", "please note that". They add nothing.
 
-9. **Honest, never hype.** Don't oversell. "This should fix it" is more honest
-   than "completely eliminates all issues". Milestones are milestones, not
-   finish lines.
+10. **Honest, never hype.** Don't oversell. "This should fix it" is more honest
+    than "completely eliminates all issues". Milestones are milestones, not
+    finish lines.
 
 ## Changelog specifics
 
-- Group changes into a few sections, each led by a single emoji, a short title,
-  and one or two sentences of body. See `frontend/src/changelog.ts`.
+- Group changes into a few sections, each with a short title and one or two
+  sentences of body. No emoji or icon on the title. See
+  `frontend/src/changelog.ts`.
 - Section titles are benefit-first and plain: "Chart your data, live", not
   "Charting improvements".
 - Write for someone mid-task who just updated and wants to know what changed.
@@ -60,7 +66,7 @@ Warm, direct, and a little dry. First person. Talks to one user, not a crowd.
 
 ## Quick before / after
 
-- No: "We've completely revamped the charting experience — unlocking powerful
+- No: "We've completely revamped the charting experience, unlocking powerful
   new real-time visualisation capabilities."
 - Yes: "You can now chart values that arrive as text, like a quoted `\"24.6\"`.
   They plot just like plain numbers."

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -104,8 +104,16 @@ React-only in preview — don't use it here. The MCP needs Storybook **served or
 built first** (`pnpm storybook`, or `pnpm build-storybook`). It complements the
 specs (it knows rendered reality; the specs know Figma drift + the dep graph).
 
+## Writing copy (UI text, changelog, docs)
+
+Anything a user reads (dialog copy, empty states, tooltips, the "What's new"
+changelog, README) follows `docs/WRITING_STYLE.md`: warm, first person, British
+spelling, concise, and no em dashes. The changelog lives in
+`frontend/src/changelog.ts`; use the `/changelog` skill to update it.
+
 ## Skills
 
 - `/ds-add-component` — scaffold or formalize a component (spec + story + tier).
 - `/ds-figma-handover` — diff Figma library vs this code, emit a handover doc.
 - `/ds-implement-handover` — apply a handover doc to code + specs + stories.
+- `/changelog` — add to the "What's new" changelog, or promote it at release.

--- a/frontend/src/changelog.test.ts
+++ b/frontend/src/changelog.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   CHANGELOG,
+  changelogForDisplay,
   entryForVersion,
+  releasedEntries,
   shouldShowChangelog,
+  unreleasedEntry,
+  type ChangelogEntry,
 } from "./changelog";
 
 describe("entryForVersion", () => {
@@ -14,6 +18,10 @@ describe("entryForVersion", () => {
   it("returns null for versions without notes", () => {
     expect(entryForVersion("v0.0.0-dev")).toBeNull();
     expect(entryForVersion("")).toBeNull();
+  });
+
+  it("never matches the unreleased staging entry", () => {
+    expect(entryForVersion("unreleased")).toBeNull();
   });
 });
 
@@ -28,18 +36,81 @@ describe("shouldShowChangelog", () => {
     expect(shouldShowChangelog("1.0.0", "v1.0.0")).toBe(false);
   });
 
-  it("does not show for versions without an entry", () => {
+  it("does not show for versions without an entry (incl. dev builds)", () => {
     expect(shouldShowChangelog("v0.0.0-dev", "")).toBe(false);
+  });
+});
+
+describe("released / unreleased split", () => {
+  it("releasedEntries are all released and semver-versioned, newest first", () => {
+    const released = releasedEntries();
+    expect(released.length).toBeGreaterThan(0);
+    for (const e of released) {
+      expect(e.released).toBe(true);
+      expect(e.version).toMatch(/^\d+\.\d+\.\d+$/);
+    }
+    // 1.0.0 comes before 0.7.0 in the list.
+    const versions = released.map((e) => e.version);
+    expect(versions.indexOf("1.0.0")).toBeLessThan(versions.indexOf("0.7.0"));
+  });
+
+  it("has at most one unreleased staging entry, flagged not-released", () => {
+    const unreleased = CHANGELOG.filter((e) => !e.released);
+    expect(unreleased.length).toBeLessThanOrEqual(1);
+    if (unreleased.length === 1) {
+      expect(unreleasedEntry()).toBe(unreleased[0]);
+      expect(unreleasedEntry()?.released).toBe(false);
+    }
+  });
+});
+
+describe("changelogForDisplay", () => {
+  it("shows the unreleased entry on dev builds (no matching release)", () => {
+    const shown = changelogForDisplay("v0.0.0-dev");
+    if (unreleasedEntry()) {
+      expect(shown[0].released).toBe(false); // newest, leftmost tab
+      expect(shown.slice(1).every((e) => e.released)).toBe(true);
+    } else {
+      expect(shown.every((e) => e.released)).toBe(true);
+    }
+  });
+
+  it("hides the unreleased entry on a released build", () => {
+    const shown = changelogForDisplay("1.0.0");
+    expect(shown.every((e) => e.released)).toBe(true);
+    expect(shown.some((e) => e.version === "1.0.0")).toBe(true);
   });
 });
 
 describe("content", () => {
   it("every entry has a version, headline, intro and sections", () => {
     for (const e of CHANGELOG) {
-      expect(e.version).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(e.version.length).toBeGreaterThan(0);
       expect(e.headline.length).toBeGreaterThan(0);
       expect(e.intro.length).toBeGreaterThan(0);
       expect(e.sections.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("released entries use bare semver versions", () => {
+    for (const e of releasedEntries()) {
+      expect(e.version).toMatch(/^\d+\.\d+\.\d+$/);
+    }
+  });
+
+  // House style: no em dashes anywhere users can read (docs/WRITING_STYLE.md).
+  it("contains no em or en dashes in any user-facing copy", () => {
+    const texts = (e: ChangelogEntry): string[] => [
+      e.headline,
+      e.intro,
+      e.outro ?? "",
+      ...e.sections.flatMap((s) => [s.title, s.body]),
+    ];
+    for (const e of CHANGELOG) {
+      for (const t of texts(e)) {
+        expect(t.includes("—"), `em dash in: ${t}`).toBe(false);
+        expect(t.includes("–"), `en dash in: ${t}`).toBe(false);
+      }
     }
   });
 });

--- a/frontend/src/changelog.test.ts
+++ b/frontend/src/changelog.test.ts
@@ -98,18 +98,29 @@ describe("content", () => {
     }
   });
 
-  // House style: no em dashes anywhere users can read (docs/WRITING_STYLE.md).
+  // House style: no em dashes and no emojis anywhere users can read
+  // (docs/WRITING_STYLE.md).
+  const userFacingText = (e: ChangelogEntry): string[] => [
+    e.headline,
+    e.intro,
+    e.outro ?? "",
+    ...e.sections.flatMap((s) => [s.title, s.body]),
+  ];
+
   it("contains no em or en dashes in any user-facing copy", () => {
-    const texts = (e: ChangelogEntry): string[] => [
-      e.headline,
-      e.intro,
-      e.outro ?? "",
-      ...e.sections.flatMap((s) => [s.title, s.body]),
-    ];
     for (const e of CHANGELOG) {
-      for (const t of texts(e)) {
+      for (const t of userFacingText(e)) {
         expect(t.includes("—"), `em dash in: ${t}`).toBe(false);
         expect(t.includes("–"), `en dash in: ${t}`).toBe(false);
+      }
+    }
+  });
+
+  it("contains no emojis in any user-facing copy", () => {
+    const emoji = /\p{Extended_Pictographic}/u;
+    for (const e of CHANGELOG) {
+      for (const t of userFacingText(e)) {
+        expect(emoji.test(t), `emoji in: ${t}`).toBe(false);
       }
     }
   });

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -6,16 +6,15 @@
 //
 // One entry sits at the top with released: false. It is the staging area for
 // the next release: new changes get added here as they land, and at release
-// time it is promoted to a real version + date (see the `changelog` skill and
-// docs/RELEASING.md). It never auto-shows and is only visible in the dialog on
-// dev builds, so users never read half-finished notes.
+// time it is promoted to a real version + date (see the `release` and
+// `changelog` skills and docs/RELEASING.md). It never auto-shows and is only
+// visible in the dialog on dev builds, so users never read half-finished notes.
 //
-// Writing: keep it warm, plain, first person, British spelling, and with NO em
-// dashes. The full brief is docs/WRITING_STYLE.md. These notes are read by
-// people mid-task, not by a release pipeline.
+// Writing: keep it warm, plain, first person, British spelling, with NO em
+// dashes and NO emojis. The full brief is docs/WRITING_STYLE.md. These notes
+// are read by people mid-task, not by a release pipeline.
 
 export interface ChangelogSection {
-  emoji: string;
   title: string;
   body: string;
 }
@@ -42,12 +41,10 @@ export const CHANGELOG: ChangelogEntry[] = [
       "Here's what's landed since 1.0.0. I'll tidy these notes up and give them a version when the update ships.",
     sections: [
       {
-        emoji: "📈",
         title: "Chart values that arrive as text",
         body: "Numeric readings often turn up wrapped in quotes, like \"24.6\". You can now chart those too, so a quoted number plots just like a plain one. Values that aren't really numbers stay out of the way.",
       },
       {
-        emoji: "🎯",
         title: "Adding a value to a chart is clearer",
         body: "Choosing \"Add value from payload\" now opens the picker straight on the value, so it's obvious what to tick. Plain numeric payloads, where the whole message is the number, work this way too.",
       },
@@ -62,32 +59,26 @@ export const CHANGELOG: ChangelogEntry[] = [
       "This one's been a long time coming. After years of betas, MQTT Viewer is officially 1.0. It's the same tool you already know, now with the polish (and the version number) to match. Thank you for debugging alongside it all this way. Here's what's packed in.",
     sections: [
       {
-        emoji: "📈",
         title: "Chart your data, live",
         body: "Tick any numeric field in a topic's payload and watch it plot over time. Pop the chart out into its own window and keep an eye on it while you work elsewhere.",
       },
       {
-        emoji: "🗂️",
         title: "A home for the messages you reuse",
         body: "Save messages into collections, per connection or global, and publish them again with a click. Your publish history lives in the sidebar too, and search covers all of it.",
       },
       {
-        emoji: "🧠",
         title: "History that minds its manners",
         body: "Message history now stays within a memory budget you control, so a viewer left open over the weekend won't eat your RAM. If you want history to survive restarts, turn on recording and page back through it whenever you like.",
       },
       {
-        emoji: "🖼️",
         title: "Images, decoded",
         body: "Publish a PNG, JPEG, GIF, WebP or BMP and the payload tab shows the actual picture, with a raw-bytes view one click away.",
       },
       {
-        emoji: "📝",
         title: "Notes like this one",
         body: "After each update you'll get a short, friendly summary of what changed. You can reopen it any time from Settings, or by clicking the version number at the bottom of the window.",
       },
       {
-        emoji: "🐧",
         title: "Better on Linux, faster everywhere",
         body: "Fedora and friends no longer crash at startup (there's a proper rpm and deb now), AppImages render correctly again, and updates install themselves through a new built-in updater.",
       },
@@ -104,22 +95,18 @@ export const CHANGELOG: ChangelogEntry[] = [
       "A big one: charting, collections, bounded memory, image previews, and a new engine under the hood.",
     sections: [
       {
-        emoji: "📈",
         title: "Topic charting",
         body: "Chart numeric payload fields over time, live, with a pop-out window.",
       },
       {
-        emoji: "🗂️",
         title: "Message library",
         body: "Collections of saved messages, publish history, and search, all in the new sidebar.",
       },
       {
-        emoji: "🧠",
         title: "Bounded memory and durable history",
         body: "History stays within a configurable memory budget, with opt-in recording to disk.",
       },
       {
-        emoji: "🖼️",
         title: "Image payload previews",
         body: "Image payloads render as images, not noise.",
       },

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -1,8 +1,18 @@
-// The in-app changelog. One entry per released version; the newest entry for
-// the running version is shown once in the "What's new" dialog (tracked via
-// app_settings.lastSeenChangelogVersion), and it stays reachable from
-// Settings. Keep the writing warm and plain — these notes are read by people
-// mid-task, not by a release pipeline.
+// The in-app changelog. The "What's new" dialog shows released versions as
+// tabs, newest on the left, and can be opened any time from Settings or by
+// clicking the version in the bottom status bar. The newest released entry is
+// also shown once automatically after an update (tracked via
+// app_settings.lastSeenChangelogVersion).
+//
+// One entry sits at the top with released: false. It is the staging area for
+// the next release: new changes get added here as they land, and at release
+// time it is promoted to a real version + date (see the `changelog` skill and
+// docs/RELEASING.md). It never auto-shows and is only visible in the dialog on
+// dev builds, so users never read half-finished notes.
+//
+// Writing: keep it warm, plain, first person, British spelling, and with NO em
+// dashes. The full brief is docs/WRITING_STYLE.md. These notes are read by
+// people mid-task, not by a release pipeline.
 
 export interface ChangelogSection {
   emoji: string;
@@ -11,8 +21,10 @@ export interface ChangelogSection {
 }
 
 export interface ChangelogEntry {
-  // Bare semver, no leading v.
+  // Bare semver (no leading v) once released; "unreleased" while in development.
   version: string;
+  // false for the staging entry that gathers changes for the next release.
+  released: boolean;
   date: string;
   headline: string;
   intro: string;
@@ -22,11 +34,32 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "unreleased",
+    released: false,
+    date: "In development",
+    headline: "In the next update",
+    intro:
+      "Here's what's landed since 1.0.0. I'll tidy these notes up and give them a version when the update ships.",
+    sections: [
+      {
+        emoji: "📈",
+        title: "Chart values that arrive as text",
+        body: "Numeric readings often turn up wrapped in quotes, like \"24.6\". You can now chart those too, so a quoted number plots just like a plain one. Values that aren't really numbers stay out of the way.",
+      },
+      {
+        emoji: "🎯",
+        title: "Adding a value to a chart is clearer",
+        body: "Choosing \"Add value from payload\" now opens the picker straight on the value, so it's obvious what to tick. Plain numeric payloads, where the whole message is the number, work this way too.",
+      },
+    ],
+  },
+  {
     version: "1.0.0",
+    released: true,
     date: "July 2026",
     headline: "MQTT Viewer 1.0 is here",
     intro:
-      "This one's been a long time coming. After years of betas, MQTT Viewer is officially 1.0 — the same tool, now with the polish (and the version number) to match. Thank you for debugging alongside it all this way. Here's what's packed in.",
+      "This one's been a long time coming. After years of betas, MQTT Viewer is officially 1.0. It's the same tool you already know, now with the polish (and the version number) to match. Thank you for debugging alongside it all this way. Here's what's packed in.",
     sections: [
       {
         emoji: "📈",
@@ -36,7 +69,7 @@ export const CHANGELOG: ChangelogEntry[] = [
       {
         emoji: "🗂️",
         title: "A home for the messages you reuse",
-        body: "Save messages into collections — per connection or global — and publish them again with a click. Your publish history lives in the sidebar too, and search covers all of it.",
+        body: "Save messages into collections, per connection or global, and publish them again with a click. Your publish history lives in the sidebar too, and search covers all of it.",
       },
       {
         emoji: "🧠",
@@ -46,12 +79,12 @@ export const CHANGELOG: ChangelogEntry[] = [
       {
         emoji: "🖼️",
         title: "Images, decoded",
-        body: "Publish a PNG, JPEG, GIF, WebP or BMP and the payload tab shows the actual picture — with a raw-bytes view one click away.",
+        body: "Publish a PNG, JPEG, GIF, WebP or BMP and the payload tab shows the actual picture, with a raw-bytes view one click away.",
       },
       {
         emoji: "📝",
         title: "Notes like this one",
-        body: "After each update you'll get a short, human summary of what changed — this dialog. You can revisit it any time from Settings.",
+        body: "After each update you'll get a short, friendly summary of what changed. You can reopen it any time from Settings, or by clicking the version number at the bottom of the window.",
       },
       {
         emoji: "🐧",
@@ -60,10 +93,11 @@ export const CHANGELOG: ChangelogEntry[] = [
       },
     ],
     outro:
-      "Found a rough edge? The Feedback button goes straight to us — 1.0 is a milestone, not a finish line.",
+      "Found a rough edge? The Feedback button comes straight to me. 1.0 is a milestone, not a finish line.",
   },
   {
     version: "0.7.0",
+    released: true,
     date: "July 2026",
     headline: "What's new in 0.7.0",
     intro:
@@ -77,11 +111,11 @@ export const CHANGELOG: ChangelogEntry[] = [
       {
         emoji: "🗂️",
         title: "Message library",
-        body: "Collections of saved messages, publish history, and search — all in the new sidebar.",
+        body: "Collections of saved messages, publish history, and search, all in the new sidebar.",
       },
       {
         emoji: "🧠",
-        title: "Bounded memory + durable history",
+        title: "Bounded memory and durable history",
         body: "History stays within a configurable memory budget, with opt-in recording to disk.",
       },
       {
@@ -96,10 +130,18 @@ export const CHANGELOG: ChangelogEntry[] = [
 const normalise = (version: string): string =>
   version.trim().replace(/^v/i, "");
 
-// Returns the changelog entry for an exact app version, or null. Dev builds
-// ("v0.0.0-dev" etc.) and versions without notes get nothing.
+/** Released entries only, newest first. */
+export const releasedEntries = (): ChangelogEntry[] =>
+  CHANGELOG.filter((e) => e.released);
+
+/** The staging entry for the next release, or null if there isn't one. */
+export const unreleasedEntry = (): ChangelogEntry | null =>
+  CHANGELOG.find((e) => !e.released) ?? null;
+
+// Returns the released changelog entry for an exact app version, or null. Dev
+// builds ("v0.0.0-dev" etc.) and versions without notes get nothing.
 export const entryForVersion = (version: string): ChangelogEntry | null =>
-  CHANGELOG.find((e) => e.version === normalise(version)) ?? null;
+  releasedEntries().find((e) => e.version === normalise(version)) ?? null;
 
 export const shouldShowChangelog = (
   appVersion: string,
@@ -108,4 +150,20 @@ export const shouldShowChangelog = (
   const entry = entryForVersion(appVersion);
   if (!entry) return false;
   return normalise(lastSeenVersion) !== normalise(appVersion);
+};
+
+/**
+ * The entries to show in the dialog for a given running version, newest first.
+ * Released entries are always included. The unreleased staging entry is shown
+ * only on builds whose version has no released entry (i.e. dev builds), so it
+ * can be previewed without ever reaching users on a shipped release.
+ */
+export const changelogForDisplay = (version: string): ChangelogEntry[] => {
+  const released = releasedEntries();
+  const unreleased = unreleasedEntry();
+  const showUnreleased =
+    unreleased !== null &&
+    unreleased.sections.length > 0 &&
+    entryForVersion(version) === null;
+  return showUnreleased ? [unreleased, ...released] : released;
 };

--- a/frontend/src/components/AppBarBottom/AppBarBottom.svelte
+++ b/frontend/src/components/AppBarBottom/AppBarBottom.svelte
@@ -2,6 +2,7 @@
   import EnvStore from "@/stores/env";
   import LicenseStatus from "./components/LicenseStatus.svelte";
   import MessageStats from "./components/MessageStats.svelte";
+  import { whatsNewOpen } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
 </script>
 
 <div
@@ -12,5 +13,9 @@
   <MessageStats />
   <div class="flex-grow" />
   <LicenseStatus />
-  <span class="cursor-default">{$EnvStore.version}</span>
+  <button
+    class="hover:text-emphasis transition-colors"
+    title="What's new"
+    on:click={() => whatsNewOpen.set(true)}>{$EnvStore.version}</button
+  >
 </div>

--- a/frontend/src/components/WhatsNewDialog/WhatsNewContent.spec.json
+++ b/frontend/src/components/WhatsNewDialog/WhatsNewContent.spec.json
@@ -2,7 +2,7 @@
   "$schema": "../../design-system/component-spec.schema.json",
   "name": "WhatsNewContent",
   "tier": "component",
-  "description": "Layout for a changelog entry: intro, emoji-bulleted sections, optional outro, dismiss button.",
+  "description": "Tabbed changelog: a tab per release (newest left), each showing intro, emoji-bulleted sections, optional outro, and a dismiss button.",
   "status": "story-only",
   "figma": {
     "fileKey": "",
@@ -13,9 +13,14 @@
   },
   "props": [
     {
-      "name": "entry",
-      "type": "object",
+      "name": "entries",
+      "type": "array",
       "required": true
+    },
+    {
+      "name": "initialVersion",
+      "type": "string",
+      "required": false
     },
     {
       "name": "onClose",
@@ -24,7 +29,11 @@
     }
   ],
   "tokens": [
-    "secondary-text"
+    "secondary-text",
+    "emphasis",
+    "white-text",
+    "outline",
+    "primary"
   ],
   "dependencies": [
     "Button"

--- a/frontend/src/components/WhatsNewDialog/WhatsNewContent.spec.json
+++ b/frontend/src/components/WhatsNewDialog/WhatsNewContent.spec.json
@@ -2,7 +2,7 @@
   "$schema": "../../design-system/component-spec.schema.json",
   "name": "WhatsNewContent",
   "tier": "component",
-  "description": "Tabbed changelog: a tab per release (newest left), each showing intro, emoji-bulleted sections, optional outro, and a dismiss button.",
+  "description": "Tabbed changelog: a tab per release (newest left), each showing intro, titled sections, optional outro, and a dismiss button.",
   "status": "story-only",
   "figma": {
     "fileKey": "",

--- a/frontend/src/components/WhatsNewDialog/WhatsNewContent.stories.svelte
+++ b/frontend/src/components/WhatsNewDialog/WhatsNewContent.stories.svelte
@@ -3,11 +3,11 @@
   import Component from "./WhatsNewContent.svelte";
   import StoryRender from "@/stories/StoryRender.svelte";
   import { getStoryArgTypes, getStoryArgs } from "@/stories/fixtures";
-  import { CHANGELOG } from "@/changelog";
+  import { CHANGELOG, releasedEntries } from "@/changelog";
 
   const componentName = "WhatsNewContent";
   const storyId = "Components/WhatsNewDialog/WhatsNewContent";
-  const props: string[] = ["entry"];
+  const props: string[] = ["entries", "initialVersion"];
   const storyArgs = getStoryArgs(storyId, componentName, props);
 
   const { Story } = defineMeta({
@@ -23,8 +23,27 @@
   <StoryRender component={Component} {args} {componentName} />
 {/snippet}
 
+<!-- Released history only: how the dialog looks on a shipped build. -->
 <Story
   name="Default"
-  args={{ ...storyArgs, entry: CHANGELOG[0] }}
+  args={{
+    ...storyArgs,
+    entries: releasedEntries(),
+    initialVersion: "1.0.0",
+  }}
+  {template}
+/>
+
+<!-- Dev build: the unreleased staging entry leads as the newest tab. -->
+<Story
+  name="With unreleased tab"
+  args={{ ...storyArgs, entries: CHANGELOG, initialVersion: null }}
+  {template}
+/>
+
+<!-- A single release: no tab strip. -->
+<Story
+  name="Single release"
+  args={{ ...storyArgs, entries: releasedEntries().slice(0, 1) }}
   {template}
 />

--- a/frontend/src/components/WhatsNewDialog/WhatsNewContent.svelte
+++ b/frontend/src/components/WhatsNewDialog/WhatsNewContent.svelte
@@ -2,33 +2,78 @@
   import Button from "@/components/Button/Button.svelte";
   import type { ChangelogEntry } from "@/changelog";
 
-  export let entry: ChangelogEntry;
+  // Newest first: entries[0] is shown leftmost, older versions to the right.
+  export let entries: ChangelogEntry[] = [];
+  // Which version's tab to open on first render (defaults to the newest).
+  export let initialVersion: string | null = null;
   export let onClose: () => void = () => {};
+
+  const startIndex = (() => {
+    const i = entries.findIndex((e) => e.version === initialVersion);
+    return i === -1 ? 0 : i;
+  })();
+  let selectedIndex = startIndex;
+
+  $: selectedIndex = Math.min(selectedIndex, Math.max(entries.length - 1, 0));
+  $: entry = entries[selectedIndex];
+  $: showTabs = entries.length > 1;
+  const tabLabel = (e: ChangelogEntry) =>
+    e.released ? e.version : "Unreleased";
 </script>
 
-<div
-  class="flex flex-col gap-4 mt-2 w-[480px] max-h-[60vh] overflow-y-auto pr-1"
->
-  <p class="text-secondary-text">{entry.intro}</p>
-
-  <div class="flex flex-col gap-3">
-    {#each entry.sections as section}
-      <div class="flex gap-3 items-start">
-        <span class="text-lg leading-6 select-none">{section.emoji}</span>
-        <div class="flex flex-col gap-[2px]">
-          <span class="text-emphasis">{section.title}</span>
-          <span class="text-secondary-text text-base">{section.body}</span>
-        </div>
-      </div>
-    {/each}
-  </div>
-
-  {#if entry.outro}
-    <p class="text-secondary-text">{entry.outro}</p>
+<div class="flex flex-col w-[480px] max-w-full">
+  {#if showTabs}
+    <div
+      class="flex shrink-0 gap-1 relative -mt-1 mb-3 overflow-x-auto"
+      role="tablist"
+      aria-label="Releases"
+    >
+      <div class="absolute bottom-0 h-[1px] w-full bg-outline"></div>
+      {#each entries as e, i (e.version)}
+        <button
+          role="tab"
+          aria-selected={i === selectedIndex}
+          class={`relative px-3 py-2 text-base whitespace-nowrap transition-colors hover:text-emphasis ${
+            i === selectedIndex ? "text-emphasis" : "text-secondary-text"
+          }`}
+          on:click={() => (selectedIndex = i)}
+        >
+          {tabLabel(e)}
+          {#if i === selectedIndex}
+            <div
+              class="absolute bottom-0 left-0 h-[1px] w-full rounded bg-primary"
+            ></div>
+          {/if}
+        </button>
+      {/each}
+    </div>
   {/if}
 
-  <div class="flex justify-end items-center gap-3">
-    <span class="text-sm text-secondary-text grow">{entry.date}</span>
-    <Button variant="primary" on:click={onClose}>Nice, got it</Button>
-  </div>
+  {#if entry}
+    <div class="flex flex-col gap-4 max-h-[56vh] overflow-y-auto pr-1">
+      <span class="text-lg font-medium text-white-text">{entry.headline}</span>
+      <p class="text-secondary-text">{entry.intro}</p>
+
+      <div class="flex flex-col gap-3">
+        {#each entry.sections as section}
+          <div class="flex gap-3 items-start">
+            <span class="text-lg leading-6 select-none">{section.emoji}</span>
+            <div class="flex flex-col gap-[2px]">
+              <span class="text-emphasis">{section.title}</span>
+              <span class="text-secondary-text text-base">{section.body}</span>
+            </div>
+          </div>
+        {/each}
+      </div>
+
+      {#if entry.outro}
+        <p class="text-secondary-text">{entry.outro}</p>
+      {/if}
+    </div>
+
+    <div class="flex justify-end items-center gap-3 mt-4">
+      <span class="text-sm text-secondary-text grow">{entry.date}</span>
+      <Button variant="primary" on:click={onClose}>Nice, got it</Button>
+    </div>
+  {/if}
 </div>

--- a/frontend/src/components/WhatsNewDialog/WhatsNewContent.svelte
+++ b/frontend/src/components/WhatsNewDialog/WhatsNewContent.svelte
@@ -56,12 +56,9 @@
 
       <div class="flex flex-col gap-3">
         {#each entry.sections as section}
-          <div class="flex gap-3 items-start">
-            <span class="text-lg leading-6 select-none">{section.emoji}</span>
-            <div class="flex flex-col gap-[2px]">
-              <span class="text-emphasis">{section.title}</span>
-              <span class="text-secondary-text text-base">{section.body}</span>
-            </div>
+          <div class="flex flex-col gap-[2px] border-l-2 border-outline pl-3">
+            <span class="text-emphasis">{section.title}</span>
+            <span class="text-secondary-text text-base">{section.body}</span>
           </div>
         {/each}
       </div>

--- a/frontend/src/components/WhatsNewDialog/WhatsNewDialog.svelte
+++ b/frontend/src/components/WhatsNewDialog/WhatsNewDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" context="module">
   import { writable } from "svelte/store";
 
-  // Exported so Settings (or anywhere) can reopen the current version's notes.
+  // Exported so Settings and the status bar (or anywhere) can open the notes.
   export const whatsNewOpen = writable(false);
 
   // Set true once the first-run retention prompt has resolved (either it was
@@ -14,7 +14,11 @@
   import Dialog from "@/components/Dialog/Dialog.svelte";
   import WhatsNewContent from "./WhatsNewContent.svelte";
   import env from "@/stores/env";
-  import { entryForVersion, shouldShowChangelog } from "@/changelog";
+  import {
+    changelogForDisplay,
+    entryForVersion,
+    shouldShowChangelog,
+  } from "@/changelog";
   import {
     GetAppSettings,
     AcknowledgeChangelog,
@@ -23,7 +27,10 @@
   let checked = false;
   let acknowledged = false;
 
-  $: entry = $env.version ? entryForVersion($env.version) : null;
+  // Newest first; includes the unreleased staging entry on dev builds only.
+  $: entries = changelogForDisplay($env.version);
+  // Open on the running version's tab when it has notes, else the newest.
+  $: initialVersion = entryForVersion($env.version)?.version ?? null;
 
   // Auto-open once per version: wait for the version to load and the
   // first-run prompt to clear, then compare against the last-seen version.
@@ -58,8 +65,8 @@
   };
 </script>
 
-{#if entry}
-  <Dialog title={entry.headline} isOpen={whatsNewOpen} showCloseButton={false}>
-    <WhatsNewContent {entry} onClose={close} />
+{#if entries.length}
+  <Dialog title="What's new" isOpen={whatsNewOpen} showCloseButton={false}>
+    <WhatsNewContent {entries} {initialVersion} onClose={close} />
   </Dialog>
 {/if}

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-02T06:44:53.365Z",
+  "generatedAt": "2026-07-02T06:54:38.803Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -2284,7 +2284,7 @@
     {
       "name": "WhatsNewContent",
       "tier": "component",
-      "description": "Tabbed changelog: a tab per release (newest left), each showing intro, emoji-bulleted sections, optional outro, and a dismiss button.",
+      "description": "Tabbed changelog: a tab per release (newest left), each showing intro, titled sections, optional outro, and a dismiss button.",
       "status": "story-only",
       "figma": {
         "fileKey": "",

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-02T03:36:11.225Z",
+  "generatedAt": "2026-07-02T06:44:53.365Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -2284,7 +2284,7 @@
     {
       "name": "WhatsNewContent",
       "tier": "component",
-      "description": "Layout for a changelog entry: intro, emoji-bulleted sections, optional outro, dismiss button.",
+      "description": "Tabbed changelog: a tab per release (newest left), each showing intro, emoji-bulleted sections, optional outro, and a dismiss button.",
       "status": "story-only",
       "figma": {
         "fileKey": "",
@@ -2295,9 +2295,14 @@
       },
       "props": [
         {
-          "name": "entry",
-          "type": "object",
+          "name": "entries",
+          "type": "array",
           "required": true
+        },
+        {
+          "name": "initialVersion",
+          "type": "string",
+          "required": false
         },
         {
           "name": "onClose",
@@ -2306,7 +2311,11 @@
         }
       ],
       "tokens": [
-        "secondary-text"
+        "secondary-text",
+        "emphasis",
+        "white-text",
+        "outline",
+        "primary"
       ],
       "dependencies": [
         "Button"

--- a/frontend/src/stories/fixtures.ts
+++ b/frontend/src/stories/fixtures.ts
@@ -354,7 +354,7 @@ export const createMockChartSeriesStore = () =>
   ]);
 
 export const mockPayloadTree = payloadTree(
-  '{"temp":24.6,"humidity":61,"sensor":{"rssi":-72},"status":"ok"}'
+  '{"temp":24.6,"humidity":61,"pressure":"1013.2","sensor":{"rssi":-72},"status":"ok"}'
 );
 
 export const createMockCollectionsStore = () => {

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/SelectedTopicPanel.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/SelectedTopicPanel.svelte
@@ -48,6 +48,13 @@
   $: chartTabIndex = mqttVersion === "3" ? 1 : 3;
   $: isChartTabActive = activeTabIndex === chartTabIndex;
   const viewChart = () => tabsRef?.setTab(chartTabIndex);
+  // Opens the payload field picker and switches to the Payload tab, so
+  // "Add value from payload" lands the user on a ready-to-pick control.
+  let showPayloadFieldPicker = false;
+  const addFromPayload = () => {
+    showPayloadFieldPicker = true;
+    tabsRef?.setTab(0);
+  };
   const popOut = () =>
     openChartWindow?.(
       $selectedTopicStore.selectedTopic ?? "",
@@ -228,6 +235,7 @@
             <PayloadTab
               bind:codec={$selectedTopicStore.options.decoding}
               bind:format={$selectedTopicStore.options.format}
+              bind:showFieldPicker={showPayloadFieldPicker}
               {isComparing}
               payload={selectedMessagePayload}
               payloadB64={selectedMessagePayloadB64}
@@ -242,7 +250,7 @@
             {selectedTopicStore}
             {chartSeriesStore}
             topic={selectedTopicString ?? ""}
-            onAddFromPayload={() => tabsRef?.setTab(0)}
+            onAddFromPayload={addFromPayload}
             onPopOut={openChartWindow ? popOut : null}
           />
         </div>
@@ -264,6 +272,7 @@
             <PayloadTab
               bind:codec={$selectedTopicStore.options.decoding}
               bind:format={$selectedTopicStore.options.format}
+              bind:showFieldPicker={showPayloadFieldPicker}
               {isComparing}
               payload={selectedMessagePayload}
               payloadB64={selectedMessagePayloadB64}
@@ -297,7 +306,7 @@
             {selectedTopicStore}
             {chartSeriesStore}
             topic={selectedTopicString ?? ""}
-            onAddFromPayload={() => tabsRef?.setTab(0)}
+            onAddFromPayload={addFromPayload}
             onPopOut={openChartWindow ? popOut : null}
           />
         </div>

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/FieldPicker.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/FieldPicker.svelte
@@ -10,7 +10,8 @@
 
   $: indent = depth * 14;
   $: isContainer = node.type === "object" || node.type === "array";
-  $: isNumber = node.type === "number";
+  // Numbers and quoted numerics (e.g. "24.6") can both be charted.
+  $: isChartable = node.chartable === true;
   $: color = selected.get(node.path);
   $: open = node.type === "array" ? "[" : "{";
   $: close = node.type === "array" ? "]" : "}";
@@ -51,20 +52,20 @@
 {:else}
   <div
     class={`flex items-center font-mono text-base py-[2px] pr-1 rounded ${
-      isNumber ? "hover:bg-hovered cursor-pointer" : ""
+      isChartable ? "hover:bg-hovered cursor-pointer" : ""
     }`}
     style:padding-left={`${indent}px`}
-    on:click={isNumber ? () => onToggle(node.path) : undefined}
-    role={isNumber ? "button" : undefined}
-    tabindex={isNumber ? 0 : undefined}
-    on:keydown={isNumber
+    on:click={isChartable ? () => onToggle(node.path) : undefined}
+    role={isChartable ? "button" : undefined}
+    tabindex={isChartable ? 0 : undefined}
+    on:keydown={isChartable
       ? (e) => (e.key === "Enter" || e.key === " ") && onToggle(node.path)
       : undefined}
   >
     {#if depth > 0}<span class="text-secondary-text">{node.key}:&nbsp;</span>{/if}
     <span class={valueClass}>{valueText}</span>
     <div class="grow"></div>
-    {#if isNumber}
+    {#if isChartable}
       <span
         class="size-4 min-w-4 rounded-[3px] border flex items-center justify-center"
         style:border-color={color ?? "var(--color-secondary-text)"}

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.test.ts
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.test.ts
@@ -34,10 +34,28 @@ describe("numericFields", () => {
     expect(numericFields("42.5")).toEqual([{ path: "", value: 42.5 }]);
   });
 
-  it("excludes strings, booleans, and null", () => {
+  it("excludes non-numeric strings, booleans, and null", () => {
     expect(numericFields('{"a":1,"b":"x","c":true,"d":null}')).toEqual([
       { path: "a", value: 1 },
     ]);
+  });
+
+  it("casts quoted numerics to numbers", () => {
+    expect(numericFields('{"temp":"24.6","rssi":"-72","load":"1e3"}')).toEqual([
+      { path: "temp", value: 24.6 },
+      { path: "rssi", value: -72 },
+      { path: "load", value: 1000 },
+    ]);
+  });
+
+  it("charts a bare quoted numeric payload with empty path", () => {
+    expect(numericFields('"42.5"')).toEqual([{ path: "", value: 42.5 }]);
+  });
+
+  it("excludes strings that are not purely numeric", () => {
+    expect(
+      numericFields('{"a":"24C","b":"","c":"0x1f","d":"1,000","e":"NaN"}')
+    ).toEqual([]);
   });
 
   it("returns [] for non-JSON payloads", () => {
@@ -58,6 +76,10 @@ describe("valueAtPath", () => {
   it("reads a bare numeric payload at empty path", () => {
     expect(valueAtPath("42.5", "")).toBe(42.5);
   });
+  it("reads quoted numeric values as numbers", () => {
+    expect(valueAtPath('{"temp":"24.6"}', "temp")).toBe(24.6);
+    expect(valueAtPath('"42.5"', "")).toBe(42.5);
+  });
   it("returns null when path is missing or non-numeric", () => {
     expect(valueAtPath('{"a":1}', "b")).toBeNull();
     expect(valueAtPath('{"a":"x"}', "a")).toBeNull();
@@ -77,6 +99,21 @@ describe("payloadTree", () => {
     expect(sensor?.children?.[0].path).toBe("sensor.rssi");
     const name = tree?.children?.find((c) => c.key === "name");
     expect(name?.type).toBe("string");
+    expect(name?.chartable).toBeUndefined();
+  });
+  it("marks numeric-string leaves as chartable but keeps string type", () => {
+    const tree = payloadTree('{"temp":"24.6","name":"kitchen"}');
+    const temp = tree?.children?.find((c) => c.key === "temp");
+    expect(temp?.type).toBe("string");
+    expect(temp?.value).toBe("24.6");
+    expect(temp?.chartable).toBe(true);
+    const name = tree?.children?.find((c) => c.key === "name");
+    expect(name?.chartable).toBeUndefined();
+  });
+  it("marks numeric leaves as chartable", () => {
+    const tree = payloadTree('{"temp":24.6}');
+    const temp = tree?.children?.find((c) => c.key === "temp");
+    expect(temp?.chartable).toBe(true);
   });
   it("returns null for non-JSON", () => {
     expect(payloadTree("nope")).toBeNull();
@@ -95,5 +132,6 @@ describe("hasNumericFields", () => {
     expect(hasNumericFields('{"a":"x"}')).toBe(false);
     expect(hasNumericFields("42")).toBe(true);
     expect(hasNumericFields("text")).toBe(false);
+    expect(hasNumericFields('{"a":"3.14"}')).toBe(true);
   });
 });

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.ts
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/payload-fields.ts
@@ -20,6 +20,7 @@ export interface PayloadNode {
   path: string; // dotted/indexed path from root
   type: PayloadNodeType;
   value?: number | string | boolean | null; // for leaves
+  chartable?: boolean; // leaf can be charted (a number, or a numeric string)
   children?: PayloadNode[];
 }
 
@@ -48,17 +49,40 @@ const typeOf = (v: unknown): PayloadNodeType => {
 const isFiniteNumber = (v: unknown): v is number =>
   typeof v === "number" && Number.isFinite(v);
 
+// A string that is a plain decimal/scientific number and nothing else. Rejects
+// empty/whitespace, hex ("0x1f"), Infinity/NaN, and unit-suffixed values ("24C").
+const NUMERIC_STRING = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+
 /**
- * Returns the numeric leaf fields of a payload. A bare numeric payload yields a
- * single field with path "". Non-JSON (and JSON with no numbers) yields [].
+ * Coerces a leaf value to a finite number for charting. Numbers pass through;
+ * quoted numerics (e.g. "24.6", "-72") are cast to float. Everything else
+ * (non-numeric strings, booleans, null, objects) yields null.
+ */
+const coerceNumber = (v: unknown): number | null => {
+  if (isFiniteNumber(v)) return v;
+  if (typeof v === "string") {
+    const trimmed = v.trim();
+    if (NUMERIC_STRING.test(trimmed)) {
+      const n = Number(trimmed);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+};
+
+/**
+ * Returns the numeric leaf fields of a payload. Numbers and quoted numerics
+ * (e.g. "24.6") both count. A bare numeric payload yields a single field with
+ * path "". Non-JSON (and JSON with no numbers) yields [].
  */
 export function numericFields(payload: string): NumericField[] {
   const parsed = parse(payload);
   if (parsed === undefined) return [];
   const out: NumericField[] = [];
   const walk = (value: unknown, path: string) => {
-    if (isFiniteNumber(value)) {
-      out.push({ path, value });
+    const num = coerceNumber(value);
+    if (num !== null) {
+      out.push({ path, value: num });
       return;
     }
     if (Array.isArray(value)) {
@@ -86,7 +110,7 @@ export function valueAtPath(payload: string, path: string): number | null {
       current = (current as Record<string, unknown>)[segment];
     }
   }
-  return isFiniteNumber(current) ? current : null;
+  return coerceNumber(current);
 }
 
 /**
@@ -118,7 +142,14 @@ export function payloadTree(payload: string): PayloadNode | null {
         ),
       };
     }
-    return { key, path, type, value: value as number | string | boolean | null };
+    const leaf: PayloadNode = {
+      key,
+      path,
+      type,
+      value: value as number | string | boolean | null,
+    };
+    if (coerceNumber(value) !== null) leaf.chartable = true;
+    return leaf;
   };
   return build(parsed, "value", "");
 }

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.stories.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.stories.svelte
@@ -3,6 +3,7 @@
   import Component from "./PayloadTab.svelte";
   import StoryRender from "@/stories/StoryRender.svelte";
   import { getStoryArgTypes, getStoryArgs } from "@/stories/fixtures";
+  import { createChartSeriesStore } from "./Chart/chart-series-store";
 
   const componentName = "PayloadTab";
   const storyId = "Views/Connection/DataView/SelectedTopicPanel/PayloadTab";
@@ -36,6 +37,22 @@
     payload: "PNG…",
     payloadB64: TINY_PNG,
     format: "none",
+  }}
+  {template}
+/>
+
+<!-- A bare numeric payload is chartable; "Add value from payload" opens this
+     picker directly on the value (issue #78). -->
+<Story
+  name="Chart fields (bare number)"
+  args={{
+    ...storyArgs,
+    isComparing: false,
+    payload: "19",
+    payloadB64: null,
+    format: "none",
+    chartSeriesStore: createChartSeriesStore([]),
+    showFieldPicker: true,
   }}
   {template}
 />

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.svelte
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/PayloadTab.svelte
@@ -32,8 +32,9 @@
   // Optional: when present, a "Chart fields" toggle reveals the numeric picker.
   export let chartSeriesStore: ChartSeriesStore | null = null;
   export let onViewChart: (() => void) | null = null;
+  // Bindable so the Chart tab's "Add value from payload" can open the picker.
+  export let showFieldPicker = false;
 
-  let showFieldPicker = false;
   let showRawImageBytes = false;
   // Reset the raw-bytes escape hatch when switching messages.
   $: payloadB64, (showRawImageBytes = false);


### PR DESCRIPTION
Turns "What's new" into a tabbed changelog, wires it into the release/update flow, and codifies the writing voice. PR #79 (charting fixes) is already merged; this records those and builds the process around them.

## Changelog display + recording

- **Tabbed history.** One dialog, a tab per release, newest on the left moving right. Body scrolls; the tab strip stays put.
- **Unreleased staging entry.** The top entry can be `released: false` (version `"unreleased"`). Changes accumulate there as they land. It only shows on dev builds and never auto-opens, so users never see half-finished notes. It is promoted to a version + date at release time, so no version is guessed ahead of time.
- `changelogForDisplay(version)` returns released entries always, plus the staging entry only on builds with no matching release (dev).

## Correctly used for updates

The shipped binary carries its own changelog, matched to its running version. After an update, `shouldShowChangelog` auto-opens the notes once for the new version (then `AcknowledgeChangelog` records it). The release step promotes the staging entry to the shipped version so those notes exist. This is baked into the `/release` skill so it can't be forgotten.

## New /release skill

`.claude/skills/release/` drives the full runbook from `docs/RELEASING.md`:
1. Pre-flight (develop green, `main` fast-forwardable, clean tree).
2. Promote the changelog for the version and land it on `develop`.
3. Optional prerelease dry run.
4. `just release VERSION PREV` (merges develop to main, creates the GitHub release that triggers the mac/windows/linux build+sign+portal workflows). Confirms with you first, since it's outward-facing.
5. Watch the workflows, then hand off the manual go-live (flip `released` in the PocketBase portal).

## Second entry point

The version in the bottom-right status bar now opens "What's new" (Settings still has its button too).

## House style (no emojis, no em dashes)

- `docs/WRITING_STYLE.md`, drawn from the README voice: warm, first person, British spelling, concise, **no em dashes, no emojis**.
- Rewrote every existing changelog entry to match and **removed all emojis** (the section layout now uses a titled left-accent instead of an emoji column).
- Tests fail if an em/en dash or an emoji slips into any changelog copy.
- `/changelog` skill adds entries and promotes at release, following the guide. `frontend/AGENTS.md` points future work at it.

## Screenshots

Dev build, staging entry as the newest tab (no emojis):

![unreleased tab](https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/pr-assets/changelog/unreleased-tab.png)

An older tab (1.0.0), copy rewritten, emoji-free:

![1.0.0 tab](https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/pr-assets/changelog/v100-tab.png)

## Tests

81/81 unit tests pass (changelog shape, em-dash guard, emoji guard, display logic). `svelte-check` clean, `pnpm ds:validate` passes.

Left for you to review and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)