### PR TITLE
docs: agent handoff package (CLAUDE.md, /perf-check, tracked perf scripts)

### DIFF
--- a/.claude/skills/perf-check/SKILL.md
+++ b/.claude/skills/perf-check/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: perf-check
+description: Verify MQTT Viewer stays smooth under heavy broker load using the local flood harness. Use before merging changes to message handling, the topic tree, history, or the graph view, or when the user says "check performance", "run the flood test", or reports the app lagging on busy brokers.
+---
+
+# Performance check under broker load
+
+## The bar
+
+Two brokers, each flooded at around 2000 msg/s across a wide topic tree,
+with the app connected to both. The UI must stay responsive: topic tree
+updates, panel interactions, and the graph view must not stutter or leak
+memory over several minutes. This reproduces what heavy public brokers
+like test.mosquitto.org do to the app.
+
+## Setup (one-time)
+
+```sh
+# local brokers (macOS)
+brew install mosquitto
+
+# python env for the harness
+python3 -m venv scripts/.venv
+scripts/.venv/bin/pip install paho-mqtt
+```
+
+## Run
+
+Terminals 1 and 2, one broker each:
+
+```sh
+mosquitto -p 1883
+mosquitto -p 1884
+```
+
+Terminals 3 and 4, one flood each (each prints achieved msg/s once per
+second; confirm it holds the target rate):
+
+```sh
+scripts/.venv/bin/python scripts/mqtt-flood.py --port 1883 --rate 2000
+scripts/.venv/bin/python scripts/mqtt-flood.py --port 1884 --rate 2000
+```
+
+Then run the app (`just dev`), connect to both brokers
+(localhost:1883 and localhost:1884), and exercise it for at least a few
+minutes.
+
+`scripts/mqtt-sim.py` is the companion script for realistic varied
+cadences rather than sustained flood; use it when debugging behavior
+rather than throughput.
+
+## What to watch
+
+- Topic tree and message counters keep updating without multi-second
+  freezes.
+- Selecting topics and opening the right panel stays instant.
+- The graph view (if the change touches it) holds an acceptable frame
+  rate; it has culling/LOD/adaptive-fps logic that should degrade
+  gracefully rather than freeze.
+- Memory: watch the process in Activity Monitor for unbounded growth
+  over 5+ minutes.
+- CPU settles rather than climbing after you disconnect the floods.
+
+Report concrete observations (achieved msg/s, where it stuttered, memory
+trend), not just "seems fine".

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ frontend/storybook-static
 *.db
 _dev_resources
 /mqtt-viewer
-secrets.json
+secrets.json*
 .env
 .DS_STORE
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent guide
+
+Start with `CLAUDE.md` in this directory: repo map, commands, conventions,
+performance bar, release process, and the skills index. For frontend and
+design-system work, `frontend/AGENTS.md` is the binding contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# MQTT Viewer
+
+Cross-platform desktop MQTT client: Go backend + Svelte 5 frontend in a
+Wails v3 shell (pinned to `v3.0.0-alpha.98-tui` in go.mod; keep the CLI
+and module aligned when bumping). One developer runs this product end to
+end; agents working here are expected to carry design, engineering, and
+release work, not just patches.
+
+## Repo map
+
+| Path | What |
+| --- | --- |
+| `backend/app/` | Wails service layer: connections, subscriptions, tabs, collections, publish history, export |
+| `backend/mqtt/` | MQTT client lifecycle: manager state machine, buffers, history with memory budgeting, stats |
+| `backend/db/` + `loader/` + `atlas.hcl` | GORM + SQLite; SQL-first Atlas migrations generated from the models `loader/main.go` registers |
+| `backend/protobuf/` | Protobuf and Sparkplug (v1a/v1b) codec + descriptor registry |
+| `events/` + `backend/event-runtime/` | Event name constants and the Wails event wrapper (global + per-connection events) |
+| `frontend/src/` | Svelte app: `stores/` for global state, `components/` + `views/` as the design-system library |
+| `frontend/bindings/` | Generated Go-to-TS bindings. Never edit; regenerate with `wails3 task common:generate:bindings` |
+| `build/` | Wails Taskfiles per platform, dev config, icons |
+| `scripts/` | `mqtt-flood.py` (load harness), `mqtt-sim.py` (realistic traffic) |
+| `docs/` | RELEASING.md, WRITING_STYLE.md, design-system docs, specs |
+
+Read `frontend/AGENTS.md` before touching any frontend component, story,
+or `.spec.json`. It is the design-system contract and its rules are
+enforced by CI (`design-system.yml` runs `pnpm ds:validate` and
+`pnpm test-storybook`).
+
+## Commands
+
+Backend (repo root):
+
+```sh
+just dev                 # wails3 dev: run the app with hot reload
+just test                # go test ./... via tparse
+just new-migration NAME  # atlas migrate diff --env gorm NAME
+go build ./... && go vet ./...
+```
+
+Frontend (from `frontend/`, pnpm version pinned in package.json):
+
+```sh
+pnpm check         # svelte-check, keep at 0 errors
+pnpm test:run      # vitest unit tests
+pnpm test-storybook
+pnpm ds:validate   # design-system CI gate
+pnpm storybook     # port 6006
+```
+
+Full pre-merge bar for `develop`: `go build ./...`, `go vet ./...`,
+`just test`, `pnpm check`, `pnpm test:run`, `pnpm build`,
+`pnpm ds:validate`, `pnpm test-storybook`.
+
+## Conventions
+
+- Branch model: feature branches PR into `develop`; `main` only moves by
+  fast-forward from `develop` at release time (`/release` skill,
+  `docs/RELEASING.md`).
+- Commits: conventional prefixes with optional scope,
+  `feat(topic-graph): ...`, `fix:`, `perf:`, `chore:`, `docs:`.
+- Svelte: the codebase runs Svelte 5 but components use legacy syntax
+  (`export let`, `on:click`). Do not rewrite to runes unless the task is
+  that migration.
+- Styling: Tailwind token utilities only (`bg-primary`), never raw hex.
+  Canonical token list is generated into
+  `frontend/src/design-system/design-tokens.json`.
+- Database changes: edit the GORM model, register it in
+  `loader/main.go` if new, then `just new-migration <name>`. Never
+  hand-edit applied migrations.
+- Backend tests use `getTestApp(t)` with golden dirs under
+  `backend/app/_test/<TestName>/`; keep new tests in that pattern.
+- Anything a user reads follows `docs/WRITING_STYLE.md`. Hard rules: no
+  emojis, no em dashes, first person singular, British spelling.
+
+## Performance bar
+
+The app must stay smooth while connected to two brokers each flooding
+around 2000 msg/s. Run `/perf-check` before merging anything that
+touches message handling, the topic tree, history, or the graph view.
+This bar exists because heavy public brokers (test.mosquitto.org) are a
+core use case.
+
+## Releases and the portal
+
+`docs/RELEASING.md` is the runbook; the `/release` skill drives it.
+Publishing a GitHub release is safe by itself: nothing reaches users
+until the `released` toggle is flipped in the portal admin. The portal
+(licensing, payments, update checks) is the private
+`mqtt-viewer/cloud` repo; its README is the operations handoff and
+holds everything that must not be public, including signing account
+details and the operator access list.
+
+## Skills
+
+- `/release` - publish a release end to end, up to the manual go-live
+- `/changelog` - gather and stage "What's new" notes
+- `/perf-check` - two-broker flood verification
+- `/ds-add-component`, `/ds-figma-handover`, `/ds-implement-handover` -
+  design-system loop (see `frontend/AGENTS.md`)

--- a/scripts/mqtt-flood.py
+++ b/scripts/mqtt-flood.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+High-rate MQTT flood publisher for MQTT Viewer performance testing.
+
+Unlike mqtt-sim.py (realistic varied cadences), this pushes a sustained,
+configurable message rate across a wide topic tree to reproduce heavy-load
+brokers like test.mosquitto.org locally.
+
+Usage:
+    scripts/.venv/bin/python scripts/mqtt-flood.py --port 1883 --rate 2000 --topics 2000
+    # Two-broker goal test (run in two terminals):
+    scripts/.venv/bin/python scripts/mqtt-flood.py --port 1883 --rate 2000
+    scripts/.venv/bin/python scripts/mqtt-flood.py --port 1884 --rate 2000
+
+Ctrl-C to stop. Prints achieved msg/s once per second.
+"""
+import argparse
+import json
+import random
+import sys
+import time
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:
+    sys.exit("paho-mqtt not installed. Run: scripts/.venv/bin/pip install paho-mqtt")
+
+
+def build_topics(count):
+    # Wide + deep tree, similar shape to a busy public broker: many devices
+    # under a few roots, metrics as leaves.
+    roots = ["plant", "fleet", "grid", "telemetry", "devices"]
+    metrics = ["temperature", "voltage", "rpm", "status", "position", "signal"]
+    topics = []
+    i = 0
+    while len(topics) < count:
+        root = roots[i % len(roots)]
+        group = i % max(1, count // 40)
+        device = i % max(1, count // len(metrics))
+        metric = metrics[i % len(metrics)]
+        topics.append(f"{root}/group-{group:03d}/device-{device:04d}/{metric}")
+        i += 1
+    return topics
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("--port", type=int, default=1883)
+    ap.add_argument("--rate", type=int, default=2000, help="target messages/second")
+    ap.add_argument("--topics", type=int, default=2000, help="distinct topic count")
+    ap.add_argument("--payload-bytes", type=int, default=120)
+    ap.add_argument("--duration", type=float, default=0, help="seconds to run (0 = forever)")
+    args = ap.parse_args()
+
+    topics = build_topics(args.topics)
+    pad = "x" * max(0, args.payload_bytes - 60)
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=f"flood-{args.port}")
+    client.connect(args.host, args.port)
+    client.loop_start()
+
+    print(f"Flooding {args.host}:{args.port} at target {args.rate} msg/s over {len(topics)} topics. Ctrl-C to stop.")
+
+    start = time.time()
+    sent = 0
+    last_report = start
+    reported_sent = 0
+    # Send in small slices so we hold the target rate without busy-looping.
+    slice_s = 0.02
+    per_slice = max(1, int(args.rate * slice_s))
+    try:
+        while True:
+            t = time.time()
+            if args.duration and t - start > args.duration:
+                break
+            for _ in range(per_slice):
+                topic = topics[sent % len(topics)]
+                payload = json.dumps({
+                    "value": round(random.uniform(0, 100), 2),
+                    "ts": int(t * 1000),
+                    "pad": pad,
+                })
+                client.publish(topic, payload)
+                sent += 1
+            if t - last_report >= 1.0:
+                print(f"  ~{(sent - reported_sent) / (t - last_report):.0f} msg/s (total {sent})")
+                last_report = t
+                reported_sent = sent
+            elapsed = time.time() - t
+            if elapsed < slice_s:
+                time.sleep(slice_s - elapsed)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        client.loop_stop()
+        client.disconnect()
+        print(f"Sent {sent} messages in {time.time() - start:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mqtt-sim.py
+++ b/scripts/mqtt-sim.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+MQTT traffic simulator for MQTT Viewer development.
+
+Publishes a realistic, hierarchical topic namespace at varied rates so the
+Topic Graph view has something live to render — hot topics, slow topics,
+idle/retained config topics, a large "factory" subtree for scale, and a
+periodic anomaly spike on one topic.
+
+Usage (broker defaults to localhost:1883):
+    scripts/.venv/bin/python scripts/mqtt-sim.py
+    scripts/.venv/bin/python scripts/mqtt-sim.py --scale 5 --host localhost --port 1883
+    scripts/.venv/bin/python scripts/mqtt-sim.py --duration 120   # auto-stop after 2 min
+
+Ctrl-C to stop. Each topic publishes on its own cadence; rates are msgs/sec.
+"""
+import argparse
+import json
+import math
+import random
+import signal
+import sys
+import time
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:
+    sys.exit("paho-mqtt not installed. Run: scripts/.venv/bin/pip install paho-mqtt")
+
+
+def now_ms():
+    return int(time.time() * 1000)
+
+
+def sensor_payload(base, unit, spread):
+    val = round(base + random.uniform(-spread, spread), 2)
+    return json.dumps({"value": val, "unit": unit, "ts": now_ms()})
+
+
+def status_payload(states):
+    return json.dumps({"state": random.choice(states), "ts": now_ms()})
+
+
+def log_payload():
+    levels = ["info", "info", "info", "warn", "debug"]
+    msgs = ["heartbeat", "frame processed", "sync ok", "cache hit", "poll"]
+    return json.dumps({"level": random.choice(levels), "msg": random.choice(msgs), "ts": now_ms()})
+
+
+# (topic, rate_hz, builder) — rate_hz is mean messages/second; 0 = retained once then quiet
+def build_topics(scale):
+    t = []
+
+    # backyard — has the hot anomaly topic
+    t.append(("backyard/sensors/34/temperature", 2.0, lambda: sensor_payload(22, "C", 3)))
+    t.append(("backyard/sensors/35/temperature", 0.7, lambda: sensor_payload(21, "C", 3)))
+    t.append(("backyard/sensors/36/humidity", 0.4, lambda: sensor_payload(55, "%", 10)))
+    t.append(("backyard/gateway/log", 1.0, log_payload))
+    t.append(("backyard/gateway/status", 0.07, lambda: status_payload(["online", "online", "degraded"])))
+    t.append(("backyard/cam/motion", 0.05, lambda: status_payload(["idle", "motion"])))
+    t.append(("backyard/cam/snapshot", 0.01, lambda: json.dumps({"size": random.randint(40000, 90000)})))
+
+    # house
+    t.append(("house/livingroom/temperature", 0.5, lambda: sensor_payload(21, "C", 1.5)))
+    t.append(("house/livingroom/humidity", 0.13, lambda: sensor_payload(48, "%", 6)))
+    t.append(("house/kitchen/temperature", 0.1, lambda: sensor_payload(23, "C", 2)))
+    t.append(("house/kitchen/co2", 0.03, lambda: sensor_payload(620, "ppm", 120)))
+    t.append(("house/bedroom/temperature", 0.03, lambda: sensor_payload(20, "C", 1)))
+    t.append(("house/hallway/motion", 0.2, lambda: status_payload(["idle", "motion"])))
+
+    # house — published on the intermediate level itself (dual-role node test)
+    t.append(("house/livingroom", 0.05, lambda: json.dumps({"occupancy": random.randint(0, 4), "ts": now_ms()})))
+
+    # garden
+    t.append(("garden/soil/moisture", 0.25, lambda: sensor_payload(40, "%", 8)))
+    t.append(("garden/light/lux", 0.15, lambda: sensor_payload(800, "lx", 300)))
+    t.append(("garden/pump/status", 0.004, lambda: status_payload(["off", "off", "on"])))  # mostly idle
+
+    # retained config topics — publish once, then go quiet (cool to fully cold)
+    t.append(("home/config/timezone", 0.0, lambda: json.dumps({"tz": "Australia/Sydney"})))
+    t.append(("home/config/firmware", 0.0, lambda: json.dumps({"version": "1.4.2"})))
+
+    # factory — large subtree for scale: lines x stations x metrics
+    lines = 3 * scale
+    for ln in range(1, lines + 1):
+        for st in range(1, 9):
+            base_rate = random.choice([0.02, 0.05, 0.1, 0.3])
+            t.append((f"factory/line-{ln:02d}/station-{st:02d}/temperature", base_rate,
+                      lambda: sensor_payload(60, "C", 8)))
+            t.append((f"factory/line-{ln:02d}/station-{st:02d}/vibration", base_rate * 0.7,
+                      lambda: sensor_payload(0.5, "g", 0.4)))
+            t.append((f"factory/line-{ln:02d}/station-{st:02d}/state", 0.02,
+                      lambda: status_payload(["running", "running", "idle", "fault"])))
+
+    # $SYS-style broker metrics
+    t.append(("$app/broker/clients", 0.05, lambda: json.dumps({"connected": random.randint(3, 12)})))
+    t.append(("$app/broker/bytes", 0.1, lambda: json.dumps({"sent": random.randint(1000, 9000)})))
+    t.append(("$app/broker/uptime", 0.008, lambda: json.dumps({"seconds": int(time.time()) % 100000})))
+
+    return t
+
+
+class Pub:
+    __slots__ = ("topic", "rate", "builder", "retain", "next_t")
+
+    def __init__(self, topic, rate, builder, retain, start):
+        self.topic = topic
+        self.rate = rate
+        self.builder = builder
+        self.retain = retain
+        self.next_t = start + (random.expovariate(rate) if rate > 0 else 0)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="MQTT traffic simulator")
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("--port", type=int, default=1883)
+    ap.add_argument("--scale", type=int, default=1, help="multiplier for the factory subtree size")
+    ap.add_argument("--duration", type=float, default=0, help="seconds to run (0 = forever)")
+    ap.add_argument("--anomaly", action="store_true", default=True,
+                    help="periodically spike backyard/sensors/34/temperature")
+    args = ap.parse_args()
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2,
+                         client_id=f"mqtt-sim-{random.randint(1000,9999)}")
+    client.connect(args.host, args.port, keepalive=30)
+    client.loop_start()
+
+    start = time.monotonic()
+    topics = build_topics(args.scale)
+    pubs = [Pub(tp, rate, b, rate == 0.0, start) for (tp, rate, b) in topics]
+
+    # publish retained config topics immediately
+    for p in pubs:
+        if p.rate == 0.0:
+            client.publish(p.topic, p.builder(), qos=0, retain=True)
+
+    total = sum(1 for p in pubs)
+    print(f"simulating {total} topics on {args.host}:{args.port} "
+          f"(factory scale x{args.scale}). Ctrl-C to stop.")
+
+    running = {"v": True}
+
+    def stop(*_):
+        running["v"] = False
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+
+    anomaly_topic = "backyard/sensors/34/temperature"
+    last_anomaly = start
+    in_anomaly_until = 0.0
+    sent = 0
+    last_report = start
+
+    while running["v"]:
+        t = time.monotonic()
+        if args.duration and (t - start) >= args.duration:
+            break
+
+        # anomaly: every ~25s, spike the hot topic to ~15 msg/s for 4s
+        if args.anomaly:
+            if in_anomaly_until == 0.0 and (t - last_anomaly) > 25:
+                in_anomaly_until = t + 4
+                last_anomaly = t
+            if in_anomaly_until and t > in_anomaly_until:
+                in_anomaly_until = 0.0
+
+        for p in pubs:
+            if p.rate <= 0:
+                continue
+            if t >= p.next_t:
+                rate = p.rate
+                if in_anomaly_until and p.topic == anomaly_topic:
+                    rate = 15.0
+                client.publish(p.topic, p.builder(), qos=0, retain=False)
+                sent += 1
+                p.next_t = t + random.expovariate(rate)
+
+        if t - last_report >= 5:
+            rate_now = sent / (t - last_report)
+            print(f"  ~{rate_now:.0f} msg/s  (total {sent})")
+            sent = 0
+            last_report = t
+
+        time.sleep(0.01)
+
+    client.loop_stop()
+    client.disconnect()
+    print("\nstopped.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Prepares the repo to run under a new agent without institutional knowledge from the current one.

## What's here

- **Root CLAUDE.md**: the onboarding index. Repo map, command reference, the full pre-merge check bar, conventions (branch model, commits, Svelte legacy syntax rule, Tailwind tokens, migration workflow, backend golden-file test pattern), the two-broker performance bar, and pointers to the release runbook and skills.
- **Root AGENTS.md**: one-paragraph pointer to CLAUDE.md and frontend/AGENTS.md for tools that read that convention.
- **/perf-check skill**: the two-broker flood verification procedure (setup, run, what to watch), so the smoothness bar survives as an invocable workflow rather than tribal knowledge.
- **scripts/mqtt-flood.py + scripts/mqtt-sim.py**: the perf harness scripts, previously only on feat/topic-graph-view-final. Copied as-is; if that branch merges later with unchanged scripts, git resolves them cleanly.

## What's deliberately not here

Signing account details, portal operations, and the operator access list are internal; they landed in the private mqtt-viewer/cloud repo's README instead (separate PR there). This repo is public, so CLAUDE.md only points at where that knowledge lives.

Complements what develop already has: /release, /changelog, the ds-* skills, docs/WRITING_STYLE.md, and frontend/AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)