### PR TITLE
feat: nudge repeat users to star the repo on GitHub

### DIFF
--- a/backend/app/settings.go
+++ b/backend/app/settings.go
@@ -3,6 +3,8 @@ package app
 import (
 	"mqtt-viewer/backend/models"
 	"mqtt-viewer/backend/mqtt"
+
+	"gorm.io/gorm"
 )
 
 // GetAppSettings returns the singleton settings row (seeded by migration).
@@ -53,6 +55,27 @@ func (a *App) AcknowledgeChangelog(version string) (models.AppSettings, error) {
 		return models.AppSettings{}, err
 	}
 	return settings, nil
+}
+
+// AcknowledgeStarPrompt records that the user has seen the "star us on GitHub"
+// prompt, so it never shows again (whether they starred or dismissed it).
+func (a *App) AcknowledgeStarPrompt() (models.AppSettings, error) {
+	var settings models.AppSettings
+	if err := a.Db.First(&settings, 1).Error; err != nil {
+		return models.AppSettings{}, err
+	}
+	settings.HasSeenStarPrompt = true
+	if err := a.Db.Save(&settings).Error; err != nil {
+		return models.AppSettings{}, err
+	}
+	return settings, nil
+}
+
+// recordAppLaunch bumps the persisted launch counter. It gates one-time nudges
+// (like the GitHub star prompt) so they never hit a fresh install on first run.
+func (a *App) recordAppLaunch() error {
+	return a.Db.Model(&models.AppSettings{}).Where("id = ?", 1).
+		UpdateColumn("launch_count", gorm.Expr("launch_count + 1")).Error
 }
 
 // memoryBudgetBytes returns the configured in-RAM budget, falling back to the

--- a/backend/app/settings_test.go
+++ b/backend/app/settings_test.go
@@ -23,6 +23,49 @@ func TestAppSettingsSeededDefaults(t *testing.T) {
 	if settings.HasSeenHistoryPrompt {
 		t.Error("expected history prompt unseen by default")
 	}
+	if settings.LaunchCount != 0 {
+		t.Errorf("expected launch count 0 in test mode, got %d", settings.LaunchCount)
+	}
+	if settings.HasSeenStarPrompt {
+		t.Error("expected star prompt unseen by default")
+	}
+}
+
+func TestRecordAppLaunchIncrementsCount(t *testing.T) {
+	app := getTestApp(t)
+
+	for i := 1; i <= 3; i++ {
+		if err := app.recordAppLaunch(); err != nil {
+			t.Fatalf("recording launch: %v", err)
+		}
+		settings, err := app.GetAppSettings()
+		if err != nil {
+			t.Fatalf("reading settings: %v", err)
+		}
+		if settings.LaunchCount != int64(i) {
+			t.Errorf("expected launch count %d, got %d", i, settings.LaunchCount)
+		}
+	}
+}
+
+func TestAcknowledgeStarPromptPersists(t *testing.T) {
+	app := getTestApp(t)
+
+	updated, err := app.AcknowledgeStarPrompt()
+	if err != nil {
+		t.Fatalf("acknowledging star prompt: %v", err)
+	}
+	if !updated.HasSeenStarPrompt {
+		t.Error("expected star prompt marked seen")
+	}
+
+	reloaded, err := app.GetAppSettings()
+	if err != nil {
+		t.Fatalf("reloading settings: %v", err)
+	}
+	if !reloaded.HasSeenStarPrompt {
+		t.Error("expected star prompt seen flag to persist")
+	}
 }
 
 func TestUpdateAppSettingsPersistsAndAppliesBudget(t *testing.T) {

--- a/backend/app/startup.go
+++ b/backend/app/startup.go
@@ -99,6 +99,15 @@ func (a *App) Startup(ctx context.Context, options *StartupOptions) {
 	// the message-buffer drain hot path.
 	a.loadRetentionSettings()
 
+	// Count this launch so one-time nudges (e.g. the GitHub star prompt) only
+	// fire once the app has clearly been used, never on a first-run install.
+	// Skipped in test mode to keep seeded-settings fixtures deterministic.
+	if a.Mode != AppModes.Test {
+		if err := a.recordAppLaunch(); err != nil {
+			slog.Error(fmt.Sprintf("error recording app launch: %v", err))
+		}
+	}
+
 	go func() {
 		err := protobuf.WriteSparkplugProtoFiles(a.Paths.ResourcePath)
 		if err != nil {

--- a/backend/db/migrations/20260704051603_add-star-prompt-tracking.sql
+++ b/backend/db/migrations/20260704051603_add-star-prompt-tracking.sql
@@ -1,0 +1,4 @@
+-- Count app launches and record whether the "star us on GitHub" prompt has been
+-- shown, so it only appears once and never on a first-run install.
+ALTER TABLE `app_settings` ADD COLUMN `launch_count` integer NOT NULL DEFAULT 0;
+ALTER TABLE `app_settings` ADD COLUMN `has_seen_star_prompt` numeric NOT NULL DEFAULT 0;

--- a/backend/db/migrations/atlas.sum
+++ b/backend/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Xx7rwvXxxmGcNpl8oyeeYjY2palcz2dBykG/tzs3eRM=
+h1:rqzCsjuiJ/Uw+P9MNDSBDicC48cyHqa1NtNBhKZbEdc=
 20240615025345_init.sql h1:NFrr86aryLwiPyIBHiQrnC5H2zDZJAPULxq5nn+PaxA=
 20240616060546_add-websocket-path.sql h1:jdu2Qw0nnbgNdT8Wv7vUlPr2AeXzQVNS8jEAQMjEUUM=
 20240731092726_persist-sort-and-panel-open-state.sql h1:RH3UzybXX/3HMLqwzbhRZNnTAV/aAq5ELXUbQJpnlUg=
@@ -11,3 +11,4 @@ h1:Xx7rwvXxxmGcNpl8oyeeYjY2palcz2dBykG/tzs3eRM=
 20260612000000_add-collections.sql h1:/p8pdfn65hKsKkPAaSSQL/ibNTlmf9fyCc2Oz+K+hxY=
 20260613000000_add-received-messages-and-settings.sql h1:d1KzWMXKevL+GkkBxEWeTOpCAGPzSqV+i6AGnQIsgI8=
 20260702032219_add-changelog-version.sql h1:ELFjvpUawUhnM7QIlqDMU2pc7j2Lm5708LKEGTJoyvg=
+20260704051603_add-star-prompt-tracking.sql h1:UcliQAzyI1HV7PkSnLk5+q0xGcT+xr2nihSVS3HIYwg=

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -14,7 +14,9 @@ type Global struct {
 // always-on leak guard); RecordingEnabled + DiskBudgetBytes control opt-in
 // durable history on disk; HasSeenHistoryPrompt gates the first-run popup.
 // LastSeenChangelogVersion records which version's "What's new" dialog the
-// user has dismissed, so it shows once per version.
+// user has dismissed, so it shows once per version. LaunchCount counts app
+// starts, used to gate one-time nudges past first run; HasSeenStarPrompt marks
+// the GitHub star prompt as shown so it only ever appears once.
 type AppSettings struct {
 	ID                       uint   `json:"id" gorm:"primaryKey"`
 	MemoryBudgetBytes        int64  `json:"memoryBudgetBytes"`
@@ -22,6 +24,8 @@ type AppSettings struct {
 	DiskBudgetBytes          int64  `json:"diskBudgetBytes"`
 	HasSeenHistoryPrompt     bool   `json:"hasSeenHistoryPrompt"`
 	LastSeenChangelogVersion string `json:"lastSeenChangelogVersion"`
+	LaunchCount              int64  `json:"launchCount"`
+	HasSeenStarPrompt        bool   `json:"hasSeenStarPrompt"`
 }
 
 // ReceivedMessage is a durable record of a message received from the broker,

--- a/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/app.ts
+++ b/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/app.ts
@@ -55,6 +55,8 @@ let mockAppSettings = new models.AppSettings({
   diskBudgetBytes: 1 * 1024 * 1024 * 1024,
   hasSeenHistoryPrompt: false,
   lastSeenChangelogVersion: "",
+  launchCount: 0,
+  hasSeenStarPrompt: false,
 });
 let mockDatabaseSizeBytes = 250 * 1024 * 1024;
 
@@ -78,6 +80,14 @@ export async function AcknowledgeChangelog(
   mockAppSettings = new models.AppSettings({
     ...mockAppSettings,
     lastSeenChangelogVersion: version,
+  });
+  return mockAppSettings;
+}
+
+export async function AcknowledgeStarPrompt(): Promise<models.AppSettings> {
+  mockAppSettings = new models.AppSettings({
+    ...mockAppSettings,
+    hasSeenStarPrompt: true,
   });
   return mockAppSettings;
 }

--- a/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/models/models.ts
+++ b/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/models/models.ts
@@ -9,6 +9,9 @@ export class AppSettings {
   recordingEnabled = false;
   diskBudgetBytes = 1 * 1024 * 1024 * 1024;
   hasSeenHistoryPrompt = false;
+  lastSeenChangelogVersion = "";
+  launchCount = 0;
+  hasSeenStarPrompt = false;
 
   static createFrom(source: any = {}) {
     return new AppSettings(source);

--- a/frontend/bindings/mqtt-viewer/backend/app/app.ts
+++ b/frontend/bindings/mqtt-viewer/backend/app/app.ts
@@ -35,6 +35,19 @@ export function AcknowledgeChangelog(version: string): Promise<models$0.AppSetti
     return $typingPromise;
 }
 
+/**
+ * AcknowledgeStarPrompt records that the user has seen the "star us on GitHub"
+ * prompt, so it never shows again (whether they starred or dismissed it).
+ */
+export function AcknowledgeStarPrompt(): Promise<models$0.AppSettings> & { cancel(): void } {
+    let $resultPromise = $Call.ByID(2492238430) as any;
+    let $typingPromise = $resultPromise.then(($result: any) => {
+        return $$createType0($result);
+    }) as any;
+    $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
+    return $typingPromise;
+}
+
 export function AddSubscription(connectionId: number): Promise<models$0.Subscription | null> & { cancel(): void } {
     let $resultPromise = $Call.ByID(1707702138, connectionId) as any;
     let $typingPromise = $resultPromise.then(($result: any) => {

--- a/frontend/bindings/mqtt-viewer/backend/models/models.ts
+++ b/frontend/bindings/mqtt-viewer/backend/models/models.ts
@@ -15,7 +15,9 @@ import * as time$0 from "../../../time/models.js";
  * always-on leak guard); RecordingEnabled + DiskBudgetBytes control opt-in
  * durable history on disk; HasSeenHistoryPrompt gates the first-run popup.
  * LastSeenChangelogVersion records which version's "What's new" dialog the
- * user has dismissed, so it shows once per version.
+ * user has dismissed, so it shows once per version. LaunchCount counts app
+ * starts, used to gate one-time nudges past first run; HasSeenStarPrompt marks
+ * the GitHub star prompt as shown so it only ever appears once.
  */
 export class AppSettings {
     "id": number;
@@ -24,6 +26,8 @@ export class AppSettings {
     "diskBudgetBytes": number;
     "hasSeenHistoryPrompt": boolean;
     "lastSeenChangelogVersion": string;
+    "launchCount": number;
+    "hasSeenStarPrompt": boolean;
 
     /** Creates a new AppSettings instance. */
     constructor($$source: Partial<AppSettings> = {}) {
@@ -44,6 +48,12 @@ export class AppSettings {
         }
         if (!("lastSeenChangelogVersion" in $$source)) {
             this["lastSeenChangelogVersion"] = "";
+        }
+        if (!("launchCount" in $$source)) {
+            this["launchCount"] = 0;
+        }
+        if (!("hasSeenStarPrompt" in $$source)) {
+            this["hasSeenStarPrompt"] = false;
         }
 
         Object.assign(this, $$source);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -21,6 +21,7 @@
   import ChartWindow from "./views/ChartWindow/ChartWindow.svelte";
   import HistoryRetentionPrompt from "./components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte";
   import WhatsNewDialog from "./components/WhatsNewDialog/WhatsNewDialog.svelte";
+  import StarPromptDialog from "./components/StarPromptDialog/StarPromptDialog.svelte";
 
   // Detached chart windows (opened by OpenChartWindow) load the same assets at
   // /?view=chart&...; render only the standalone chart, not the full app shell.
@@ -92,6 +93,7 @@
       <UpdateDialog />
       <HistoryRetentionPrompt />
       <WhatsNewDialog />
+      <StarPromptDialog />
     {/await}
     <Toast />
   </IconContext>

--- a/frontend/src/components/StarPromptDialog/StarPromptDialog.spec.json
+++ b/frontend/src/components/StarPromptDialog/StarPromptDialog.spec.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../design-system/component-spec.schema.json",
+  "name": "StarPromptDialog",
+  "tier": "component",
+  "description": "One-time nudge asking a repeat user to star the project on GitHub.",
+  "status": "story-only",
+  "figma": {
+    "fileKey": "",
+    "nodeId": "",
+    "url": "",
+    "lastSyncedHash": null,
+    "lastSyncedAt": null
+  },
+  "props": [],
+  "tokens": [
+    "secondary-text"
+  ],
+  "dependencies": [],
+  "notes": "Figma is not linked yet. Auto-opens from app state (launch count, seen flag) via bindings, gated behind the What's New dialog; renders closed in Storybook where those stores are inert."
+}

--- a/frontend/src/components/StarPromptDialog/StarPromptDialog.stories.svelte
+++ b/frontend/src/components/StarPromptDialog/StarPromptDialog.stories.svelte
@@ -1,0 +1,25 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import Component from "./StarPromptDialog.svelte";
+  import StoryRender from "@/stories/StoryRender.svelte";
+  import { getStoryArgTypes, getStoryArgs } from "@/stories/fixtures";
+
+  const componentName = "StarPromptDialog";
+  const storyId = "Components/StarPromptDialog";
+  const props: string[] = [];
+  const storyArgs = getStoryArgs(storyId, componentName, props);
+
+  const { Story } = defineMeta({
+    title: "Components/StarPromptDialog",
+    component: Component,
+    tags: ["autodocs"],
+    argTypes: getStoryArgTypes(componentName, props) as any,
+    parameters: { design: { type: "figma", url: "" } },
+  });
+</script>
+
+{#snippet template(args: any)}
+  <StoryRender component={Component} {args} {componentName} />
+{/snippet}
+
+<Story name="Default" args={storyArgs} {template} />

--- a/frontend/src/components/StarPromptDialog/StarPromptDialog.svelte
+++ b/frontend/src/components/StarPromptDialog/StarPromptDialog.svelte
@@ -1,0 +1,97 @@
+<script lang="ts" context="module">
+  import { writable } from "svelte/store";
+
+  // Exported so the prompt can be opened or inspected from elsewhere if needed.
+  export const starPromptOpen = writable(false);
+</script>
+
+<script lang="ts">
+  import Dialog from "@/components/Dialog/Dialog.svelte";
+  import Button from "@/components/Button/Button.svelte";
+  import { Browser } from "@wailsio/runtime";
+  import {
+    whatsNewResolved,
+    whatsNewOpen,
+  } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
+  import {
+    GetAppSettings,
+    AcknowledgeStarPrompt,
+  } from "bindings/mqtt-viewer/backend/app/app";
+
+  const REPO_URL = "https://github.com/mqtt-viewer/mqtt-viewer";
+
+  // Only nudge once the app has clearly been used a few times, so a fresh
+  // install never sees this on first run.
+  const MIN_LAUNCHES = 3;
+
+  let checked = false;
+  let acknowledged = false;
+  let wasOpen = false;
+
+  // Decide once, and only after the "What's new" dialog has had its say. If
+  // it's showing this launch, hold off rather than stack two prompts. The seen
+  // flag stays unset, so the nudge just waits for a later launch.
+  $: if (!checked && $whatsNewResolved) {
+    checked = true;
+    if (!$whatsNewOpen) {
+      (async () => {
+        try {
+          const settings = await GetAppSettings();
+          if (
+            !settings.hasSeenStarPrompt &&
+            settings.launchCount >= MIN_LAUNCHES
+          ) {
+            starPromptOpen.set(true);
+          }
+        } catch (e) {
+          console.error("Failed to check star prompt state", e);
+        }
+      })();
+    }
+  }
+
+  // Acknowledge on any close (button, the X, Escape, overlay click) so it never
+  // shows again, whether the user starred or dismissed it.
+  $: {
+    if ($starPromptOpen) {
+      wasOpen = true;
+    } else if (wasOpen) {
+      wasOpen = false;
+      acknowledge();
+    }
+  }
+
+  const acknowledge = async () => {
+    if (acknowledged) return;
+    acknowledged = true;
+    try {
+      await AcknowledgeStarPrompt();
+    } catch (e) {
+      console.error("Failed to acknowledge star prompt", e);
+    }
+  };
+
+  const onStar = () => {
+    Browser.OpenURL(REPO_URL);
+    starPromptOpen.set(false);
+  };
+
+  const onLater = () => {
+    starPromptOpen.set(false);
+  };
+</script>
+
+<Dialog title="Like the app?" isOpen={starPromptOpen}>
+  <div class="flex flex-col gap-5 mt-1 w-[400px]">
+    <p class="text-secondary-text">
+      Starring the project on GitHub is an easy way to help out. It helps more
+      people find MQTT Viewer, and it's a real boost for me to see. Thanks for
+      using it.
+    </p>
+
+    <div class="flex gap-3 justify-end items-center">
+      <Button variant="text" on:click={onLater}>Maybe later</Button>
+      <Button variant="primary" on:click={onStar}>Star on GitHub</Button>
+    </div>
+  </div>
+</Dialog>

--- a/frontend/src/components/WhatsNewDialog/WhatsNewDialog.svelte
+++ b/frontend/src/components/WhatsNewDialog/WhatsNewDialog.svelte
@@ -8,6 +8,11 @@
   // never needed, or the user dismissed it). Keeps the two dialogs from
   // stacking on a fresh install.
   export const firstRunGateCleared = writable(false);
+
+  // Set true once the auto-open decision has been made, whether or not the
+  // dialog opened. Later nudges (the GitHub star prompt) wait on this so they
+  // never land on top of the "What's new" notes.
+  export const whatsNewResolved = writable(false);
 </script>
 
 <script lang="ts">
@@ -49,6 +54,8 @@
         }
       } catch (e) {
         console.error("Failed to check changelog state", e);
+      } finally {
+        whatsNewResolved.set(true);
       }
     })();
   }

--- a/frontend/src/design-system/COMPONENT_CHECKLIST.md
+++ b/frontend/src/design-system/COMPONENT_CHECKLIST.md
@@ -65,6 +65,7 @@
 | Components/HistoryRetentionPrompt | [x] | [ ] | [ ] | [x] |
 | Components/MaxOpenTabsDialog | [x] | [ ] | [ ] | [ ] |
 | Components/SettingsDialog | [x] | [ ] | [x] | [x] |
+| Components/StarPromptDialog | [x] | [ ] | [ ] | [x] |
 | Components/UpdateDialog | [x] | [ ] | [ ] | [ ] |
 | Components/WhatsNewDialog | [x] | [ ] | [ ] | [x] |
 | Components/WhatsNewDialog/WhatsNewContent | [x] | [ ] | [x] | [x] |
@@ -134,7 +135,7 @@
 
 ## Summary
 
-- Components scanned: 108
-- Story present: 108
+- Components scanned: 109
+- Story present: 109
 - Figma-linked: 0
 - Missing specs: 0

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-02T06:54:38.803Z",
+  "generatedAt": "2026-07-04T05:21:19.313Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -2122,6 +2122,30 @@
       "specPath": "src/components/SparkplugLogo/SparkplugLogo.spec.json",
       "storyPath": "src/components/SparkplugLogo/SparkplugLogo.stories.svelte",
       "storyId": "Primitives/SparkplugLogo",
+      "specMissing": false
+    },
+    {
+      "name": "StarPromptDialog",
+      "tier": "component",
+      "description": "One-time nudge asking a repeat user to star the project on GitHub.",
+      "status": "story-only",
+      "figma": {
+        "fileKey": "",
+        "nodeId": "",
+        "url": "",
+        "lastSyncedHash": null,
+        "lastSyncedAt": null
+      },
+      "props": [],
+      "tokens": [
+        "secondary-text"
+      ],
+      "dependencies": [],
+      "notes": "Figma is not linked yet. Auto-opens from app state (launch count, seen flag) via bindings, gated behind the What's New dialog; renders closed in Storybook where those stores are inert.",
+      "sourcePath": "src/components/StarPromptDialog/StarPromptDialog.svelte",
+      "specPath": "src/components/StarPromptDialog/StarPromptDialog.spec.json",
+      "storyPath": "src/components/StarPromptDialog/StarPromptDialog.stories.svelte",
+      "storyId": "Components/StarPromptDialog",
       "specMissing": false
     },
     {


### PR DESCRIPTION
## What

Adds a one-time dialog asking users who like the app to star the project on GitHub. It only appears once the app has clearly been used, so first-time installers never see it on first run.

The copy follows `docs/WRITING_STYLE.md` (warm, first person, no em dashes or emojis):

> **Like the app?**
> Starring the project on GitHub is an easy way to help out. It helps more people find MQTT Viewer, and it's a real boost for me to see. Thanks for using it.

Buttons: "Maybe later" and "Star on GitHub" (opens the repo via `Browser.OpenURL`).

## How it stays off first-run installs

- `app_settings` gains two fields: `launch_count` and `has_seen_star_prompt` (new migration, mirrors the existing changelog-version migration).
- `Startup` bumps `launch_count` once per real app launch (skipped in test mode to keep fixtures deterministic).
- The prompt shows only when `launch_count >= 3` **and** it hasn't been seen yet. A brand-new install is on launch 1, so it never triggers.
- It waits behind the "What's new" dialog (new `whatsNewResolved` gate) so the two never stack, and if What's New is showing this launch the star prompt holds off until a later one.
- Any dismissal (button, the X, Escape, overlay click) calls the new `AcknowledgeStarPrompt` binding, so it only ever shows once.

## Files

- Backend: `AppSettings` model + migration, `AcknowledgeStarPrompt` / `recordAppLaunch` in `settings.go`, launch count in `startup.go`, tests.
- Frontend: colocated `StarPromptDialog` component + `.spec.json` + story, mounted in `App.svelte`; `whatsNewResolved` gate added to `WhatsNewDialog`; regenerated bindings + Storybook mocks.

## Checks

Green: `go build ./backend/...`, `go vet ./backend/...`, `backend/app` + `backend/db` tests, `pnpm check`, `pnpm test:run`, `pnpm ds:validate`, `pnpm build`, `pnpm test-storybook` (all 114 story tests, incl. the new one).

Two pre-existing failures on this machine are unrelated and fail identically on `develop`: `TestV3PubSub` (live public-broker network test) and `TestTabsAreLoadedCorrectly` (SQLite FK enforcement).

Note: the prompt is gated behind the desktop Wails shell reaching 3 launches, so it can't be exercised by the browser-preview flow. Its render is covered by the Storybook smoke test and it reuses the existing `HistoryRetentionPrompt` Dialog/Button layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)