### PR TITLE
chore(db): align GORM models with the hand-hardened schema (kill migration drift)

### DIFF
--- a/backend/db/migrations/20260704051603_add-star-prompt-tracking.sql
+++ b/backend/db/migrations/20260704051603_add-star-prompt-tracking.sql
@@ -1,4 +1,4 @@
 -- Count app launches and record whether the "star us on GitHub" prompt has been
 -- shown, so it only appears once and never on a first-run install.
 ALTER TABLE `app_settings` ADD COLUMN `launch_count` integer NOT NULL DEFAULT 0;
-ALTER TABLE `app_settings` ADD COLUMN `has_seen_star_prompt` numeric NOT NULL DEFAULT 0;
+ALTER TABLE `app_settings` ADD COLUMN `has_seen_star_prompt` numeric NOT NULL DEFAULT false;

--- a/backend/db/migrations/atlas.sum
+++ b/backend/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:rqzCsjuiJ/Uw+P9MNDSBDicC48cyHqa1NtNBhKZbEdc=
+h1:cCnHejpxmzjdT9Upc6PAFPAjL3y6BALMEKpLMAWpJ+w=
 20240615025345_init.sql h1:NFrr86aryLwiPyIBHiQrnC5H2zDZJAPULxq5nn+PaxA=
 20240616060546_add-websocket-path.sql h1:jdu2Qw0nnbgNdT8Wv7vUlPr2AeXzQVNS8jEAQMjEUUM=
 20240731092726_persist-sort-and-panel-open-state.sql h1:RH3UzybXX/3HMLqwzbhRZNnTAV/aAq5ELXUbQJpnlUg=
@@ -11,4 +11,4 @@ h1:rqzCsjuiJ/Uw+P9MNDSBDicC48cyHqa1NtNBhKZbEdc=
 20260612000000_add-collections.sql h1:/p8pdfn65hKsKkPAaSSQL/ibNTlmf9fyCc2Oz+K+hxY=
 20260613000000_add-received-messages-and-settings.sql h1:d1KzWMXKevL+GkkBxEWeTOpCAGPzSqV+i6AGnQIsgI8=
 20260702032219_add-changelog-version.sql h1:ELFjvpUawUhnM7QIlqDMU2pc7j2Lm5708LKEGTJoyvg=
-20260704051603_add-star-prompt-tracking.sql h1:UcliQAzyI1HV7PkSnLk5+q0xGcT+xr2nihSVS3HIYwg=
+20260704051603_add-star-prompt-tracking.sql h1:zG2yaLTFTUlZiFeCC0KePn6TMzT2TOpf7rl97xZBIXQ=

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -23,20 +23,22 @@ type AppSettings struct {
 	RecordingEnabled         bool   `json:"recordingEnabled"`
 	DiskBudgetBytes          int64  `json:"diskBudgetBytes"`
 	HasSeenHistoryPrompt     bool   `json:"hasSeenHistoryPrompt"`
-	LastSeenChangelogVersion string `json:"lastSeenChangelogVersion"`
-	LaunchCount              int64  `json:"launchCount"`
-	HasSeenStarPrompt        bool   `json:"hasSeenStarPrompt"`
+	LastSeenChangelogVersion string `json:"lastSeenChangelogVersion" gorm:"not null;default:''"`
+	LaunchCount              int64  `json:"launchCount" gorm:"not null;default:0"`
+	HasSeenStarPrompt        bool   `json:"hasSeenStarPrompt" gorm:"not null;default:0"`
 }
 
 // ReceivedMessage is a durable record of a message received from the broker,
 // written in batches only when recording is enabled. Mirrors the message shape
 // of PublishHistory; payload is a blob to avoid UTF-8 inflation of raw bytes.
 // id is autoincrement, so it doubles as a stable arrival-order cursor for
-// keyset-paginated window lookups. Indexes are defined in the SQL migration.
+// keyset-paginated window lookups. The composite index serves per-topic paged
+// lookups (connection_id, topic, id) and its leftmost prefix serves the
+// per-connection cascade deletes.
 type ReceivedMessage struct {
-	ID           uint   `json:"id" gorm:"primaryKey"`
-	ConnectionID uint   `json:"connectionId"`
-	Topic        string `json:"topic"`
+	ID           uint   `json:"id" gorm:"primaryKey;index:received_messages_conn_topic_id,priority:3"`
+	ConnectionID uint   `json:"connectionId" gorm:"index:received_messages_conn_topic_id,priority:1"`
+	Topic        string `json:"topic" gorm:"index:received_messages_conn_topic_id,priority:2"`
 	QoS          uint   `json:"qos"`
 	Retain       bool   `json:"retain"`
 	Payload      []byte `json:"payload"`
@@ -79,6 +81,11 @@ type Connection struct {
 	CustomIconSeed       *string          `json:"customIconSeed"`
 	FilterHistories      []FilterHistory  `json:"filterHistories"`
 	PublishHistories     []PublishHistory `json:"publishHistories"`
+	// Declared only so the schema keeps the foreign keys added during the DB
+	// hardening review. Never preloaded (received history can be huge) and kept
+	// out of JSON/bindings; ConnectionID on the child is the source of truth.
+	Collections      []Collection      `json:"-"`
+	ReceivedMessages []ReceivedMessage `json:"-"`
 }
 
 type FilterHistory struct {


### PR DESCRIPTION
## Problem

Every `just new-migration` (and any `atlas migrate diff`) spat out a big destructive table rebuild instead of just the new change — including **dropping the `received_messages_conn_topic_id` perf index and two foreign keys**. That's the trap I trimmed by hand in #88, and it would bite anyone adding a migration next.

## Root cause

The committed migrations and the GORM models had drifted. The offending objects were **hand-added during the adversarial DB review** (9705b29) and never expressed in the models:

- FK `fk_connections_collections`
- FK `fk_connections_received_messages`
- composite index `received_messages_conn_topic_id` on `(connection_id, topic, id)`

Because the models didn't declare them, `gormschema` kept generating a schema without them, so Atlas always wanted to "reconcile" by rebuilding those tables and dropping the hardening.

## Fix: describe the real schema in the models (don't drop the hardening)

Dropping the FKs/index would mean rebuilding the potentially huge `received_messages` table on users' machines. Instead I made the models match what's actually in the DB:

- **Composite index** tags on `ReceivedMessage` `(connection_id, topic, id)`.
- **Restored the two `Connection` has-many associations** that generate those exact FK names. They're `json:"-"` (excluded from bindings), never preloaded (all preloads in the codebase are explicit/named — verified no `clause.Associations` usage), so there's **no behavioural or binding change** — purely schema metadata for `gormschema`.
- **`app_settings`** `not null`/`default` tags to match the columns the changelog + star-prompt migrations created that way, and normalised my star-prompt migration's bool default from `0` to gorm's canonical `false` (identical in SQLite; that migration is unreleased).

## Result

- `atlas migrate diff` → **"no changes to be made"** (empty).
- `atlas migrate validate` passes.
- **No new migration, no schema change on user DBs** — the physical schema was always right; only the model definitions were catching up.
- The next `just new-migration` now emits *only* the author's change.

## Verification

- `atlas migrate diff` empty; `atlas migrate validate` clean.
- `go build ./backend/...`, `go vet ./backend/...` clean.
- `backend/db` (migrate idempotency) + `backend/app` FK/index/settings tests pass, including `TestDeleteConnectionCascadesReceivedMessages` and `TestDeleteConnectionRemovesScopedCollectionsOnly` (exercise the FKs directly).
- Regenerated bindings: **zero diff** (the `json:"-"` fields don't leak).

Pre-existing, unrelated: a handful of seeded-connection/tab tests fail identically on `develop` on my machine (SQLite FK enforcement during test seeding); this branch changes none of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)