### PR TITLE
fix(dev): update launch.json wails entry to Wails v3 dev command

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,9 +9,9 @@
     },
     {
       "name": "wails",
-      "runtimeExecutable": "wails",
-      "runtimeArgs": ["dev", "-noreload", "-skipbindings"],
-      "port": 34115
+      "runtimeExecutable": "wails3",
+      "runtimeArgs": ["dev", "-config", "./build/config.yml", "-port", "9245"],
+      "port": 9245
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `.claude/launch.json`'s `wails` entry ran the Wails v2 CLI (`wails dev -noreload -skipbindings`) against this v3 project, failing with `open wails.json: no such file or directory`.
- Updated it to the real dev command from `Taskfile.yml`: `wails3 dev -config ./build/config.yml -port 9245`, matching the default `VITE_PORT`.
- Note: the app window itself is native, so preview tooling can watch the vite dev server logs/port but cannot drive the UI directly.

## Test plan
- [x] Ran `preview_start` against the updated `wails` config and confirmed it builds bindings, builds the frontend, builds the Go binary, and brings up the vite dev server on `http://127.0.0.1:9245/` with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)