### PR TITLE
chore: guard against accidental pushes to main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Reject pushes to main unless ALLOW_MAIN_PUSH=1 is set.
+#
+# main only moves by fast-forward from develop at release time
+# (docs/RELEASING.md). This guard exists because agents and tooling push
+# with the maintainer's credentials, so server-side rules can't tell a
+# release push from a mistake. Activate with:
+#   git config core.hooksPath .githooks
+
+remote_url="$2"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+	if [ "$remote_ref" = "refs/heads/main" ] && [ "$ALLOW_MAIN_PUSH" != "1" ]; then
+		echo "pre-push: blocked push to main on $remote_url" >&2
+		echo "pre-push: main only moves by fast-forward at release time." >&2
+		echo "pre-push: if this is a release, run: ALLOW_MAIN_PUSH=1 git push" >&2
+		exit 1
+	fi
+done
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,13 @@ Full pre-merge bar for `develop`: `go build ./...`, `go vet ./...`,
 - Branch model: feature branches PR into `develop`; `main` only moves by
   fast-forward from `develop` at release time (`/release` skill,
   `docs/RELEASING.md`).
+- Never push to any branch named `main`. A committed pre-push hook
+  enforces this; activate it once per clone with
+  `git config core.hooksPath .githooks`. Release pushes set
+  `ALLOW_MAIN_PUSH=1`. External PRs from forks often target `main` by
+  mistake; retarget with `gh pr edit <n> --base develop`. To push to a
+  fork's PR branch, check out with `gh pr checkout <n> -b pr-<n>` (fork
+  head branches named `main` otherwise collide with local `main`).
 - Commits: conventional prefixes with optional scope,
   `feat(topic-graph): ...`, `fix:`, `perf:`, `chore:`, `docs:`.
 - Svelte: the codebase runs Svelte 5 but components use legacy syntax

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,7 +13,9 @@ reference it follows.
 
 ```sh
 # 1. get develop green and merged
-git checkout main && git merge --ff-only origin/develop && git push
+#    (ALLOW_MAIN_PUSH=1 satisfies the .githooks/pre-push guard; a GitHub
+#    ruleset separately blocks force-pushes and deletion on main)
+git checkout main && git merge --ff-only origin/develop && ALLOW_MAIN_PUSH=1 git push
 
 # 2. dry-run with a prerelease (optional but recommended for risky changes)
 gh release create v0.X.Y-beta1 --target main --prerelease --generate-notes \


### PR DESCRIPTION
## Why

While handling PR #103 (a fork whose head branch is named `main`), `gh pr checkout` landed on the local `main` branch and a follow-up push sent PR commits directly to upstream `main`, violating the fast-forward-only release model. Server-side rules cannot prevent a repeat: pushes from this machine use the maintainer's credentials, and the release fast-forward looks identical to a mistake.

## What

- `.githooks/pre-push`: rejects any push to a branch named `main` on any remote (fork PR heads included) unless `ALLOW_MAIN_PUSH=1` is set.
- `docs/RELEASING.md`: release step now uses `ALLOW_MAIN_PUSH=1 git push`.
- `CLAUDE.md`: records the convention, the one-time activation (`git config core.hooksPath .githooks`), and the fork-PR checkout gotcha (`gh pr checkout <n> -b pr-<n>`).

Complements the new `protect-main` GitHub ruleset (blocks force-pushes and branch deletion, no bypass), which covers what the hook cannot: history rewrites by anyone with write access.

## Verified

- Hook blocks a fast-forward dry-run push to `origin main` with a clear message and exit 1.
- `ALLOW_MAIN_PUSH=1` allows the same dry-run push.
- Hook activated in this clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)