### PR TITLE
fix(select): dropdowns invisible on Windows WebView2 (#108)

### DIFF
--- a/frontend/src/components/InputFields/Select.svelte
+++ b/frontend/src/components/InputFields/Select.svelte
@@ -52,7 +52,15 @@
     selected,
     positioning: {
       placement: "bottom-start",
-      fitViewport: true,
+      // NB: `fitViewport` is deliberately omitted. It activates floating-ui's
+      // `size` middleware, which writes an inline `max-height`/`max-width` onto
+      // the menu computed from the available viewport space. On Windows WebView2
+      // that available space can be computed as ~0 (issue #108), producing an
+      // inline `max-height: 0px` that overrides the CSS `max-h-[300px]` cap and,
+      // combined with `overflow-y-auto`, collapses the menu to an invisible
+      // sliver — the dropdown "opens" (arrow toggles) but no list is shown.
+      // The CSS `max-h-[300px] overflow-y-auto` on the menu already caps height
+      // and scrolls long lists, so `fitViewport` is redundant here.
       sameWidth,
     },
     onSelectedChange: ({ curr, next }) => {


### PR DESCRIPTION
Fixes #108

## Symptom
On Windows 11 (WebView2), the **Version** and **Protocol** dropdowns in the Edit Connection form open — the chevron toggles — but no option list appears. Arrow keys do nothing either. New SSL connections are effectively impossible because the protocol can't be changed off the non-SSL default. Works fine on macOS (WebKit).

## Root cause
`Select.svelte` passes `positioning: { fitViewport: true }` to melt-ui's `createSelect`. `fitViewport` activates floating-ui's `size` middleware, which writes an **inline `max-height`/`max-width`** onto the menu element computed from the available viewport space.

When that available space computes as ~0, the resulting inline `max-height: 0px` overrides the menu's CSS `max-h-[300px]` cap and — combined with `overflow-y-auto` — collapses the menu to an ~8px invisible sliver. The open state (`$open`) still flips, so the chevron animates and the menu stays keyboard-focusable, but nothing is visible. That matches the report exactly (chevron toggles, no list, arrow keys "dead").

`DropdownMenu.svelte` does **not** use `fitViewport`, which is why the app's other menus work and only the selects were reported broken.

## Fix
Remove `fitViewport`. The menu already carries `max-h-[300px] overflow-y-auto`, which caps height and scrolls long option lists, so the middleware-computed cap was redundant. With it gone, no inline `max-height` is ever written and the menu can no longer be collapsed. `flip`/`shift` still keep it on-screen.

## Verification
Reproduced and verified in Storybook against Chromium (same engine family as WebView2):
- Forcing `max-height: 0` on the open menu reproduces the invisible ~8px sliver with all options hidden.
- With `fitViewport` removed, no inline `max-height` is written; the menu renders all options, capped at the CSS 300px.

⚠️ **Verification gap:** I could not run an actual Windows/WebView2 build in this environment, so the specific step "WebView2 computes the available space as ~0" is inferred (a known DPI / `overflow:hidden`-clipping / layout-timing class), not directly observed. The collapse mechanism and the fix are both demonstrated in Chromium. **Please confirm on a Windows 11 build before merging.** If dropdowns still fail to appear on Windows after this change, the cause is elsewhere (likely WebView2 GPU compositing) and the next lever would be a Wails WebView2 GPU flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)