### PR TITLE
chore(deps): bump golang.org/x/crypto to v0.52.0

### DIFF
--- a/docs/MULTI_AGENT_DEV.md
+++ b/docs/MULTI_AGENT_DEV.md
@@ -33,10 +33,12 @@ rather than silently moving).
 
 ## What is shared
 
-- The local test broker (`mqtt-test-broker` container on `localhost:1883`)
-  and `test.mosquitto.org`. Fine to share, but prefix your test topics with
-  something unique (for example the branch name) so parallel agents do not
-  read each other's traffic.
+- The local test broker (`mqtt-test-broker` container on `localhost:1883`
+  for mqtt and `localhost:9001` for websockets) and `test.mosquitto.org`.
+  The Go tests in `backend/mqtt` and `backend/app` need it running; start
+  it with `scripts/test-broker.sh up`. Fine to share, but prefix your test
+  topics with something unique (for example the branch name) so parallel
+  agents do not read each other's traffic.
 - The user's installed `/Applications/MQTT Viewer.app`. Dev builds use the
   bundle id `com.mqttviewer.MQTTViewer.dev` (`build/darwin/Info.dev.plist`)
   so LaunchServices never confuses a dev build with the installed app.

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/samber/slog-multi v1.2.0
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/scripts/test-broker.sh
+++ b/scripts/test-broker.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Start (or stop) the shared local test broker the Go tests expect:
+# an eclipse-mosquitto container named mqtt-test-broker listening on
+# localhost:1883 (mqtt) and localhost:9001 (websockets), anonymous auth.
+# Shared across worktrees, so it is safe to leave running.
+#
+# Usage:
+#   scripts/test-broker.sh up      # create/start the container
+#   scripts/test-broker.sh down    # stop and remove it
+#   scripts/test-broker.sh status  # show whether it is running
+set -eu
+
+name=mqtt-test-broker
+conf_dir="${TMPDIR:-/tmp}/$name"
+
+up() {
+  if docker ps --format '{{.Names}}' | grep -qx "$name"; then
+    echo "$name already running"
+    return
+  fi
+  if docker ps -a --format '{{.Names}}' | grep -qx "$name"; then
+    docker start "$name" >/dev/null
+    echo "$name started"
+    return
+  fi
+  mkdir -p "$conf_dir"
+  cat >"$conf_dir/mosquitto.conf" <<'EOF'
+listener 1883
+allow_anonymous true
+
+listener 9001
+protocol websockets
+allow_anonymous true
+EOF
+  docker run -d --name "$name" \
+    -p 1883:1883 -p 9001:9001 \
+    -v "$conf_dir/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro" \
+    eclipse-mosquitto >/dev/null
+  echo "$name created and started"
+}
+
+case "${1:-up}" in
+  up) up ;;
+  down) docker rm -f "$name" >/dev/null 2>&1 && echo "$name removed" || echo "$name not found" ;;
+  status) docker ps --filter "name=$name" ;;
+  *) echo "usage: $0 [up|down|status]" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Bumps `golang.org/x/crypto` v0.51.0 → v0.52.0. All 13 open Dependabot alerts (7 critical, 2 high, 4 moderate) are against this one package at < 0.52.0, so this single bump clears the whole board: https://github.com/mqtt-viewer/mqtt-viewer/security/dependabot
- Adds `scripts/test-broker.sh` (up/down/status) to run the `mqtt-test-broker` mosquitto container the Go tests expect on localhost:1883 (mqtt) and localhost:9001 (websockets). The container was documented in `docs/MULTI_AGENT_DEV.md` but there was no way to create it, so `just test` failed on a fresh machine with 12 broker-dependent failures. The doc now points at the script.

## Verification
- `go build ./...` and `go vet ./...` pass
- `just test`: all packages green except `backend/cloud`, whose single test needs the portal dev server on localhost:8090 and fails identically on unmodified develop (pre-existing environment dependency, unrelated to this bump)
- `pnpm check` (0 errors), `pnpm test:run` (81 passed), `pnpm build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)