### PR TITLE
fix(test): skip cloud auth test when the portal is unreachable

### DIFF
--- a/backend/cloud/client_test.go
+++ b/backend/cloud/client_test.go
@@ -2,14 +2,42 @@ package cloud
 
 import (
 	"encoding/json"
+	"mqtt-viewer/backend/env"
+	"net"
+	"net/url"
 	"testing"
+	"time"
 )
 
 type expectedAuthCheckRes struct {
 	Status string `json:"status"`
 }
 
+// The auth check needs a reachable portal (the dev server on :8090 locally,
+// or the real one in CI). Skip rather than fail when it isn't running.
+func skipIfPortalUnreachable(t *testing.T) {
+	t.Helper()
+	u, err := url.Parse(env.ServerAddress)
+	if err != nil {
+		t.Fatalf("invalid env.ServerAddress %q: %v", env.ServerAddress, err)
+	}
+	host := u.Host
+	if u.Port() == "" {
+		if u.Scheme == "https" {
+			host = net.JoinHostPort(u.Hostname(), "443")
+		} else {
+			host = net.JoinHostPort(u.Hostname(), "80")
+		}
+	}
+	conn, err := net.DialTimeout("tcp", host, 500*time.Millisecond)
+	if err != nil {
+		t.Skipf("portal not reachable at %s: %v", env.ServerAddress, err)
+	}
+	conn.Close()
+}
+
 func TestClientIsAuthorised(t *testing.T) {
+	skipIfPortalUnreachable(t)
 	client := GetClient()
 	if client == nil {
 		t.Errorf("Error getting client")


### PR DESCRIPTION
## Summary
`TestClientIsAuthorised` in `backend/cloud` hits `env.ServerAddress` (the portal dev server on localhost:8090 in dev builds), so `just test` was permanently red on any machine without the portal running, including unmodified develop.

This adds a `skipIfPortalUnreachable` helper: a 500ms TCP dial against the portal address before the test body. Nothing listening → `t.Skip` with a clear message. Port answering → the test runs exactly as before, so any environment with the portal up (CI or a local portal checkout) keeps full coverage. The probe derives host and port from `env.ServerAddress`, so prod-style builds pointing at cloud.mqttviewer.app are probed on 443 rather than hardcoding :8090.

## Verification
- Portal down: `go test ./backend/cloud/` → `SKIP: portal not reachable at http://localhost:8090`, package passes
- Port 8090 answering (dummy HTTP server): the test runs and asserts against the response, proving the gate opens
- `go vet ./backend/cloud/` and `go build ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)