### PR TITLE
test(cloud): skip portal tests fast when offline

### DIFF
--- a/backend/cloud/client_test.go
+++ b/backend/cloud/client_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"mqtt-viewer/backend/env"
 	"net"
@@ -29,7 +30,7 @@ func skipIfPortalUnreachable(t *testing.T) {
 			host = net.JoinHostPort(u.Hostname(), "80")
 		}
 	}
-	conn, err := net.DialTimeout("tcp", host, 500*time.Millisecond)
+	conn, err := net.DialTimeout("tcp", host, 2*time.Second)
 	if err != nil {
 		t.Skipf("portal not reachable at %s: %v", env.ServerAddress, err)
 	}
@@ -40,11 +41,20 @@ func TestClientIsAuthorised(t *testing.T) {
 	skipIfPortalUnreachable(t)
 	client := GetClient()
 	if client == nil {
-		t.Errorf("Error getting client")
+		t.Fatal("Error getting client")
 	}
-	res, err := client.R().Get("/api/cv1/auth-check")
+
+	// A TCP dial only proves something is listening. Bound the request itself
+	// so a host that accepts the connection but never answers (a stray listener
+	// on the dev port, a captive portal) can't hang the suite until Go's 10m
+	// test timeout. A transport-level failure means the portal isn't really
+	// there, so skip rather than fail.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	res, err := client.R().SetContext(ctx).Get("/api/cv1/auth-check")
 	if err != nil {
-		t.Errorf("Error getting response: %v", err)
+		t.Skipf("portal request failed, treating as unreachable: %v", err)
 	}
 	if res.StatusCode() != 200 {
 		t.Errorf("Expected status code 200, got %v", res.StatusCode())


### PR DESCRIPTION
## Problem

`just test` (`go test ./...`) hung ~10 minutes and exited 1 when offline or when the cloud portal was unreachable. `TestClientIsAuthorised` guards itself with a 500ms TCP dial probe, but the resty request that follows had **no timeout**. A host that accepts the TCP connection yet never answers the HTTP request — a stray listener squatting the dev port (`localhost:8090`), a captive portal, or the real portal when the network drops mid-request — sailed past the probe and hung the request until Go's 10m test timeout.

I reproduced this locally: an unrelated process was listening on `8090`, the probe connected, and the test sat on `client.R().Get(...)` until the 10m deadline.

## Fix (test-only)

- Bound the request with a 3s `context` timeout and treat any transport-level failure as unreachable (`t.Skip`, not `t.Error`) — a network error means the portal isn't really there.
- Widen the dial probe from 500ms to 2s so a slow-but-real handshake on CI isn't misread as offline.
- `t.Errorf` -> `t.Fatal` on the nil-client guard so a nil client can't nil-panic on the next line.

Production client behaviour (`GetClient`) is untouched; the timeout is per-request via `SetContext`, not a mutation of the shared client.

## Verification

| Scenario | Before | After |
| --- | --- | --- |
| Stray listener on `:8090` (accepts TCP, never answers) | hang ~10m, exit 1 | SKIP in 3.00s (`context deadline exceeded`), total 3.6s |
| Unroutable address (`10.255.255.1`, verified by temporary override then restored) | n/a | SKIP in 2.03s via dial probe, total 2.6s |

`go build ./backend/...` and `go vet ./backend/...` both clean. (The repo-root `all:frontend/dist` embed error is pre-existing/environmental — the frontend isn't built in a fresh worktree — and unrelated to this change.)

No changelog entry: test-only, no user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)