### PR TITLE
feat(broker-status): diagnostic v2 with health strip, traffic chart and loudest topics

### DIFF
--- a/docs/broker-status-v2-spec.md
+++ b/docs/broker-status-v2-spec.md
@@ -1,0 +1,330 @@
+# Broker Status Window v2 — density and diagnosis
+
+Status: FINAL (survived two adversarial review cycles, July 2026)
+
+## Goal
+
+Upgrade the broker status window (shipped in PR #118, spec:
+`docs/broker-status-spec.md`) from a status display into a diagnostic tool.
+The v1 page reports state but cannot answer "is something wrong" or "who is
+causing it". v2 adds failure signals, context on numbers, and client-side
+per-topic insight, while keeping the app's clean, minimal look: existing
+Tailwind tokens, semantic colour only where state demands it, no new
+palettes.
+
+Competitive context (researched July 2026): no desktop MQTT client has a
+diagnostic status view. Density benchmarks are broker consoles (TBMQ,
+HiveMQ Control Center). Per-topic stats and health signals in a client are
+open territory.
+
+## Non-goals
+
+- No user-configurable thresholds (fixed conservative defaults).
+- No cross-session persistence; no multi-broker aggregate view.
+- No backend changes: CONNACK v5 capability display is cut (follow-up).
+- No NanoMQ event-derived churn (NanoMQ is a no-$SYS broker in v2).
+- No topic-prefix aggregation in loudest topics (follow-up).
+
+## Layout (top to bottom, scrollable body)
+
+Order is by universality: what works on every broker sits highest. The
+body (shell change: the `grow min-h-0` wrapper gains `overflow-y-auto`)
+scrolls; the window header stays pinned and the health strip is sticky at
+the top of the scroll container. Intended fold at 760x560: strip + hero
+(160 px) + loudest topics visible; gauges and below scroll. Loudest
+topics defaults to top 6 rows (24 px each) so the fold lands after the
+table footer, not mid-table.
+
+1. **Header** (in `BrokerStatusWindow.svelte`, the shell): staleness pill
+   and time-range selector.
+   - Pill: "waiting for $SYS" until the first $SYS message; then
+     "$SYS <age> ago", greyed once age exceeds 2x the learned interval.
+     Hidden on no-$SYS brokers.
+   - Ranges: 1m / 5m / 15m, default 5m. **Always enabled** — the selector
+     drives the hero window and the loudest-topics window, and loudest
+     topics is client-side 1 s data valid at any range on any broker.
+     When the range is shorter than 5x the learned $SYS interval, the
+     broker series in the hero render as sparse points with a small note
+     "broker publishes about every <interval>"; nothing is disabled.
+   - The selector does NOT affect health windows (fixed per rule) or tile
+     sparklines (always 15m). Shell passes the range to the store via
+     `setRange()`.
+2. **Health strip**: compact chips, dot + label + monospaced value +
+   one-word text qualifier (state never encoded by colour alone: ok is an
+   outline dot with no qualifier; attention is a filled warning dot +
+   qualifier; problem is a filled error dot + qualifier). A chip renders
+   only once its signal has the minimum samples its rule needs; until
+   then nothing renders (never paint "ok" off one sample). A chip whose
+   source has been silent for `3x learnedInterval + 30 s` greys out:
+   value stays, dot and qualifier drop (same grey semantics as the pill).
+   The strip hides when no chip has data. When $SYS is absent entirely,
+   the v1 empty-state card (kept, with its add-subscription CTA) carries
+   the explanation; a separate one-line capability notice renders in the
+   strip's place ONLY when the v1 card is not showing (no duplicate
+   messaging): "No $SYS metrics are visible on this connection. Showing
+   what this client can measure."
+3. **Traffic hero chart** (ECharts): msgs/s in and out co-plotted,
+   client-observed third series (dashed, muted when broker series
+   present; promoted to solid primary when alone). ECharts legend is
+   disabled (`legend: {show: false}`); a custom HTML legend row above the
+   chart carries live values at tile weight: flex row, `tabular-nums`,
+   fixed-min-width value slots (no 1 Hz reflow jitter), colour swatches
+   from the shared chart colour exports, app `Tooltip` per item. In/out
+   item tooltips name the smoothing and show the broker's 5m/15m
+   averages where published ("1 min average, from the broker; 5m: X,
+   15m: Y"); the observed tooltip reads "this second, as received by
+   this client". Lines start mid-chart when history is shorter than the
+   window; a null point is inserted across disconnect gaps so no line is
+   drawn over them.
+4. **Loudest topics**: header "Loudest topics (this client's
+   subscriptions)"; "(collecting)" suffix until the selected window has
+   fully elapsed since window-open. Table: topic, msg/s, bytes/s, share
+   bar; top 6 over the selected range. Topic names middle-ellipsise
+   (first segment + last two segments kept, full topic in a tooltip); at
+   narrow widths the share bar drops first, then bytes/s. Overflow is a
+   footer line, never a row: "N+ more topics, X msg/s" ("+" because the
+   per-second other-bucket makes the distinct count a lower bound; the
+   msg/s sum is exact). No row click in this PR.
+5. **Gauges grid**: clients, subscriptions, retained, bytes/s in/out,
+   store size, fan-out, avg msg size, custom mapping tiles, observed
+   tiles, "+" cell last. Tile upgrades: delta-vs-window arrow in the
+   header, shown only when |delta| >= 2% (no ambient flicker); min/max
+   and exact values in a hover panel owned by StatTile (the v1 outer
+   Tooltip wrapper on observed tiles is removed — one hover surface per
+   tile, hover and focus-visible both trigger it; the panel text names
+   the window). No min/max footer line, no endpoint dot, no alert tile
+   state (drops state lives in the health chip only). Sparklines stay
+   currentColor primary.
+6. **Facts row**: one line: broker/version, uptime, sessions with word
+   labels ("17 live, 6 offline, 2 expired"), avg msg size.
+7. **Raw $SYS browser**: collapsed bar unchanged. Expanded view gains a
+   derived rate column for counter-like topics (monotonicity heuristic:
+   3+ consecutive non-decreasing numeric observations).
+
+## Health rules
+
+Module `health.ts`, evaluated on the 1 s tick:
+`(samples, prevState, now) -> {state, since}` per chip. Hysteresis: a
+state downgrades only after its condition has been clear for
+`max(30 s, learnedInterval)`; hysteresis timestamps live in store state
+and are cleared by `resetData()`.
+
+Cadence-robust trend semantics (identical for every chip):
+
+- effective window = `max(ruleWindow, 3 x learnedInterval)`
+- "rising" requires >= 3 samples (or rate deltas) inside the effective
+  window, all increasing, AND newest sample age <= 2x learnedInterval;
+  with fewer than 3 samples the trend clause is false (state falls back
+  to the non-trend column, never "hold previous")
+- absence of a new sample means "value held flat" (mosquitto republishes
+  only changed values; silence is signal, not missing data)
+- a chip renders nothing until it has >= 2 samples
+
+| Chip | Source (first with data) | ok | attention | problem |
+| --- | --- | --- | --- | --- |
+| Drops | `load/publish/dropped/1min` (scale 1/60); else rate derived from the cumulative candidates listed in the registry table | rate 0 | rate > 0, not rising | rate rising (ruleWindow 60 s), OR rate > 5% of inbound rate (guarded by the derived-rate rules; never fires on inbound < 1 msg/s) |
+| Delivery backlog | `packet/out/count` (gauge per mosquitto-8: "current number of packets queued"; a registry fixture from an idle broker asserts plateau behaviour before the chip may bind) | not rising | rising (ruleWindow 60 s) | rising (ruleWindow 120 s) |
+| Heap | `heap/current` + `heap/maximum` | plain always, no state dot. "8.2M (peak 9.1M)". `heap/maximum` is a high-watermark, not capacity | — | — |
+| Store | `store/messages/count` + `bytes` | not rising | rising (ruleWindow 120 s) | — (never red) |
+| Churn | `load/sockets/1min` / `load/connections/1min` (scale 1/60) | plain always, informational | — | — |
+
+## Learned $SYS interval
+
+One EMA shared by the pill, chip staleness, and the hero sparse-note.
+Mosquitto publishes bursts, so raw gaps would converge to ~0: arrivals
+within the same wall second collapse to one burst; the EMA runs on burst
+gaps, floored at 2 s, seeded at 10 s until two burst gaps exist. Gaps
+spanning a disconnected period are excluded (bracket with a
+was-disconnected flag off the existing connection events).
+
+## Data: per-broker signal availability (researched July 2026)
+
+| Broker | $SYS root | Interval | What v2 gets |
+| --- | --- | --- | --- |
+| Mosquitto 2.x | `$SYS/broker/` | 10 s, retained, change-only republish | Everything incl. drops + load averages, backlog, heap (compile-opt), store, sessions, churn |
+| EMQX 4.x/5.x | `$SYS/brokers/<node>/` | 1 min, not retained, localhost-only ACL default | Drops counter, clients/subs gauges. No backlog/heap/load-avgs. 4.x dotted vs 5.x slashed `stats/*` leaves; both spellings registered. Remote sessions usually see nothing (ACL) → capability notice |
+| VerneMQ | `$SYS/<node>/` (node unpredictable → `+` wildcard) | 20 s | Counters incl. queue drops, vm_memory family, retained |
+| Mochi-MQTT | `$SYS/broker/` | 1 s, retained | Non-standard leaves (`messages/dropped`, `messages/inflight`, `retained`, `subscriptions`). `system/memory` is process memory — NOT bound to the heap chip |
+| FlashMQ / RSMB / CloudMQTT | `$SYS/broker/` | ~10 s | Mosquitto-style subset |
+| Aedes + aedes-stats | `$SYS/<random-id>/` | 1 s | clients, heap, uptime via `+` wildcards (leaf spellings verified against aedes-stats source during implementation) |
+| NanoMQ | events only | — | Treated as no-$SYS |
+| HiveMQ (all), RabbitMQ, BifroMQ, Moquette, AWS IoT, Azure Event Grid, HiveMQ Cloud, EMQX Cloud Serverless, flespi | none | — | Capability notice + observed-only page. Rejected and silent-empty subscribes resolve to the same UI state |
+
+Candidate ordering: exact family paths precede `+` wildcards. Registry
+tests: full mosquitto fixture binds every chip to its exact candidate;
+aedes-only fixture binds via wildcards; no cross-family mislabel; idle
+plateau fixture for `packet/out/count`.
+
+### Registry changes (`sys-metrics.ts`)
+
+Two new flags on metric definitions — they do not coincide:
+- `hidden: true` — no gauge tile; value and samples still tracked and
+  exposed to the view via a new state field `metricByKey`
+- `overrideTarget: false` — excluded from the mapping editor's override
+  Select (`MetricMappingEditor` filter changes from `!computed` to an
+  explicit allowlist)
+
+Reclassified v1 builtins: `msg_rate_in/out`, `bytes_rate_in/out` become
+`hidden` (their samples feed the hero; overriding one redirects the hero
+series — intended and documented), `bytes_rate_*` keep gauge tiles;
+`uptime`, `version` become `hidden` (feed the facts row). All stay
+override targets.
+
+New builtin metrics (all `hidden`, chip/facts/legend consumers):
+
+| id | candidates | kind | scale |
+| --- | --- | --- | --- |
+| `msgs_dropped` | `$SYS/broker/load/publish/dropped/1min`; `$SYS/broker/mqtt/publish/dropped`*; `$SYS/broker/publish/messages/dropped`*; `$SYS/broker/messages/publish/dropped`*; `$SYS/broker/messages/dropped`*; `$SYS/brokers/+/metrics/messages/dropped`* | gauge; * cumulative | 1/60 on the load candidate |
+| `delivery_backlog` | `$SYS/broker/packet/out/count` | gauge | — |
+| `heap_current` | `$SYS/broker/heap/current`; `$SYS/+/memory/heap/current` | gauge | — |
+| `heap_max` | `$SYS/broker/heap/maximum`; `$SYS/+/memory/heap/maximum` | gauge | — |
+| `store_msgs` | `$SYS/broker/store/messages/count`; `$SYS/broker/messages/stored` | gauge | — |
+| `store_bytes` | `$SYS/broker/store/messages/bytes` | gauge | — |
+| `clients_disconnected` | `$SYS/broker/clients/disconnected` | gauge | — |
+| `clients_expired` | `$SYS/broker/clients/expired` | gauge | — |
+| `sockets_1min` | `$SYS/broker/load/sockets/1min`; `$SYS/broker/load/connections/1min` | gauge | 1/60 |
+| `msg_rate_in_5min` / `_15min`, `msg_rate_out_5min` / `_15min` | `$SYS/broker/load/messages/{received,sent}/{5min,15min}` | gauge | 1/60 |
+| `messages_received_total` / `messages_sent_total` | `$SYS/broker/messages/received|sent`; `$SYS/brokers/+/metrics/messages/received|sent` | cumulative | — |
+
+The `*_total` pair feeds fan-out ratio and avg msg size. Derived-rate
+guards: a ratio renders "no data" unless both deltas are positive, both
+samples span the same interval (timestamps within one learned interval),
+and the denominator rate >= 1 msg/s. Counter reset (negative delta)
+invalidates that interval for ratios.
+
+## Store additions (`broker-status-store.ts`)
+
+- **Per-topic engine** (loudest topics), O(1) per message:
+  - Current-interval maps `curCount/curBytes: Map<topic, number>`;
+    admission-only cap: at 512 distinct topics, absent topics increment
+    `otherCount/otherBytes` scalars. No eviction, no scans, no per-entry
+    objects in the batch path. Buckets are tick-interval, not exact wall
+    seconds (a 300 ms batch spanning a boundary lands in the open
+    interval) — fine at display grain, comment it.
+  - On the 1 s tick: O(512 x 16) partial-select of top 16, push frozen
+    record into a 900-deep ring (dedupe by sec), fresh Maps.
+  - Top-6 display: merge ring records over the selected window on the
+    tick (15 m worst case: 14,400 map ops ~1-2 ms, on the tick, never
+    the batch path), cache on the store; `buildState` reuses the cache.
+  - Memory: the ring can hold ~14,400 entry objects and non-interned
+    topic strings, ~1-2 MB worst case — accepted, documented. No string
+    interning (an interning map is unbounded under adversarial
+    cardinality).
+  - Known bias: a topic never in any per-second top-16 undercounts;
+    invisible at top-6 grain.
+- **Observed instantaneous series** (hero): on each tick push the rate
+  of bucket `sec(now) - 2` (fully settled: batches arrive up to ~300 ms
+  late), dedupe by sec, backfill any skipped sec from the 61-bucket ring,
+  skip the partial first second after window-open. Cap 900. Tiles keep
+  the 60 s trailing average (unchanged, documented).
+- **Sample buffers**: cap 300 → 900. `Sparkline` decimates to <= 150
+  points via min-max bucketing **by array index** (sidesteps the
+  degenerate same-t case), pairs emitted in original order, true last
+  sample always emitted.
+- **Health**: `health.ts` rules above, evaluated on tick; hysteresis
+  timestamps in store state.
+- **Interval EMA**: burst-collapsed, as specified above.
+- **`setRange(minutes)`**: drives hero window + loudest-topics merge.
+- **resetData() clears additionally**: per-topic maps + ring + top
+  cache, hidden cumulative baselines, interval EMA, raw-browser
+  prev-values, health hysteresis state, observed instantaneous series.
+- **Raw browser rates**: `latestByTopic` entries gain
+  `prevValue`/`prevTimeMs` (helper in `raw-browser.ts`).
+- Disconnect: ticker already stops; chips, loudest and hero freeze with
+  the existing "Values frozen" banner — consistent, documented.
+
+## Hero chart implementation
+
+- New pure module `hero-chart-option.ts` + unit test:
+  `{series: {id, label, points, dashed, emphasis}[], windowMinutes, now,
+  theme} -> EChartsOption`. Not built on `buildChartOption` (coupled to
+  message history). Colours: export `CHROME_COLORS` from
+  `chart-option.ts` (axis/tooltip chrome; its test pins values) and take
+  series colours from `CHART_PALETTE` in `chart-series-store.ts` — both
+  named, no palette fork.
+- `TopicChart.svelte` lifecycle verbatim: init on mount, ResizeObserver
+  resize, dispose on destroy, 1 Hz slide, `$theme` re-render,
+  `replaceMerge: ["series"]` with stable ids ("in"/"out"/"observed"),
+  x-axis min/max always emitted. `animation: false`, height 160 px.
+- Stories inject fixed `now` + static series (deterministic
+  test-storybook).
+
+## Performance bar (extended)
+
+- Batch handler adds one map get + add per message, admission-capped.
+  Store writes stay coalesced (one per batch + one per tick).
+- Perf test: timed flood case grows to ~1,100 batches (proportional time
+  budget ~5 s) so the 900 sparkline cap is actually exceeded and
+  asserted; per-topic engine runs under the same flood (~9.4k distinct
+  topics exercises the 512 admission cap); 5 ms/batch bar holds. A
+  separate fake-timer test fills and wraps the 900-deep per-topic ring
+  with near-empty batches (cheap), asserting bounded state.
+- Hero: setOption at most 1 Hz.
+
+## Files to touch (complete)
+
+New: `health.ts` + test, `hero-chart-option.ts` + test,
+`HeroChart`, `TimeRangeSelector`, `HealthStrip` + `HealthChip`,
+`LoudestTopics`, `FactsRow` (each .svelte + .spec.json + .stories).
+Updated: `broker-status-store.ts` + both test files, `sys-metrics.ts` +
+test, `StatTile` (arrow, hover panel; spec/story matrix),
+`Sparkline` (decimation), `BrokerStatusView` (layout, scroll, raw rate
+column, remove observed-tile Tooltip wrapper), `raw-browser.ts`,
+`BrokerStatusWindow.svelte` + spec + story (pill, selector, scroll
+wrapper), `MetricMappingEditor.svelte` (override Select allowlist),
+`chart-option.ts` + test (export), `frontend/src/stories/fixtures.ts`
+(MockBrokerState truth-up: new fields, hidden tiles removed from mock
+grids, fixtures for the new components), `component-index.json`
+(regenerated). Estimated ~40 files, +3,000-3,600 / -400 lines.
+
+## Commit staging (single PR, three reviewable commits)
+
+1. **Store engine**: registry flags + new entries (data only — the
+   hidden filter is NOT applied yet, so the intermediate app still shows
+   v1 tiles), per-topic engine, observed series, interval EMA, health
+   module, `setRange`, all store/registry/health tests, perf-test
+   changes. App fully functional at this commit.
+2. **Hero chart + selector**: `hero-chart-option.ts`, `CHROME_COLORS`
+   export, `HeroChart`, `TimeRangeSelector`, specs + stories. Components
+   land unused; ds:validate and test-storybook pass standalone.
+3. **Surfaces + wiring**: health strip, loudest topics, facts row,
+   StatTile/Sparkline upgrades, view layout + scroll + raw rate column,
+   shell header, editor allowlist, hidden-filter flip, fixtures
+   truth-up, component-index.
+
+Gate before PR: `go build ./... && go vet ./...`, `just test`,
+`pnpm check`, `pnpm test:run`, `pnpm build`, `pnpm ds:validate`,
+`pnpm test-storybook`, `/perf-check` (message handling touched), and an
+adversarial code review at the top session tier.
+
+## Decisions log (cycles 1 and 2)
+
+Cycle 1: "session" range cut (buffer honesty); load-trend row cut
+(restated the hero's inputs; 5m/15m live in legend tooltips); CONNACK
+caps cut (backend touch); NanoMQ churn cut; heap chip never colours;
+drops red requires trend or relative threshold; hysteresis everywhere;
+dot shape + text qualifier (colour never the only channel); loudest
+overflow is a footer line; per-second top-K ring replaced the
+fold-smallest design (O(512)/message worst case, double-counted
+re-entrants); layout reordered by universality; capability notice
+replaces silent hiding; tile ornament halved; facts row word labels;
+`packet/out/count` verified against mosquitto-8 after challenge; single
+PR (owner constraint) with staged commits.
+
+Cycle 2: em dash removed from specified copy (docs/WRITING_STYLE.md hard
+rule) and units unified to msg/s; range selector fully decoupled from
+$SYS cadence (client-side loudest topics must not be crippled on EMQX —
+only the broker series go sparse); health rules respecified in samples
+with `max(fixed, 3x interval)` effective windows, held-flat semantics
+for change-only republishers, minimum-sample rendering, and staleness
+greying for chips; capability notice deduplicated against the v1 empty
+card and reworded (ACL-blocked brokers do publish; the client just
+cannot see it); custom HTML legend replaces the ECharts legend (tabular
+nums, no reflow jitter, no click-to-hide trap); fold arithmetic fixed
+(hero 160 px, top 6 rows, sticky strip); alert-tile clause deleted (one
+signal, one place); endpoint dot cut and delta arrow noise-gated;
+interval EMA burst-collapsed with disconnect bracketing; observed series
+reads `sec-2` with dedupe/backfill; `hidden` split from `overrideTarget`;
+perf-test strategy corrected (1,100-batch timed flood + separate
+fake-timer ring test); 5m/15min load topics added as hidden entries;
+staging amended so every intermediate commit is fully functional.

--- a/docs/broker-status-v2-spec.md
+++ b/docs/broker-status-v2-spec.md
@@ -118,7 +118,11 @@ Cadence-robust trend semantics (identical for every chip):
   to the non-trend column, never "hold previous")
 - absence of a new sample means "value held flat" (mosquitto republishes
   only changed values; silence is signal, not missing data)
-- a chip renders nothing until it has >= 2 samples
+- a chip renders nothing until it has a sample. One gauge sample suffices
+  (change-only republishers never re-emit a permanently-zero gauge, so a
+  two-sample gate would hide the drops and backlog chips on a healthy
+  mosquitto forever); cumulative sources are still protected because their
+  first sample is a rate, which needs two raw counter readings
 
 | Chip | Source (first with data) | ok | attention | problem |
 | --- | --- | --- | --- | --- |

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     sections: [
       {
         title: "A status page for your broker",
-        body: "There's a new broker status window showing what your broker is up to: connected clients, message and byte rates, subscriptions, retained messages, uptime and version, each with a little trend line. It reads the $SYS topics mosquitto, EMQX and VerneMQ publish, and I also measure message rates client-side so you still get numbers on brokers that publish nothing. Open it from the pulse icon above the topic tree, or hover the $SYS row.",
+        body: "There's a new broker status window built for on-the-fly debugging. A health strip warns when the broker is dropping messages or its delivery queue is backing up, a traffic chart plots messages in and out against what this client receives over a 1, 5 or 15 minute window, and a loudest topics table shows which topics are making the noise. It reads the $SYS topics mosquitto, EMQX and VerneMQ publish, and I also measure rates client-side so you still get numbers on brokers that publish nothing. Open it from the pulse icon above the topic tree, or hover the $SYS row.",
         thanks: [
           {
             name: "m1dnight",

--- a/frontend/src/components/InputFields/Select.spec.json
+++ b/frontend/src/components/InputFields/Select.spec.json
@@ -49,6 +49,13 @@
       "default": "> string"
     },
     {
+      "name": "menuClass",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Extra classes for the open menu. The default z-index sits below the toast layer; a select inside a dialog passes an elevated one (e.g. 'z-[10002]') rather than raising every select app-wide."
+    },
+    {
       "name": "selected",
       "type": "string",
       "required": false,

--- a/frontend/src/components/InputFields/Select.svelte
+++ b/frontend/src/components/InputFields/Select.svelte
@@ -153,7 +153,7 @@
   {/if}
   {#if $open}
     <div
-      class="z-10 flex max-h-[300px] flex-col
+      class="z-[10002] flex max-h-[300px] flex-col
         overflow-y-auto rounded bg-elevation-2 p-1
         shadow focus:!ring-0"
       use:melt={$menu}

--- a/frontend/src/components/InputFields/Select.svelte
+++ b/frontend/src/components/InputFields/Select.svelte
@@ -31,6 +31,11 @@
     | string
     | undefined;
   export let buttonClass = "";
+  // Extra classes for the open menu. Its default z-index deliberately sits
+  // BELOW the toast layer; a select rendered inside a dialog needs to escape
+  // the dialog's own stacking level and passes an elevated one here rather
+  // than raising every select in the app above the toasts.
+  export let menuClass = "";
   export let onChange = (value: OptionType | undefined) => {};
 
   const {
@@ -153,9 +158,12 @@
   {/if}
   {#if $open}
     <div
-      class="z-[10002] flex max-h-[300px] flex-col
+      class={twMerge(
+        `z-10 flex max-h-[300px] flex-col
         overflow-y-auto rounded bg-elevation-2 p-1
-        shadow focus:!ring-0"
+        shadow focus:!ring-0`,
+        menuClass
+      )}
       use:melt={$menu}
       transition:fade={{ duration: 150 }}
     >

--- a/frontend/src/design-system/COMPONENT_CHECKLIST.md
+++ b/frontend/src/design-system/COMPONENT_CHECKLIST.md
@@ -76,7 +76,11 @@
 |---|:---:|:---:|:---:|:---:|
 | Views/BrokerStatusWindow | [x] | [ ] | [ ] | [x] |
 | Views/BrokerStatusWindow/BrokerStatusView | [x] | [ ] | [x] | [x] |
+| Views/BrokerStatusWindow/FactsRow | [x] | [ ] | [x] | [x] |
+| Views/BrokerStatusWindow/HealthChip | [x] | [ ] | [x] | [x] |
+| Views/BrokerStatusWindow/HealthStrip | [x] | [ ] | [x] | [ ] |
 | Views/BrokerStatusWindow/HeroChart | [x] | [ ] | [x] | [x] |
+| Views/BrokerStatusWindow/LoudestTopics | [x] | [ ] | [x] | [x] |
 | Views/BrokerStatusWindow/MetricMappingEditor | [x] | [ ] | [x] | [x] |
 | Views/BrokerStatusWindow/Sparkline | [x] | [ ] | [x] | [ ] |
 | Views/BrokerStatusWindow/StatTile | [x] | [ ] | [x] | [x] |
@@ -142,7 +146,7 @@
 
 ## Summary
 
-- Components scanned: 116
-- Story present: 116
+- Components scanned: 120
+- Story present: 120
 - Figma-linked: 0
 - Missing specs: 0

--- a/frontend/src/design-system/COMPONENT_CHECKLIST.md
+++ b/frontend/src/design-system/COMPONENT_CHECKLIST.md
@@ -76,9 +76,11 @@
 |---|:---:|:---:|:---:|:---:|
 | Views/BrokerStatusWindow | [x] | [ ] | [ ] | [x] |
 | Views/BrokerStatusWindow/BrokerStatusView | [x] | [ ] | [x] | [x] |
+| Views/BrokerStatusWindow/HeroChart | [x] | [ ] | [x] | [x] |
 | Views/BrokerStatusWindow/MetricMappingEditor | [x] | [ ] | [x] | [x] |
 | Views/BrokerStatusWindow/Sparkline | [x] | [ ] | [x] | [ ] |
 | Views/BrokerStatusWindow/StatTile | [x] | [ ] | [x] | [x] |
+| Views/BrokerStatusWindow/TimeRangeSelector | [x] | [ ] | [x] | [x] |
 | Views/ChartWindow | [x] | [ ] | [ ] | [x] |
 | Views/Connection | [x] | [ ] | [x] | [ ] |
 | Views/Connection/ConnectionDetailsView/ConfirmDeleteConnectionDialog | [x] | [ ] | [x] | [x] |
@@ -140,7 +142,7 @@
 
 ## Summary
 
-- Components scanned: 114
-- Story present: 114
+- Components scanned: 116
+- Story present: 116
 - Figma-linked: 0
 - Missing specs: 0

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-16T09:48:15.466Z",
+  "generatedAt": "2026-07-18T01:17:32.715Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -2454,6 +2454,55 @@
       "specMissing": false
     },
     {
+      "name": "HeroChart",
+      "tier": "view",
+      "description": "Broker-status traffic hero: msgs/s in and out co-plotted with a dashed client-observed series, ECharts line chart under a custom live-value legend row.",
+      "status": "story-only",
+      "figma": {
+        "fileKey": "",
+        "nodeId": "",
+        "url": "",
+        "lastSyncedHash": null,
+        "lastSyncedAt": null
+      },
+      "props": [
+        {
+          "name": "series",
+          "type": "object",
+          "required": false,
+          "default": null,
+          "description": "HeroSeries[] — each { id, label, points: {t, v}[], dashed, emphasis?, tooltip? }. `v` null marks a gap (line break). ids are stable ('in'/'out'/'observed')."
+        },
+        {
+          "name": "windowMinutes",
+          "type": "number",
+          "required": false,
+          "default": 5,
+          "description": "Visible span in minutes; anchors the sliding x-axis window."
+        },
+        {
+          "name": "height",
+          "type": "number",
+          "required": false,
+          "default": 160,
+          "description": "Canvas height in pixels."
+        }
+      ],
+      "tokens": [
+        "secondary-text",
+        "emphasis"
+      ],
+      "dependencies": [
+        "Tooltip"
+      ],
+      "notes": "ECharts paints to canvas, so axis/tooltip chrome and series colours come from literal JS palettes (CHROME_COLORS, CHART_PALETTE) rather than tokens; the legend value swatch is coloured inline from the same shared palette. Stories inject a fixed `now` + static series for deterministic test-storybook.",
+      "sourcePath": "src/views/BrokerStatusWindow/components/HeroChart/HeroChart.svelte",
+      "specPath": "src/views/BrokerStatusWindow/components/HeroChart/HeroChart.spec.json",
+      "storyPath": "src/views/BrokerStatusWindow/components/HeroChart/HeroChart.stories.svelte",
+      "storyId": "Views/BrokerStatusWindow/HeroChart",
+      "specMissing": false
+    },
+    {
       "name": "MetricMappingEditor",
       "tier": "view",
       "description": "Dialog for a connection's broker-status metric-tile mappings: add/edit/delete rows with Label, Topic (required), JSON path, Unit, and an Overrides target (a builtin tile id or a custom tile). Persists via the SysMetricMapping CRUD bindings and reloads the store. Opens blank or prefilled from the raw browser's pin action.",
@@ -2620,6 +2669,62 @@
       "specPath": "src/views/BrokerStatusWindow/components/StatTile/StatTile.spec.json",
       "storyPath": "src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte",
       "storyId": "Views/BrokerStatusWindow/StatTile",
+      "specMissing": false
+    },
+    {
+      "name": "TimeRangeSelector",
+      "tier": "view",
+      "description": "Small segmented control for the broker-status window range (1m / 5m / 15m); emits a legacy `change` event with the selected minutes.",
+      "status": "story-only",
+      "figma": {
+        "fileKey": "",
+        "nodeId": "",
+        "url": "",
+        "lastSyncedHash": null,
+        "lastSyncedAt": null
+      },
+      "props": [
+        {
+          "name": "value",
+          "type": "number",
+          "required": false,
+          "default": 5,
+          "description": "Selected window in minutes; one of `options`."
+        },
+        {
+          "name": "options",
+          "type": "object",
+          "required": false,
+          "default": [
+            1,
+            5,
+            15
+          ],
+          "description": "Selectable windows in minutes."
+        },
+        {
+          "name": "sparseNote",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Optional tooltip on the group explaining sparse broker series at short ranges. Nothing is ever disabled."
+        }
+      ],
+      "tokens": [
+        "outline",
+        "elevation-1",
+        "selected",
+        "emphasis",
+        "secondary-text"
+      ],
+      "dependencies": [
+        "Tooltip"
+      ],
+      "notes": "Emits on:change (legacy createEventDispatcher) with the selected minutes as detail.",
+      "sourcePath": "src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.svelte",
+      "specPath": "src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.spec.json",
+      "storyPath": "src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.stories.svelte",
+      "storyId": "Views/BrokerStatusWindow/TimeRangeSelector",
       "specMissing": false
     },
     {

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-18T01:17:32.715Z",
+  "generatedAt": "2026-07-18T02:02:44.487Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -2395,8 +2395,11 @@
         "white-text",
         "elevation-0"
       ],
-      "dependencies": [],
-      "notes": "Figma is not linked yet.",
+      "dependencies": [
+        "BrokerStatusView",
+        "TimeRangeSelector"
+      ],
+      "notes": "Figma is not linked yet. The shell owns the header staleness pill and time-range selector, and wraps the body in an overflow-y-auto scroll container for the sticky health strip.",
       "sourcePath": "src/views/BrokerStatusWindow/BrokerStatusWindow.svelte",
       "specPath": "src/views/BrokerStatusWindow/BrokerStatusWindow.spec.json",
       "storyPath": "src/views/BrokerStatusWindow/BrokerStatusWindow.stories.svelte",
@@ -2406,7 +2409,7 @@
     {
       "name": "BrokerStatusView",
       "tier": "view",
-      "description": "Body of the Broker Status window: responsive stat-tile grid with an always-last add-tile '+', a no-$SYS empty state with an add-subscription CTA, and a collapsible raw $SYS topic browser. Reads a BrokerStatusStore and drives the MetricMappingEditor.",
+      "description": "Body of the Broker Status window (v2): sticky health strip (or capability notice), traffic hero chart, loudest-topics table, gauges grid with an always-last '+', facts row, and a collapsible raw $SYS browser with a derived rate column. Keeps the v1 no-$SYS empty state + add-subscription CTA. Reads a BrokerStatusStore and drives the MetricMappingEditor.",
       "status": "story-only",
       "figma": {
         "fileKey": "",
@@ -2431,6 +2434,7 @@
       ],
       "tokens": [
         "outline",
+        "elevation-0",
         "elevation-1",
         "secondary-text",
         "emphasis",
@@ -2440,17 +2444,195 @@
       "dependencies": [
         "StatTile",
         "MetricMappingEditor",
+        "HealthStrip",
+        "HeroChart",
+        "LoudestTopics",
+        "FactsRow",
         "Icon",
         "IconButton",
         "Tooltip",
         "Button",
         "BaseInput"
       ],
-      "notes": "Figma is not linked yet; stories use a mock BrokerStatusStore from fixtures. Age labels in the raw browser derive from a single shared 1 s tick (raw-browser.ts) referenced only while expanded, so no per-row timers run when collapsed.",
+      "notes": "Figma is not linked yet; stories use a mock BrokerStatusStore from fixtures. Age labels in the raw browser derive from a single shared 1 s tick (raw-browser.ts) referenced only while expanded, so no per-row timers run when collapsed. The derived rate column tracks per-topic prev-values in a tracker owned here and reset on a history clear.",
       "sourcePath": "src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte",
       "specPath": "src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.spec.json",
       "storyPath": "src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.stories.svelte",
       "storyId": "Views/BrokerStatusWindow/BrokerStatusView",
+      "specMissing": false
+    },
+    {
+      "name": "FactsRow",
+      "tier": "view",
+      "description": "One-line broker facts under the gauges: broker/version, uptime, session counts with word labels ('17 live, 6 offline, 2 expired'), and average message size. Each part is omitted when its metric has no data.",
+      "status": "story-only",
+      "figma": {
+        "fileKey": "",
+        "nodeId": "",
+        "url": "",
+        "lastSyncedHash": null,
+        "lastSyncedAt": null
+      },
+      "props": [
+        {
+          "name": "version",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Broker/version string, or null when unpublished."
+        },
+        {
+          "name": "uptimeSeconds",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Uptime in seconds; rendered via humanizeDuration."
+        },
+        {
+          "name": "clientsConnected",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Live sessions."
+        },
+        {
+          "name": "clientsDisconnected",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Offline sessions."
+        },
+        {
+          "name": "clientsExpired",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Expired sessions."
+        },
+        {
+          "name": "avgMsgSize",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Average message size in bytes."
+        }
+      ],
+      "tokens": [
+        "secondary-text"
+      ],
+      "dependencies": [],
+      "notes": "Figma is not linked yet. Values are read from the store's metricByKey by BrokerStatusView and passed in as plain props.",
+      "sourcePath": "src/views/BrokerStatusWindow/components/FactsRow/FactsRow.svelte",
+      "specPath": "src/views/BrokerStatusWindow/components/FactsRow/FactsRow.spec.json",
+      "storyPath": "src/views/BrokerStatusWindow/components/FactsRow/FactsRow.stories.svelte",
+      "storyId": "Views/BrokerStatusWindow/FactsRow",
+      "specMissing": false
+    },
+    {
+      "name": "HealthChip",
+      "tier": "view",
+      "description": "One broker-health chip: state dot (outline ok / filled warning / filled error), label, monospaced value, and a one-word qualifier. State is never colour-only; informational chips carry no dot; a stale chip keeps its value but drops the dot and qualifier.",
+      "status": "story-only",
+      "figma": {
+        "fileKey": "",
+        "nodeId": "",
+        "url": "",
+        "lastSyncedHash": null,
+        "lastSyncedAt": null
+      },
+      "props": [
+        {
+          "name": "label",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "level",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "'ok' | 'attention' | 'problem', or null for an informational chip with no dot.",
+          "options": [
+            "ok",
+            "attention",
+            "problem"
+          ]
+        },
+        {
+          "name": "informational",
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "description": "Value-only chip (heap, churn) with no state dot."
+        },
+        {
+          "name": "qualifier",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "One-word text qualifier shown beside the value; '' hides it."
+        },
+        {
+          "name": "valueText",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Preformatted monospaced value (units and any peak already composed by the caller)."
+        },
+        {
+          "name": "stale",
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "description": "Source silent past the stale threshold: greys the value and drops the dot and qualifier."
+        }
+      ],
+      "tokens": [
+        "outline",
+        "elevation-1",
+        "secondary-text",
+        "emphasis",
+        "warning",
+        "error"
+      ],
+      "dependencies": [],
+      "notes": "Figma is not linked yet. Value formatting per chip lives in HealthStrip; this component is purely presentational.",
+      "sourcePath": "src/views/BrokerStatusWindow/components/HealthChip/HealthChip.svelte",
+      "specPath": "src/views/BrokerStatusWindow/components/HealthChip/HealthChip.spec.json",
+      "storyPath": "src/views/BrokerStatusWindow/components/HealthChip/HealthChip.stories.svelte",
+      "storyId": "Views/BrokerStatusWindow/HealthChip",
+      "specMissing": false
+    },
+    {
+      "name": "HealthStrip",
+      "tier": "view",
+      "description": "Row of broker-health chips. Renders only chips that have their minimum samples (chip.render) and hides entirely when none do. Composes each chip's monospaced value (heap folds in its peak; rate chips carry a /s suffix).",
+      "status": "story-only",
+      "figma": {
+        "fileKey": "",
+        "nodeId": "",
+        "url": "",
+        "lastSyncedHash": null,
+        "lastSyncedAt": null
+      },
+      "props": [
+        {
+          "name": "health",
+          "type": "object",
+          "required": false,
+          "default": [],
+          "description": "HealthChip[] from the store; only entries with render:true are shown."
+        }
+      ],
+      "tokens": [],
+      "dependencies": [
+        "HealthChip"
+      ],
+      "notes": "Figma is not linked yet; stories use local health-chip fixtures. Stickiness and the capability-notice fallback are owned by BrokerStatusView, not this component.",
+      "sourcePath": "src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.svelte",
+      "specPath": "src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.spec.json",
+      "storyPath": "src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.stories.svelte",
+      "storyId": "Views/BrokerStatusWindow/HealthStrip",
       "specMissing": false
     },
     {
@@ -2500,6 +2682,46 @@
       "specPath": "src/views/BrokerStatusWindow/components/HeroChart/HeroChart.spec.json",
       "storyPath": "src/views/BrokerStatusWindow/components/HeroChart/HeroChart.stories.svelte",
       "storyId": "Views/BrokerStatusWindow/HeroChart",
+      "specMissing": false
+    },
+    {
+      "name": "LoudestTopics",
+      "tier": "view",
+      "description": "Client-side loudest-topics table for the broker-status window: top rows over the selected range with msg/s, bytes/s and a share bar, a '(collecting)' header suffix while the window fills, and an overflow footer line. Topics middle-ellipsise with the full topic in a tooltip; at narrow widths the share bar drops first, then bytes/s.",
+      "status": "story-only",
+      "figma": {
+        "fileKey": "",
+        "nodeId": "",
+        "url": "",
+        "lastSyncedHash": null,
+        "lastSyncedAt": null
+      },
+      "props": [
+        {
+          "name": "loudest",
+          "type": "object",
+          "required": false,
+          "default": null,
+          "description": "LoudestState from the store: { rows: {topic, msgPerSec, bytesPerSec}[], overflowTopics, overflowMsgPerSec, collecting }."
+        }
+      ],
+      "tokens": [
+        "outline",
+        "elevation-1",
+        "elevation-2",
+        "secondary-text",
+        "emphasis",
+        "divider",
+        "primary"
+      ],
+      "dependencies": [
+        "Tooltip"
+      ],
+      "notes": "Figma is not linked yet; stories use a local LoudestState fixture. Responsive column drops are driven by bind:clientWidth against fixed breakpoints, not the viewport.",
+      "sourcePath": "src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.svelte",
+      "specPath": "src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.spec.json",
+      "storyPath": "src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.stories.svelte",
+      "storyId": "Views/BrokerStatusWindow/LoudestTopics",
       "specMissing": false
     },
     {
@@ -2652,10 +2874,39 @@
           "required": false,
           "default": false,
           "description": "Shows a subdued 'no data yet' placeholder instead of the value."
+        },
+        {
+          "name": "deltaPct",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Percentage change across the visible window (last vs first sample). A direction arrow shows only when |deltaPct| >= 2, so steady tiles carry no flicker."
+        },
+        {
+          "name": "exact",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Exact, unabbreviated value string for the hover panel; falls back to `value`."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "One-line note shown at the top of the hover panel (e.g. an observed tile's measurement note)."
+        },
+        {
+          "name": "windowName",
+          "type": "string",
+          "required": false,
+          "default": "15m",
+          "description": "Window the sparkline and delta span; named in the hover panel."
         }
       ],
       "tokens": [
         "elevation-1",
+        "elevation-2",
         "outline",
         "secondary-text",
         "emphasis",
@@ -2664,7 +2915,7 @@
       "dependencies": [
         "Sparkline"
       ],
-      "notes": "Figma is not linked yet; stories use local fixtures. Sparkline color is set here via text-primary on the wrapper.",
+      "notes": "Figma is not linked yet; stories use local fixtures. Sparkline color is set here via text-primary on the wrapper. The tile owns its hover/focus panel (exact value, min/max, window name) so observed tiles no longer need an outer Tooltip wrapper; the panel opens on group-hover and group-focus-within.",
       "sourcePath": "src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte",
       "specPath": "src/views/BrokerStatusWindow/components/StatTile/StatTile.spec.json",
       "storyPath": "src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte",

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-18T02:02:44.487Z",
+  "generatedAt": "2026-07-28T23:16:24.784Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -1765,6 +1765,13 @@
           "type": "string",
           "required": false,
           "default": "> string"
+        },
+        {
+          "name": "menuClass",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Extra classes for the open menu. The default z-index sits below the toast layer; a select inside a dialog passes an elevated one (e.g. 'z-[10002]') rather than raising every select app-wide."
         },
         {
           "name": "selected",

--- a/frontend/src/stories/fixtures.ts
+++ b/frontend/src/stories/fixtures.ts
@@ -463,7 +463,10 @@ export const createMockBrokerStatusEmptyStore = () =>
     windowOpenedAt: now - 20000,
     metricByKey: new Map(),
     observedSeries: mockObservedSeries(),
-    loudest: { rows: [], overflowTopics: 0, overflowMsgPerSec: 0, collecting: true },
+    // The client IS receiving traffic (observed tiles show a rate), so the
+    // loudest table must have rows too; an empty table next to a live
+    // observed rate is an impossible state (review cycle 4).
+    loudest: mockLoudest(),
     health: [],
   });
 

--- a/frontend/src/stories/fixtures.ts
+++ b/frontend/src/stories/fixtures.ts
@@ -247,6 +247,10 @@ const observedTiles = () => [
   }),
 ];
 
+// v2: the reclassified builtins (msg_rate_in/out, uptime, version) are `hidden`
+// and no longer render as gauge tiles — they feed the hero and facts row via
+// metricByKey. The mock grid mirrors what BrokerStatusView actually renders:
+// the surviving gauges, the observed computed tiles, and the custom tile.
 export const mockBrokerTilesPopulated = [
   brokerTile({
     key: "clients_connected",
@@ -256,25 +260,18 @@ export const mockBrokerTilesPopulated = [
     samples: brokerSparkline(15, 3, "steady", 1),
   }),
   brokerTile({
-    key: "msg_rate_in",
-    label: "Msgs/s in",
-    value: 842,
-    display: "842",
-    samples: brokerSparkline(820, 120, "ramp", 2),
-  }),
-  brokerTile({
-    key: "msg_rate_out",
-    label: "Msgs/s out",
-    value: 1180,
-    display: "1.2k",
-    samples: brokerSparkline(1100, 160, "ramp", 3),
-  }),
-  brokerTile({
     key: "bytes_rate_in",
     label: "Bytes/s in",
     value: 48200,
     display: "48.2k",
     samples: brokerSparkline(46000, 6000, "bursty", 4),
+  }),
+  brokerTile({
+    key: "bytes_rate_out",
+    label: "Bytes/s out",
+    value: 61300,
+    display: "61.3k",
+    samples: brokerSparkline(58000, 7000, "bursty", 8),
   }),
   brokerTile({
     key: "subscriptions",
@@ -288,20 +285,6 @@ export const mockBrokerTilesPopulated = [
     value: 89,
     display: "89",
   }),
-  brokerTile({
-    key: "uptime",
-    label: "Uptime",
-    value: 273600,
-    display: "3d 4h",
-    isDuration: true,
-  }),
-  brokerTile({
-    key: "version",
-    label: "Broker",
-    valueKind: "text",
-    text: "mosquitto 2.0.18",
-    display: "mosquitto 2.0.18",
-  }),
   ...observedTiles(),
   brokerTile({
     key: "custom:factory/line/temp#",
@@ -313,18 +296,86 @@ export const mockBrokerTilesPopulated = [
   }),
 ];
 
-const emptyBuiltins = () =>
-  [
-    { key: "clients_connected", label: "Connected clients" },
-    { key: "msg_rate_in", label: "Msgs/s in" },
-    { key: "msg_rate_out", label: "Msgs/s out" },
-    { key: "bytes_rate_in", label: "Bytes/s in" },
-    { key: "bytes_rate_out", label: "Bytes/s out" },
-    { key: "subscriptions", label: "Subscriptions" },
-    { key: "retained", label: "Retained msgs" },
-    { key: "uptime", label: "Uptime" },
-    { key: "version", label: "Broker" },
-  ].map((b) => brokerTile({ ...b, valueKind: "empty" }));
+// --- v2 state-field fixtures ------------------------------------------------
+
+type MockSnapshot = import("@/views/BrokerStatusWindow/broker-status-store").MetricSnapshot;
+
+const snap = (
+  key: string,
+  opts: Partial<Omit<MockSnapshot, "key">> = {}
+): MockSnapshot => ({
+  key,
+  value: opts.value ?? null,
+  text: opts.text ?? null,
+  isDuration: opts.isDuration ?? false,
+  samples: opts.samples ?? [],
+  lastTimeMs: opts.lastTimeMs ?? now,
+  hidden: opts.hidden ?? true,
+});
+
+// Sparse broker rate samples: one point per ~10 s across the last 5 min, so the
+// hero's in/out lines read as the sparse points a $SYS republisher produces.
+const brokerHeroSamples = (base: number, amp: number, seed: number) =>
+  Array.from({ length: 30 }, (_, i) => ({
+    t: now - (29 - i) * 10_000,
+    v: Math.max(0, base + Math.sin(i / 4 + seed) * amp + pnoise(i + seed * 17) * amp * 0.2),
+  }));
+
+// Settled per-second client-observed msgs/s across the last ~2 min.
+export const mockObservedSeries = () =>
+  Array.from({ length: 120 }, (_, i) => ({
+    t: now - (119 - i) * 1000,
+    v: Math.max(0, 36 + Math.sin(i / 9) * 8 + pnoise(i * 3) * 3),
+  }));
+
+// Every metric's snapshot keyed by registry id, including the hidden ones that
+// feed the hero, facts row and derived tiles.
+export const mockMetricByKey = (): Map<string, MockSnapshot> =>
+  new Map<string, MockSnapshot>([
+    ["version", snap("version", { text: "mosquitto 2.0.18", lastTimeMs: now - 60_000 })],
+    ["uptime", snap("uptime", { value: 273600, isDuration: true, lastTimeMs: now - 2000 })],
+    ["clients_connected", snap("clients_connected", { value: 17, hidden: false, samples: brokerSparkline(15, 3, "steady", 1) })],
+    ["clients_disconnected", snap("clients_disconnected", { value: 6 })],
+    ["clients_expired", snap("clients_expired", { value: 2 })],
+    ["avg_msg_size", snap("avg_msg_size", { value: 312 })],
+    ["msg_rate_in", snap("msg_rate_in", { value: 842, samples: brokerHeroSamples(820, 120, 2) })],
+    ["msg_rate_out", snap("msg_rate_out", { value: 1180, samples: brokerHeroSamples(1100, 160, 3) })],
+    ["msg_rate_in_5min", snap("msg_rate_in_5min", { value: 810 })],
+    ["msg_rate_in_15min", snap("msg_rate_in_15min", { value: 790 })],
+    ["msg_rate_out_5min", snap("msg_rate_out_5min", { value: 1150 })],
+    ["msg_rate_out_15min", snap("msg_rate_out_15min", { value: 1120 })],
+  ]);
+
+type MockHealthChip = import("@/views/BrokerStatusWindow/health").HealthChip;
+
+// Health chips spanning every rendered state: a filled-error problem, a
+// filled-warning attention, an outline-dot ok, and the two dotless
+// informational chips (heap folds in its peak).
+export const mockHealthChips = (): MockHealthChip[] => [
+  { id: "drops", label: "Drops", level: "problem", informational: false, qualifier: "rising", value: 12.4, detail: null, since: now - 30_000, stale: false, render: true },
+  { id: "backlog", label: "Delivery backlog", level: "attention", informational: false, qualifier: "rising", value: 340, detail: null, since: now - 15_000, stale: false, render: true },
+  { id: "store", label: "Store", level: "ok", informational: false, qualifier: "", value: 1280, detail: null, since: now - 60_000, stale: false, render: true },
+  { id: "heap", label: "Heap", level: null, informational: true, qualifier: "", value: 8_600_000, detail: 9_100_000, since: now, stale: false, render: true },
+  { id: "churn", label: "Churn", level: null, informational: true, qualifier: "", value: 3.2, detail: null, since: now, stale: false, render: true },
+];
+
+type MockLoudestState = import("@/views/BrokerStatusWindow/broker-status-store").LoudestState;
+
+// Loudest-topics view model: six rows (one deliberately long, to exercise the
+// middle-ellipsis + tooltip) and a non-zero overflow footer.
+export const mockLoudest = (): MockLoudestState => ({
+  rows: [
+    { topic: "factory/line/1/temperature", msgPerSec: 128.4, bytesPerSec: 5120 },
+    { topic: "factory/line/2/temperature", msgPerSec: 96.1, bytesPerSec: 3980 },
+    { topic: "devices/sensor/44/state", msgPerSec: 62.7, bytesPerSec: 2510 },
+    { topic: "telemetry/region/eu-west/gateway/07/metrics", msgPerSec: 40.3, bytesPerSec: 8800 },
+    { topic: "home/livingroom/thermostat", msgPerSec: 22.0, bytesPerSec: 610 },
+    { topic: "app/status", msgPerSec: 8.5, bytesPerSec: 210 },
+  ],
+  overflowTopics: 12,
+  overflowMsgPerSec: 34.2,
+  collecting: false,
+});
 
 export const mockBrokerLatestByTopic = () =>
   new Map<string, { value: string; timeMs: number }>([
@@ -358,8 +409,8 @@ type MockBrokerState = {
   connected: boolean;
   sysEverSeen: boolean;
   windowOpenedAt: number;
-  // v2 state fields; minimal defaults here, fleshed-out fixtures land with
-  // the surfaces commit alongside the components that render them.
+  // v2 state fields consumed by the hero, health strip, loudest topics and
+  // facts row.
   metricByKey: Map<string, import("@/views/BrokerStatusWindow/broker-status-store").MetricSnapshot>;
   rangeMinutes: number;
   learnedIntervalMs: number;
@@ -379,13 +430,13 @@ export const createMockBrokerStatusStore = (
     connected: true,
     sysEverSeen: true,
     windowOpenedAt: now,
-    metricByKey: new Map(),
+    metricByKey: mockMetricByKey(),
     rangeMinutes: 5,
     learnedIntervalMs: 10_000,
-    sysLastSeenMs: now,
-    observedSeries: [],
-    loudest: { rows: [], overflowTopics: 0, overflowMsgPerSec: 0, collecting: true },
-    health: [],
+    sysLastSeenMs: now - 3000,
+    observedSeries: mockObservedSeries(),
+    loudest: mockLoudest(),
+    health: mockHealthChips(),
     ...overrides,
   };
   const { subscribe } = writable<MockBrokerState>(state);
@@ -403,10 +454,17 @@ export const createMockBrokerStatusStore = (
 
 export const createMockBrokerStatusEmptyStore = () =>
   createMockBrokerStatusStore({
-    tiles: [...emptyBuiltins(), ...observedTiles()],
+    // No $SYS ever seen: the observed tiles (client-measured) still populate, the
+    // v1 empty card carries the explanation, and the hero shows the promoted
+    // solid observed line. No health chips, no facts, empty loudest table.
+    tiles: [...observedTiles()],
     latestByTopic: new Map(),
     sysEverSeen: false,
     windowOpenedAt: now - 20000,
+    metricByKey: new Map(),
+    observedSeries: mockObservedSeries(),
+    loudest: { rows: [], overflowTopics: 0, overflowMsgPerSec: 0, collecting: true },
+    health: [],
   });
 
 export const createMockBrokerStatusDisconnectedStore = () =>
@@ -930,6 +988,8 @@ const componentDefaults: Record<string, Record<string, unknown>> = {
     value: "1.2k",
     unit: "/s",
     points: mockSparklinePoints,
+    exact: "1,204",
+    windowName: "15m",
   },
   Select: {
     options: ["mqtt", "mqtts", "ws", "wss"],

--- a/frontend/src/stories/fixtures.ts
+++ b/frontend/src/stories/fixtures.ts
@@ -229,7 +229,7 @@ const brokerTile = (t: MockBrokerTile) => ({
 const observedTiles = () => [
   brokerTile({
     key: "observed_msg_rate",
-    label: "Observed msgs/s",
+    label: "Observed msg/s",
     computed: true,
     tooltip: "Measured by this client across its subscriptions",
     value: 36.5,
@@ -984,7 +984,7 @@ const componentDefaults: Record<string, Record<string, unknown>> = {
   Sidebar: { isOpen: true, open: noop, close: noop },
   Sparkline: { points: mockSparklinePoints, height: 28 },
   StatTile: {
-    label: "Msgs/s in",
+    label: "Msg/s in",
     value: "1.2k",
     unit: "/s",
     points: mockSparklinePoints,

--- a/frontend/src/stories/fixtures.ts
+++ b/frontend/src/stories/fixtures.ts
@@ -358,6 +358,15 @@ type MockBrokerState = {
   connected: boolean;
   sysEverSeen: boolean;
   windowOpenedAt: number;
+  // v2 state fields; minimal defaults here, fleshed-out fixtures land with
+  // the surfaces commit alongside the components that render them.
+  metricByKey: Map<string, import("@/views/BrokerStatusWindow/broker-status-store").MetricSnapshot>;
+  rangeMinutes: number;
+  learnedIntervalMs: number;
+  sysLastSeenMs: number;
+  observedSeries: import("@/views/BrokerStatusWindow/broker-status-store").SparklineSample[];
+  loudest: import("@/views/BrokerStatusWindow/broker-status-store").LoudestState;
+  health: import("@/views/BrokerStatusWindow/health").HealthChip[];
 };
 
 export const createMockBrokerStatusStore = (
@@ -370,6 +379,13 @@ export const createMockBrokerStatusStore = (
     connected: true,
     sysEverSeen: true,
     windowOpenedAt: now,
+    metricByKey: new Map(),
+    rangeMinutes: 5,
+    learnedIntervalMs: 10_000,
+    sysLastSeenMs: now,
+    observedSeries: [],
+    loudest: { rows: [], overflowTopics: 0, overflowMsgPerSec: 0, collecting: true },
+    health: [],
     ...overrides,
   };
   const { subscribe } = writable<MockBrokerState>(state);
@@ -379,6 +395,8 @@ export const createMockBrokerStatusStore = (
     reloadMappings: async () => [],
     destroy: noop,
     snapshot: () => state,
+    setRange: noop,
+    topicRingSize: () => 0,
     connectionId,
   };
 };

--- a/frontend/src/stories/fixtures.ts
+++ b/frontend/src/stories/fixtures.ts
@@ -407,6 +407,8 @@ type MockBrokerState = {
   tiles: ReturnType<typeof brokerTile>[];
   latestByTopic: Map<string, { value: string; timeMs: number }>;
   connected: boolean;
+  everConnected: boolean;
+  trendFloorMs: number;
   sysEverSeen: boolean;
   windowOpenedAt: number;
   // v2 state fields consumed by the hero, health strip, loudest topics and
@@ -428,6 +430,8 @@ export const createMockBrokerStatusStore = (
     tiles: mockBrokerTilesPopulated,
     latestByTopic: mockBrokerLatestByTopic(),
     connected: true,
+    everConnected: true,
+    trendFloorMs: 0,
     sysEverSeen: true,
     windowOpenedAt: now,
     metricByKey: mockMetricByKey(),

--- a/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.spec.json
@@ -19,6 +19,6 @@
     "white-text",
     "elevation-0"
   ],
-  "dependencies": [],
-  "notes": "Figma is not linked yet."
+  "dependencies": ["BrokerStatusView", "TimeRangeSelector"],
+  "notes": "Figma is not linked yet. The shell owns the header staleness pill and time-range selector, and wraps the body in an overflow-y-auto scroll container for the sticky health strip."
 }

--- a/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.stories.svelte
@@ -9,6 +9,22 @@
   const props: string[] = [];
   const storyArgs = getStoryArgs(storyId, componentName, props);
 
+  // The shell reads its connection id from the window URL (the backend opens
+  // it as /?view=status&conn=<id>). Without this the story only ever renders
+  // the "Connection not found" error path, so the header, pill and banner are
+  // never exercised. Inject conn=1 (the mock connection) before mount.
+  if (
+    typeof window !== "undefined" &&
+    !window.location.search.includes("conn=")
+  ) {
+    const sep = window.location.search === "" ? "?" : "&";
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}${sep}conn=1`
+    );
+  }
+
   const { Story } = defineMeta({
     title: "Views/BrokerStatusWindow",
     component: Component,

--- a/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.svelte
+++ b/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.svelte
@@ -13,22 +13,81 @@
     type BrokerStatusStore,
   } from "./broker-status-store";
   import BrokerStatusView from "./components/BrokerStatusView/BrokerStatusView.svelte";
+  import TimeRangeSelector from "./components/TimeRangeSelector/TimeRangeSelector.svelte";
+  import { nowTick, formatAge } from "./components/BrokerStatusView/raw-browser";
 
   // State comes from the window URL the backend opened:
   // /?view=status&conn=<id>
   const params = new URLSearchParams(window.location.search);
   const connectionId = parseInt(params.get("conn") ?? "0", 10);
 
+  // How long after opening (or a history clear) with no $SYS before the pill
+  // treats the broker as a no-$SYS broker and hides itself.
+  const PILL_GRACE_MS = 10_000;
+
   let store: BrokerStatusStore | null = null;
   let viewRef: BrokerStatusView | null = null;
   let connectionName = "Broker status";
   let error = "";
+
+  // Header state, mirrored from the store via a manual subscription (the store
+  // is nullable until onMount, so `$store` auto-subscription is not usable here).
+  let sysEverSeen = false;
+  let sysLastSeenMs = -1;
+  let learnedIntervalMs = 10_000;
+  let rangeMinutes = 5;
+  let unsubStore: (() => void) | null = null;
+
+  // Pill grace timer, re-armed whenever the store's opened-at clock changes.
+  let pillGraceElapsed = false;
+  let pillGraceTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastOpenedAt = -1;
+
+  const armPillGrace = (openedAt: number) => {
+    pillGraceElapsed = false;
+    if (pillGraceTimer) clearTimeout(pillGraceTimer);
+    const remaining = Math.max(0, PILL_GRACE_MS - (Date.now() - openedAt));
+    pillGraceTimer = setTimeout(() => (pillGraceElapsed = true), remaining);
+  };
+
+  const bindHeader = (s: BrokerStatusStore) => {
+    unsubStore?.();
+    unsubStore = s.subscribe((st) => {
+      sysEverSeen = st.sysEverSeen;
+      sysLastSeenMs = st.sysLastSeenMs;
+      learnedIntervalMs = st.learnedIntervalMs;
+      rangeMinutes = st.rangeMinutes;
+      if (st.windowOpenedAt !== lastOpenedAt) {
+        lastOpenedAt = st.windowOpenedAt;
+        armPillGrace(st.windowOpenedAt);
+      }
+    });
+  };
 
   // Live connection state for the header dot + disconnected banner. Driven by
   // the connections store, which the backend keeps up to date via events.
   $: connectionState =
     $connections.connections[connectionId]?.connectionState ?? "disconnected";
   $: isDisconnected = connectionState === "disconnected";
+
+  // Staleness pill: "waiting for $SYS" until the first message, then
+  // "$SYS <age> ago" (greyed once the age exceeds 2x the learned interval).
+  // Hidden on brokers that publish no $SYS at all (grace elapsed, none seen).
+  $: pillAgeMs = sysLastSeenMs > 0 ? $nowTick - sysLastSeenMs : 0;
+  $: pill = sysEverSeen
+    ? { show: true, text: `$SYS ${formatAge($nowTick, sysLastSeenMs)}`, grey: pillAgeMs > 2 * learnedIntervalMs }
+    : !pillGraceElapsed
+      ? { show: true, text: "waiting for $SYS", grey: false }
+      : { show: false, text: "", grey: false };
+
+  // When the range is shorter than 5x the learned $SYS interval, the broker
+  // series render as sparse points; the note explains why (nothing is disabled).
+  $: sparseNote =
+    sysEverSeen && rangeMinutes * 60_000 < 5 * learnedIntervalMs
+      ? `broker publishes about every ${Math.round(learnedIntervalMs / 1000)}s`
+      : undefined;
+
+  const onRangeChange = (e: CustomEvent<number>) => store?.setRange(e.detail);
 
   onMount(async () => {
     // Init subscriptions too so BrokerStatusView's hasSysSubscription reflects
@@ -44,6 +103,7 @@
     store = createBrokerStatusStore(connectionId, connection.eventSet, {
       connected: connection.connectionState === "connected",
     });
+    bindHeader(store);
     // Backfills $SYS + mapped-topic history and begins live-appending from the
     // shared event stream.
     await store.init();
@@ -52,6 +112,8 @@
   onDestroy(() => {
     // Drop the app-global event listeners (and the 1 s ticker) when the window
     // closes so we don't leak listeners on the shared backend.
+    unsubStore?.();
+    if (pillGraceTimer) clearTimeout(pillGraceTimer);
     store?.destroy();
   });
 </script>
@@ -69,7 +131,21 @@
       <span class="text-lg text-emphasis truncate">{connectionName}</span>
       <span class="text-secondary-text text-sm">broker status</span>
       {#if store}
-        <div class="ml-auto">
+        <div class="ml-auto flex items-center gap-3">
+          {#if pill.show}
+            <span
+              class="text-sm tabular-nums {pill.grey
+                ? 'text-secondary-text opacity-60'
+                : 'text-secondary-text'}"
+            >
+              {pill.text}
+            </span>
+          {/if}
+          <TimeRangeSelector
+            value={rangeMinutes}
+            {sparseNote}
+            on:change={onRangeChange}
+          />
           <IconButton
             tooltipText="Configure metrics"
             tooltipPlacement="bottom"
@@ -95,7 +171,7 @@
         {error}
       </div>
     {:else if store}
-      <div class="grow min-h-0" style="--wails-draggable:false">
+      <div class="grow min-h-0 overflow-y-auto" style="--wails-draggable:false">
         <BrokerStatusView bind:this={viewRef} {store} {connectionId} />
       </div>
     {:else}

--- a/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.svelte
+++ b/frontend/src/views/BrokerStatusWindow/BrokerStatusWindow.svelte
@@ -64,11 +64,26 @@
     });
   };
 
-  // Live connection state for the header dot + disconnected banner. Driven by
-  // the connections store, which the backend keeps up to date via events.
+  // Live connection state for the header dot + banner. Driven by the
+  // connections store, which the backend keeps up to date via events.
   $: connectionState =
     $connections.connections[connectionId]?.connectionState ?? "disconnected";
-  $: isDisconnected = connectionState === "disconnected";
+  // A connection that has never been up this session has nothing frozen to
+  // warn about, so it gets a neutral note rather than a warning banner.
+  $: everConnected =
+    !!$connections.connections[connectionId]?.firstConnectedThisSessionAtMs;
+  // An unexpected outage sits in "reconnecting", not "disconnected"; both mean
+  // the values on screen are frozen.
+  $: banner =
+    connectionState === "connected"
+      ? null
+      : connectionState === "reconnecting"
+        ? { text: "Reconnecting. Values frozen.", warn: true }
+        : connectionState === "connecting"
+          ? { text: "Connecting…", warn: false }
+          : everConnected
+            ? { text: "Disconnected. Values frozen.", warn: true }
+            : { text: "Not connected.", warn: false };
 
   // Staleness pill: "waiting for $SYS" until the first message, then
   // "$SYS <age> ago" (greyed once the age exceeds 2x the learned interval).
@@ -157,12 +172,14 @@
       {/if}
     </header>
 
-    {#if isDisconnected && !error}
+    {#if banner && !error}
       <div
-        class="px-4 py-1 text-sm text-warning border-y border-warning truncate"
+        class="px-4 py-1 text-sm truncate border-y {banner.warn
+          ? 'text-warning border-warning'
+          : 'text-secondary-text border-divider'}"
         style="--wails-draggable:false"
       >
-        Disconnected. Values frozen.
+        {banner.text}
       </div>
     {/if}
 

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.perf.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.perf.test.ts
@@ -10,17 +10,24 @@
 // O(n²)/per-message-allocation regressions and unbounded state growth.
 //
 // What it drives:
-//   - 3 minutes of 4000 msg/s = 600 batch events × 1200 messages at the real
-//     ~300 ms Wails batch cadence, with the 1 s observed-rate ticker running.
+//   - ~5.5 minutes of 4000 msg/s = 1100 batch events × 1200 messages at the
+//     real ~300 ms Wails batch cadence, with the 1 s observed-rate ticker
+//     running. 1100 batches means each tile samples past the 900 sparkline cap,
+//     so the in-place trim is actually exercised and asserted.
 //   - Message mix: ~2% $SYS topics with numeric payloads (drive the tiles),
 //     ~98% regular topics across a wide, mostly-distinct topic tree with
-//     realistic base64 payloads (~100–300 decoded bytes).
+//     realistic base64 payloads (~100–300 decoded bytes) — ~9k distinct topics
+//     exercise the per-topic engine's 512 admission cap.
 //
 // What it asserts:
-//   - mean per-batch handler time < 5 ms, total handler time < 3 s.
-//   - bounded state: sparkline sample arrays ≤ SPARKLINE_CAP, and latestByTopic
-//     never exceeds the count of distinct tracked ($SYS) topics — i.e. the
-//     thousands of untracked regular topics do NOT accumulate entries.
+//   - mean per-batch handler time < 5 ms, total handler time < 5.5 s
+//     (proportional to the batch count).
+//   - bounded state: sparkline sample arrays ≤ SPARKLINE_CAP (and at least one
+//     reaches it), the per-topic loudest table stays ≤ 6 rows, and
+//     latestByTopic never exceeds the count of distinct tracked ($SYS) topics —
+//     i.e. the thousands of untracked regular topics do NOT accumulate entries.
+//   - a separate fake-timer test fills and wraps the 900-deep per-topic ring
+//     with near-empty batches, asserting the ring stays bounded.
 
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { get } from "svelte/store";
@@ -103,7 +110,7 @@ const mkMsg = (topic: string, payloadB64: string) =>
 
 // --- Flood parameters ---------------------------------------------------------
 
-const BATCHES = 600; // 600 × 300 ms = 180 s = 3 minutes
+const BATCHES = 1100; // 1100 × 300 ms ≈ 330 s; enough to exceed the 900 cap
 const MSGS_PER_BATCH = 1200; // 1200 / 0.3 s = 4000 msg/s
 const BATCH_MS = 300; // real Wails batch cadence
 const TEMPLATES = 8; // handful of reused batch objects
@@ -242,7 +249,7 @@ describe("createBrokerStatusStore — flood perf", () => {
     // Perf contract (generous CI headroom; the point is catching O(n²) /
     // per-message-allocation regressions, not micro-benchmarks).
     expect(mean).toBeLessThan(5);
-    expect(total).toBeLessThan(3000);
+    expect(total).toBeLessThan(5500);
 
     // Bounded state: no sparkline buffer exceeds the cap...
     for (const t of state.tiles) {
@@ -252,12 +259,38 @@ describe("createBrokerStatusStore — flood perf", () => {
     // in-place trim runs (not merely that buffers never grew).
     expect(maxSamples).toBe(SPARKLINE_CAP);
 
+    // Per-topic engine stayed bounded under the wide flood: the loudest table
+    // never exceeds its row cap, and the ring never exceeds its depth.
+    expect(state.loudest.rows.length).toBeLessThanOrEqual(6);
+    expect(store.topicRingSize()).toBeLessThanOrEqual(900);
+
     // Bounded state: latestByTopic holds only the distinct tracked ($SYS)
     // topics. The ~9k distinct untracked regular topics contributed to the rate
     // counters only — they must NOT accumulate entries.
     expect(state.latestByTopic.size).toBeLessThanOrEqual(distinctSysTopics);
     expect(distinctRegularLeaves).toBeGreaterThan(1000); // the flood really was wide
 
+    store.destroy();
+  });
+
+  // Cheap, deterministic ring-wrap test on the fake clock: fire far more than
+  // 900 ticks with tiny batches and assert the 900-deep per-topic ring (and the
+  // observed series ring) stay bounded rather than growing per tick.
+  it("keeps the per-topic ring bounded as it wraps past its depth", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init(); // await so the 1 s ticker is running before the loop
+
+    const TICKS = 1200; // > 900, so the ring wraps fully
+    for (let i = 0; i < TICKS; i++) {
+      // One near-empty batch per second keeps the ring turning cheaply.
+      const m = mkMsg(`ring/topic${i & 7}`, b64("x"));
+      m.timeMs = Date.now();
+      emit("msgs", [m]);
+      vi.advanceTimersByTime(1000); // one ticker tick → one ring record
+    }
+
+    expect(store.topicRingSize()).toBe(900); // capped at depth, not TICKS
+    expect(get(store).observedSeries.length).toBeLessThanOrEqual(900);
     store.destroy();
   });
 });

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.test.ts
@@ -533,3 +533,256 @@ describe("createBrokerStatusStore — empty state & teardown", () => {
     expect(get(store)).toBe(snapshot);
   });
 });
+
+// --- v2: hidden metrics, metricByKey, visible-tile predicate ------------------
+
+describe("createBrokerStatusStore — hidden metrics & metricByKey", () => {
+  it("keeps the relocated v1 tiles visible but omits the new hidden metrics", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    const keys = get(store).tiles.map((t) => t.key);
+    // v1 tiles reclassified hidden but grandfathered in this commit.
+    for (const k of ["msg_rate_in", "msg_rate_out", "uptime", "version"]) {
+      expect(keys, k).toContain(k);
+    }
+    // Non-hidden gauges + observed computed tiles stay.
+    for (const k of ["clients_connected", "bytes_rate_in", OBSERVED_MSG_KEY]) {
+      expect(keys, k).toContain(k);
+    }
+    // Brand-new hidden diagnostic / derived metrics never surface as tiles.
+    for (const k of ["msgs_dropped", "delivery_backlog", "heap_current", "fan_out"]) {
+      expect(keys, k).not.toContain(k);
+    }
+    store.destroy();
+  });
+
+  it("exposes every metric — hidden included — via metricByKey", async () => {
+    mocks.getSys.mockResolvedValue([
+      msg("$SYS/broker/heap/current", "8200000", BASE_MS),
+      msg("$SYS/broker/packet/out/count", "12", BASE_MS),
+    ]);
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    const m = get(store).metricByKey;
+
+    const heap = m.get("heap_current");
+    expect(heap?.value).toBe(8200000);
+    expect(heap?.hidden).toBe(true);
+    expect(heap?.samples.length).toBeGreaterThan(0);
+    expect(m.get("delivery_backlog")?.value).toBe(12);
+    // A visible tile is present in metricByKey too.
+    expect(m.get("clients_connected")?.hidden).toBe(false);
+    store.destroy();
+  });
+});
+
+// --- v2: loudest-topics engine -----------------------------------------------
+
+describe("createBrokerStatusStore — loudest topics", () => {
+  it("ranks the top rows by msg/s and reports exact overflow", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    // 7 topics with counts 7..1 in one interval.
+    const batch: any[] = [];
+    for (let n = 7; n >= 1; n--) {
+      for (let i = 0; i < n; i++) {
+        batch.push(msg(`plant/topic${n}`, "x", Date.now()));
+      }
+    }
+    emit("msgs", batch);
+    vi.advanceTimersByTime(1000); // tick: rotate + merge
+
+    const loud = get(store).loudest;
+    expect(loud.rows.map((r) => r.topic)).toEqual([
+      "plant/topic7",
+      "plant/topic6",
+      "plant/topic5",
+      "plant/topic4",
+      "plant/topic3",
+      "plant/topic2",
+    ]);
+    expect(loud.rows[0].msgPerSec).toBe(7); // divisor = 1 s collected
+    expect(loud.overflowTopics).toBe(1); // topic1 beyond the 6 rows
+    expect(loud.overflowMsgPerSec).toBe(1); // exact: topic1's single message
+    expect(loud.collecting).toBe(true); // window not yet elapsed
+    store.destroy();
+  });
+
+  it("admission-caps the interval map at 512 distinct topics", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    // 600 distinct topics, one message each. 512 admitted to the map, the
+    // remaining 88 collapse into the other-scalars; the per-second capture keeps
+    // its top 16.
+    const batch = Array.from({ length: 600 }, (_, i) =>
+      msg(`wide/topic${i}`, "x", Date.now())
+    );
+    emit("msgs", batch);
+    vi.advanceTimersByTime(1000);
+
+    const loud = get(store).loudest;
+    expect(loud.rows).toHaveLength(6);
+    expect(loud.rows[0].msgPerSec).toBe(1);
+    // 16 captured topics − 6 shown = 10 (a lower bound, rendered with "+").
+    expect(loud.overflowTopics).toBe(10);
+    // Exact: (16 captured + 88 other − 6 shown) msgs over 1 s.
+    expect(loud.overflowMsgPerSec).toBe(98);
+    store.destroy();
+  });
+});
+
+// --- v2: observed instantaneous series ---------------------------------------
+
+describe("createBrokerStatusStore — observed instantaneous series", () => {
+  it("pushes the settled sec(now)-2 rate, skipping the partial open second", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    // Advance one tick past the partial open second, then publish 7 messages in
+    // this second. Two more ticks later that second has settled (sec-2 lag) and
+    // its rate lands in the series.
+    vi.advanceTimersByTime(1000);
+    emit(
+      "msgs",
+      Array.from({ length: 7 }, () => msg("t", "hi", Date.now()))
+    );
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(1000);
+
+    const series = get(store).observedSeries;
+    expect(series.some((p) => p.v === 7)).toBe(true);
+    // Timestamps strictly increase (deduped by second).
+    for (let i = 1; i < series.length; i++) {
+      expect(series[i].t).toBeGreaterThan(series[i - 1].t);
+    }
+    store.destroy();
+  });
+});
+
+// --- v2: learned $SYS interval EMA -------------------------------------------
+
+describe("createBrokerStatusStore — learned interval EMA", () => {
+  const sys = (payload: string, timeMs: number) =>
+    msg("$SYS/broker/uptime", payload, timeMs);
+
+  it("seeds at 10 s until two burst gaps, then tracks burst spacing", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    expect(get(store).learnedIntervalMs).toBe(10_000); // seed
+
+    emit("msgs", [sys("1", BASE_MS)]); // burst 0
+    emit("msgs", [sys("2", BASE_MS + 20_000)]); // gap 1 = 20 s (still seed)
+    expect(get(store).learnedIntervalMs).toBe(10_000);
+
+    emit("msgs", [sys("3", BASE_MS + 40_000)]); // gap 2 = 20 s → EMA takes over
+    expect(get(store).learnedIntervalMs).toBe(20_000);
+    store.destroy();
+  });
+
+  it("collapses same-second arrivals into one burst", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    // Two messages in the same wall second are one burst → no gap folded.
+    emit("msgs", [sys("1", BASE_MS), sys("2", BASE_MS + 400)]);
+    emit("msgs", [sys("3", BASE_MS + 15_000)]); // gap 1 = 15 s
+    emit("msgs", [sys("4", BASE_MS + 30_000)]); // gap 2 = 15 s
+    expect(get(store).learnedIntervalMs).toBe(15_000);
+    store.destroy();
+  });
+
+  it("excludes a gap spanning a disconnect", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    emit("msgs", [sys("1", BASE_MS)]); // burst 0
+    emit("disc");
+    emit("conn");
+    // First burst after reconnect: its 30 s gap must NOT poison the EMA.
+    emit("msgs", [sys("2", BASE_MS + 30_000)]);
+    emit("msgs", [sys("3", BASE_MS + 40_000)]); // gap 1 = 10 s
+    emit("msgs", [sys("4", BASE_MS + 50_000)]); // gap 2 = 10 s
+    // Only the two 10 s gaps folded — a folded 30 s gap would read ~24 s.
+    expect(get(store).learnedIntervalMs).toBe(10_000);
+    store.destroy();
+  });
+});
+
+// --- v2: derived tiles (fan-out, avg msg size) -------------------------------
+
+describe("createBrokerStatusStore — derived tiles", () => {
+  it("computes fan-out and avg msg size from the cumulative totals + byte rate", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    // Two samples one second apart: received +100/s, sent +300/s, 100 bytes/s in.
+    emit("msgs", [
+      msg("$SYS/broker/messages/received", "1000", BASE_MS),
+      msg("$SYS/broker/messages/sent", "2000", BASE_MS),
+      msg("$SYS/broker/load/bytes/received/1min", "6000", BASE_MS),
+    ]);
+    emit("msgs", [
+      msg("$SYS/broker/messages/received", "1100", BASE_MS + 1000),
+      msg("$SYS/broker/messages/sent", "2300", BASE_MS + 1000),
+      msg("$SYS/broker/load/bytes/received/1min", "6000", BASE_MS + 1000),
+    ]);
+    vi.advanceTimersByTime(1000); // tick computes the derived tiles
+
+    const m = get(store).metricByKey;
+    expect(m.get("fan_out")?.value).toBeCloseTo(3, 6); // 300 out / 100 in
+    expect(m.get("avg_msg_size")?.value).toBeCloseTo(1, 6); // 100 bytes / 100 in
+    store.destroy();
+  });
+
+  it("reports no data until the derived-rate guards are satisfied", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    // A single cumulative sample yields no rate yet → guards fail.
+    emit("msgs", [
+      msg("$SYS/broker/messages/received", "1000", BASE_MS),
+      msg("$SYS/broker/messages/sent", "2000", BASE_MS),
+    ]);
+    vi.advanceTimersByTime(1000);
+    expect(get(store).metricByKey.get("fan_out")?.value).toBeNull();
+    store.destroy();
+  });
+});
+
+// --- v2: setRange & resetData extensions -------------------------------------
+
+describe("createBrokerStatusStore — setRange & reset", () => {
+  it("defaults to 5 m and updates the selected range", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    expect(get(store).rangeMinutes).toBe(5);
+    store.setRange(15);
+    expect(get(store).rangeMinutes).toBe(15);
+    store.setRange(1);
+    expect(get(store).rangeMinutes).toBe(1);
+    store.destroy();
+  });
+
+  it("clears the per-topic engine, observed series and interval EMA on reset", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    emit("msgs", [
+      msg("plant/a", "x", Date.now()),
+      msg("$SYS/broker/uptime", "1", BASE_MS),
+    ]);
+    emit("msgs", [msg("$SYS/broker/uptime", "2", BASE_MS + 20_000)]);
+    emit("msgs", [msg("$SYS/broker/uptime", "3", BASE_MS + 40_000)]);
+    vi.advanceTimersByTime(1000); // tick populates loudest + ring
+    expect(get(store).loudest.rows.length).toBeGreaterThan(0);
+    expect(store.topicRingSize()).toBeGreaterThan(0);
+    expect(get(store).learnedIntervalMs).toBe(20_000);
+
+    emit("clear");
+    const state = get(store);
+    expect(state.loudest.rows).toHaveLength(0);
+    expect(state.observedSeries).toHaveLength(0);
+    expect(state.learnedIntervalMs).toBe(10_000); // back to the seed
+    expect(store.topicRingSize()).toBe(0);
+    store.destroy();
+  });
+});

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.test.ts
@@ -87,6 +87,14 @@ const customTile = (state: BrokerStatusState): BrokerTileView => {
   return t;
 };
 
+// v2: the reclassified builtins are `hidden` and no longer render as gauge
+// tiles, so their live values are read from metricByKey instead of `tiles`.
+const metric = (state: BrokerStatusState, key: string) => {
+  const m = state.metricByKey.get(key);
+  if (!m) throw new Error(`no metric ${key}: have ${[...state.metricByKey.keys()]}`);
+  return m;
+};
+
 const BASE_MS = 1_000_000_000; // fixed epoch base for deterministic buckets
 
 beforeEach(() => {
@@ -118,8 +126,9 @@ describe("createBrokerStatusStore — backfill", () => {
 
     expect(tile(state, "clients_connected").display).toBe("5");
     expect(tile(state, "subscriptions").display).toBe("3");
-    expect(tile(state, "version").display).toBe("mosquitto 2.0.18");
-    expect(tile(state, "version").valueKind).toBe("text");
+    // version is hidden (feeds the facts row) — read it from metricByKey.
+    expect(metric(state, "version").text).toBe("mosquitto 2.0.18");
+    expect(metric(state, "version").value).toBeNull();
 
     expect(state.latestByTopic.get("$SYS/broker/clients/connected")).toEqual({
       value: "5",
@@ -332,7 +341,7 @@ describe("createBrokerStatusStore — cumulative rate derivation", () => {
     ]);
     const store = createBrokerStatusStore(CONN, eventSet);
     await store.init();
-    expect(tile(get(store), "msg_rate_in").value).toBeCloseTo(75, 6);
+    expect(metric(get(store), "msg_rate_in").value).toBeCloseTo(75, 6);
     store.destroy();
   });
 
@@ -345,7 +354,7 @@ describe("createBrokerStatusStore — cumulative rate derivation", () => {
     await store.init();
     // Broker restart: counter drops below the previous value.
     emit("msgs", [msg(EMQX, "50", BASE_MS + 2000)]);
-    expect(tile(get(store), "msg_rate_in").value).toBe(0);
+    expect(metric(get(store), "msg_rate_in").value).toBe(0);
     store.destroy();
   });
 
@@ -361,7 +370,7 @@ describe("createBrokerStatusStore — cumulative rate derivation", () => {
     ]);
     const store = createBrokerStatusStore(CONN, eventSet);
     await store.init();
-    const t = tile(get(store), "msg_rate_in");
+    const t = metric(get(store), "msg_rate_in");
     expect(t.samples.map((s) => s.v)).toEqual([100]);
     expect(t.value).toBeCloseTo(100, 6);
     store.destroy();
@@ -491,7 +500,10 @@ describe("createBrokerStatusStore — empty state & teardown", () => {
 
     emit("msgs", [msg("$SYS/broker/uptime", "60 seconds", BASE_MS)]);
     expect(get(store).sysEverSeen).toBe(true);
-    expect(tile(get(store), "uptime").display).toBe("1m");
+    // uptime is hidden (feeds the facts row) — read it from metricByKey.
+    const up = metric(get(store), "uptime");
+    expect(up.value).toBe(60);
+    expect(up.isDuration).toBe(true);
     store.destroy();
   });
 
@@ -537,21 +549,26 @@ describe("createBrokerStatusStore — empty state & teardown", () => {
 // --- v2: hidden metrics, metricByKey, visible-tile predicate ------------------
 
 describe("createBrokerStatusStore — hidden metrics & metricByKey", () => {
-  it("keeps the relocated v1 tiles visible but omits the new hidden metrics", async () => {
+  it("omits every hidden metric from the gauges grid (v2 surfaces)", async () => {
     const store = createBrokerStatusStore(CONN, eventSet);
     await store.init();
     const keys = get(store).tiles.map((t) => t.key);
-    // v1 tiles reclassified hidden but grandfathered in this commit.
+    // v1 tiles reclassified hidden now leave the grid (they feed the hero and
+    // facts row via metricByKey instead).
     for (const k of ["msg_rate_in", "msg_rate_out", "uptime", "version"]) {
-      expect(keys, k).toContain(k);
+      expect(keys, k).not.toContain(k);
+    }
+    // Brand-new hidden diagnostic / derived metrics never surface as tiles.
+    for (const k of ["msgs_dropped", "delivery_backlog", "heap_current", "fan_out"]) {
+      expect(keys, k).not.toContain(k);
     }
     // Non-hidden gauges + observed computed tiles stay.
     for (const k of ["clients_connected", "bytes_rate_in", OBSERVED_MSG_KEY]) {
       expect(keys, k).toContain(k);
     }
-    // Brand-new hidden diagnostic / derived metrics never surface as tiles.
-    for (const k of ["msgs_dropped", "delivery_backlog", "heap_current", "fan_out"]) {
-      expect(keys, k).not.toContain(k);
+    // ...but the hidden values remain available via metricByKey.
+    for (const k of ["msg_rate_in", "uptime", "version", "heap_current"]) {
+      expect(get(store).metricByKey.has(k), k).toBe(true);
     }
     store.destroy();
   });

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.test.ts
@@ -36,8 +36,10 @@ vi.mock("bindings/mqtt-viewer/backend/app/app", () => ({
 
 import {
   createBrokerStatusStore,
+  LATEST_TOPIC_CAP,
   OBSERVED_MSG_KEY,
   OBSERVED_BYTE_KEY,
+  SPARKLINE_CAP,
   type BrokerStatusState,
   type BrokerTileView,
 } from "./broker-status-store";
@@ -642,7 +644,8 @@ describe("createBrokerStatusStore — loudest topics", () => {
     const loud = get(store).loudest;
     expect(loud.rows).toHaveLength(6);
     expect(loud.rows[0].msgPerSec).toBe(1);
-    // 16 captured topics − 6 shown = 10 (a lower bound, rendered with "+").
+    // 16 captured topics − 6 shown = 10 (a lower bound; the table renders the
+    // exact overflow RATE rather than this count).
     expect(loud.overflowTopics).toBe(10);
     // Exact: (16 captured + 88 other − 6 shown) msgs over 1 s.
     expect(loud.overflowMsgPerSec).toBe(98);
@@ -800,6 +803,152 @@ describe("createBrokerStatusStore — setRange & reset", () => {
     expect(state.observedSeries).toHaveLength(0);
     expect(state.learnedIntervalMs).toBe(10_000); // back to the seed
     expect(store.topicRingSize()).toBe(0);
+    store.destroy();
+  });
+});
+
+// --- v2: connection-loss contract --------------------------------------------
+
+describe("createBrokerStatusStore — connection loss", () => {
+  it("treats mqttReconnecting as a connection loss", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    expect(vi.getTimerCount()).toBe(1);
+
+    // An unexpected outage emits reconnecting, never disconnected.
+    emit("reconnecting");
+    expect(get(store).connected).toBe(false);
+    expect(vi.getTimerCount()).toBe(0); // ticker frozen, no fabricated samples
+
+    emit("conn");
+    expect(get(store).connected).toBe(true);
+    expect(vi.getTimerCount()).toBe(1);
+    store.destroy();
+  });
+
+  it("greys every rendered health chip when the connection drops", async () => {
+    mocks.getSys.mockResolvedValue([
+      msg("$SYS/broker/store/messages/count", "10", BASE_MS - 1000),
+    ]);
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    vi.advanceTimersByTime(1000); // tick evaluates health
+
+    const before = get(store).health.filter((c) => c.render);
+    expect(before.length).toBeGreaterThan(0);
+    expect(before.some((c) => !c.stale)).toBe(true);
+
+    emit("reconnecting");
+    const after = get(store).health.filter((c) => c.render);
+    expect(after.every((c) => c.stale)).toBe(true);
+    expect(after.every((c) => c.qualifier === "")).toBe(true);
+    store.destroy();
+  });
+
+  it("does not backfill zeros across an outage", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    vi.advanceTimersByTime(1000);
+    emit("msgs", Array.from({ length: 4 }, () => msg("t", "hi", Date.now())));
+    vi.advanceTimersByTime(3000);
+    const beforeLen = get(store).observedSeries.length;
+    expect(beforeLen).toBeGreaterThan(0);
+
+    // 10 minutes offline. The ticker is stopped, so nothing is sampled; the
+    // resumed series must not invent one zero per silent second either.
+    emit("reconnecting");
+    vi.advanceTimersByTime(600_000);
+    emit("conn");
+    vi.advanceTimersByTime(3000);
+
+    const series = get(store).observedSeries;
+    // At most one sample per resumed tick: no 600-sample zero run.
+    expect(series.length).toBeLessThanOrEqual(beforeLen + 3);
+    // The outage shows as a time jump the view renders as a line break.
+    let maxGapMs = 0;
+    for (let i = 1; i < series.length; i++) {
+      maxGapMs = Math.max(maxGapMs, series[i].t - series[i - 1].t);
+    }
+    expect(maxGapMs).toBeGreaterThan(500_000);
+    store.destroy();
+  });
+
+  it("clamps the catch-up after a long suspend to the sparkline cap", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+    vi.advanceTimersByTime(1000);
+
+    // Simulate a suspended machine: the clock jumps hours while the connection
+    // stays nominally up, so one tick has to catch up ~28,800 seconds.
+    vi.setSystemTime(new Date(BASE_MS + 8 * 60 * 60_000));
+    vi.advanceTimersByTime(1000);
+
+    expect(get(store).observedSeries.length).toBeLessThanOrEqual(SPARKLINE_CAP);
+    store.destroy();
+  });
+});
+
+// --- v2: loudest-topics honesty ----------------------------------------------
+
+describe("createBrokerStatusStore — loudest topics honesty", () => {
+  it("age-gates the merge so a frozen ring cannot fabricate a live rate", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    emit("msgs", [msg("plant/a", "x", Date.now())]);
+    vi.advanceTimersByTime(1000);
+    expect(get(store).loudest.rows.length).toBe(1);
+
+    // 20 minutes offline, well past the default 5 m window, then back.
+    emit("reconnecting");
+    vi.advanceTimersByTime(1_200_000);
+    emit("conn");
+    vi.advanceTimersByTime(1000);
+
+    const loud = get(store).loudest;
+    expect(loud.rows).toHaveLength(0);
+    expect(loud.overflowMsgPerSec).toBe(0);
+    store.destroy();
+  });
+
+  it("keeps $SYS out of the loudest table", async () => {
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    emit("msgs", [
+      ...Array.from({ length: 20 }, () =>
+        msg("$SYS/broker/uptime", "1", Date.now())
+      ),
+      msg("plant/a", "x", Date.now()),
+    ]);
+    vi.advanceTimersByTime(1000);
+
+    const loud = get(store).loudest;
+    expect(loud.rows.map((r) => r.topic)).toEqual(["plant/a"]);
+    expect(loud.overflowMsgPerSec).toBe(0);
+    store.destroy();
+  });
+});
+
+// --- v2: browsed-topic cap ----------------------------------------------------
+
+describe("createBrokerStatusStore — browsed topic cap", () => {
+  it("stops admitting new topics past the cap", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = createBrokerStatusStore(CONN, eventSet);
+    await store.init();
+
+    emit(
+      "msgs",
+      Array.from({ length: LATEST_TOPIC_CAP + 100 }, (_, i) =>
+        msg(`$SYS/broker/clients/c${i}/count`, String(i), Date.now())
+      )
+    );
+
+    expect(get(store).latestByTopic.size).toBe(LATEST_TOPIC_CAP);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
     store.destroy();
   });
 });

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
@@ -33,9 +33,20 @@ import {
   type MetricTile,
   type SysMetricMappingRow,
 } from "./sys-metrics";
+import {
+  evaluateHealth,
+  type HealthChip,
+  type HealthChipId,
+  type HealthChipState,
+  type HealthMetric,
+} from "./health";
 
-/** Max sparkline points retained per tile; older points are trimmed in place. */
-export const SPARKLINE_CAP = 300;
+/**
+ * Max sparkline points retained per tile; older points are trimmed in place.
+ * v2: raised 300 → 900 so the 15 m tile sparklines (and the observed hero
+ * series) hold a full window at 1 Hz.
+ */
+export const SPARKLINE_CAP = 900;
 /** Ring size for the observed-rate counters: 60 s window + 1 spare bucket. */
 export const OBSERVED_BUCKETS = 61;
 /** Sliding window (seconds) the observed msgs/s and bytes/s are averaged over. */
@@ -45,6 +56,35 @@ export const TICKER_MS = 1000;
 
 export const OBSERVED_MSG_KEY = "observed_msg_rate";
 export const OBSERVED_BYTE_KEY = "observed_byte_rate";
+/** Derived tiles filled on the tick from the hidden cumulative message totals. */
+export const FAN_OUT_KEY = "fan_out";
+export const AVG_MSG_SIZE_KEY = "avg_msg_size";
+
+// --- Per-topic ("loudest topics") engine constants ---------------------------
+/**
+ * Admission cap on the current-interval maps: once this many distinct topics
+ * have been seen in the open interval, further NEW topics fall into the
+ * other-scalars instead of growing the map. Keeps the batch path O(1) and the
+ * map bounded regardless of topic cardinality.
+ */
+export const TOPIC_ADMISSION_CAP = 512;
+/** Per-second top-K captured off each interval into the ring. */
+export const TOPIC_TOP_K = 16;
+/** Depth of the per-second ring: 900 s = 15 m at 1 Hz. */
+export const TOPIC_RING_CAP = 900;
+/** Rows shown in the loudest-topics table. */
+export const LOUDEST_ROWS = 6;
+
+// --- Time-range constants ----------------------------------------------------
+export const DEFAULT_RANGE_MINUTES = 5;
+
+// --- Learned $SYS interval (burst-collapsed EMA) constants -------------------
+/** Seed interval (s) until two burst gaps have been observed. */
+export const INTERVAL_SEED_SEC = 10;
+/** Floor (s) on a single burst gap (mosquitto bursts would converge to ~0). */
+export const INTERVAL_FLOOR_SEC = 2;
+/** EMA smoothing factor on burst gaps. */
+export const INTERVAL_ALPHA = 0.3;
 
 /** One sparkline point: `t` = ms epoch, `v` = plotted value. */
 export interface SparklineSample {
@@ -81,9 +121,55 @@ export interface BrokerTileView {
   samples: SparklineSample[];
 }
 
+/**
+ * A metric's live snapshot, exposed for every registry entry — hidden ones
+ * included — so the hero, health strip, facts row and derived tiles can read
+ * values that no longer have a gauge tile of their own.
+ */
+export interface MetricSnapshot {
+  key: string;
+  value: number | null;
+  text: string | null;
+  isDuration: boolean;
+  samples: SparklineSample[];
+  /** Newest sample time folded in (for cadence/staleness reasoning). */
+  lastTimeMs: number;
+  hidden: boolean;
+}
+
+/** One row of the loudest-topics table. */
+export interface LoudestTopic {
+  topic: string;
+  msgPerSec: number;
+  bytesPerSec: number;
+}
+
+/** The loudest-topics view model, recomputed on the tick and cached. */
+export interface LoudestState {
+  rows: LoudestTopic[];
+  /**
+   * Distinct topics beyond the shown rows. A LOWER BOUND (rendered with a
+   * trailing "+") because the per-second other-bucket hides an unknown number
+   * of distinct topics.
+   */
+  overflowTopics: number;
+  /** Exact msg/s not attributed to a shown row (merged tail + other-bucket). */
+  overflowMsgPerSec: number;
+  /** False until the selected window has fully elapsed since window-open. */
+  collecting: boolean;
+}
+
 export interface BrokerStatusState {
-  /** Effective tiles (builtins + custom/override mappings), in display order. */
+  /**
+   * Visible tiles the gauges grid renders, in display order. v2 marks several
+   * builtins `hidden`; in the store-engine commit the visible predicate still
+   * keeps the reclassified v1 tiles (`msg_rate_*`, `uptime`, `version`) so the
+   * running app is unchanged — the brand-new hidden metrics never appear here
+   * (read them from `metricByKey`).
+   */
   tiles: BrokerTileView[];
+  /** Every metric's snapshot, keyed by registry id — hidden ones included. */
+  metricByKey: Map<string, MetricSnapshot>;
   /** Raw browser data: newest decoded value per $SYS/* or mapped topic. */
   latestByTopic: Map<string, LatestTopicEntry>;
   /** Broker connection up/down, driven by the connection's Wails events. */
@@ -92,6 +178,18 @@ export interface BrokerStatusState {
   sysEverSeen: boolean;
   /** Epoch ms the window/store opened — the view's 10 s empty-state grace. */
   windowOpenedAt: number;
+  /** Selected time range (minutes): drives the hero window + loudest merge. */
+  rangeMinutes: number;
+  /** Burst-collapsed EMA of the $SYS republish interval (ms), for pill/chips. */
+  learnedIntervalMs: number;
+  /** Newest $SYS message time (ms), for the header staleness pill. */
+  sysLastSeenMs: number;
+  /** Per-second client-observed msgs/s (settled), for the hero's third series. */
+  observedSeries: SparklineSample[];
+  /** Loudest-topics view model (top rows + overflow + collecting flag). */
+  loudest: LoudestState;
+  /** Evaluated health chips (renderable), in strip order. */
+  health: HealthChip[];
 }
 
 export type BrokerStatusStore = ReturnType<typeof createBrokerStatusStore>;
@@ -116,6 +214,24 @@ interface ObservedBucket {
   bytes: number;
 }
 
+/** One captured entry inside a per-second top-K ring record. */
+interface TopicRingEntry {
+  topic: string;
+  count: number;
+  bytes: number;
+}
+
+/**
+ * A frozen per-second capture: the interval's top-K topics plus the collapsed
+ * other-bucket totals. Pushed onto the ring by the tick; never mutated after.
+ */
+interface TopicRingRecord {
+  sec: number;
+  entries: TopicRingEntry[];
+  otherCount: number;
+  otherBytes: number;
+}
+
 const emptyRuntime = (): TileRuntime => ({
   samples: [],
   value: null,
@@ -124,6 +240,29 @@ const emptyRuntime = (): TileRuntime => ({
   lastTimeMs: -1,
   lastTopic: "",
 });
+
+/**
+ * v1 builtins reclassified `hidden` for v2's eventual layout but kept on the
+ * gauges grid until the surfaces commit relocates them to the hero / facts row.
+ * Keeping the running app unchanged in the store-engine commit.
+ */
+const KEEP_VISIBLE_WHILE_HIDDEN = new Set<string>([
+  "msg_rate_in",
+  "msg_rate_out",
+  "uptime",
+  "version",
+]);
+
+/**
+ * Which effective tiles render on the gauges grid THIS commit. Non-hidden
+ * tiles (custom/override tiles, the surviving v1 builtins, the observed
+ * computed tiles) always show; the reclassified v1 tiles are grandfathered in;
+ * the brand-new hidden diagnostic/derived metrics never do (they reach the view
+ * via `metricByKey`). The surfaces commit replaces this with a plain `!hidden`
+ * filter once the new consumers exist.
+ */
+const isVisibleTile = (tile: MetricTile): boolean =>
+  !tile.hidden || KEEP_VISIBLE_WHILE_HIDDEN.has(tile.key);
 
 export const createBrokerStatusStore = (
   connectionId: number,
@@ -152,7 +291,57 @@ export const createBrokerStatusStore = (
     () => ({ sec: -1, count: 0, bytes: 0 })
   );
 
+  // Per-second client-observed msgs/s, settled at sec(now)-2. Capped ring array
+  // (trimmed in place), consumed by the hero's third series.
+  let observedSeries: SparklineSample[] = [];
+  // Newest settled second already pushed into observedSeries (-1 = none yet).
+  let lastObservedSec = -1;
+
+  // --- Per-topic engine (loudest topics) -------------------------------------
+  // Current open interval's per-topic counters. Admission-capped: at
+  // TOPIC_ADMISSION_CAP distinct topics, further NEW topics fall into the
+  // other-scalars. Reset every tick. Buckets are tick-interval, not exact wall
+  // seconds — a batch straddling a boundary lands wholly in the open interval,
+  // which is fine at display grain.
+  const curCount = new Map<string, number>();
+  const curBytes = new Map<string, number>();
+  let otherCount = 0;
+  let otherBytes = 0;
+  // Fixed-size ring of frozen per-second records (a plain circular buffer).
+  const topicRing: (TopicRingRecord | null)[] = new Array(TOPIC_RING_CAP).fill(
+    null
+  );
+  let topicRingHead = -1; // index of the most recent record
+  let topicRingLen = 0; // number of populated records (≤ TOPIC_RING_CAP)
+  // Cached merge over the selected window, recomputed on the tick so buildState
+  // is cheap. Seeded empty.
+  let loudestCache: LoudestState = {
+    rows: [],
+    overflowTopics: 0,
+    overflowMsgPerSec: 0,
+    collecting: true,
+  };
+
+  // --- Learned $SYS interval (burst-collapsed EMA) ---------------------------
+  let lastBurstSec = -1; // wall second of the last $SYS burst (-1 = none)
+  let intervalEmaSec = INTERVAL_SEED_SEC; // running EMA accumulator
+  let intervalBurstGaps = 0; // folded gaps so far
+  let learnedIntervalSec = INTERVAL_SEED_SEC; // exposed value (seed until ≥2 gaps)
+  // Set when a disconnect breaks the burst sequence; the next burst's gap is
+  // excluded so a disconnected span never poisons the EMA.
+  let intervalGapBroken = false;
+
+  // --- Health ----------------------------------------------------------------
+  // Persisted hysteresis state per chip, passed back into evaluateHealth each
+  // tick and cleared by resetData.
+  let healthStates = new Map<HealthChipId, HealthChipState>();
+  let healthChips: HealthChip[] = [];
+
+  // Selected time range (minutes). Drives the hero window + loudest merge.
+  let rangeMinutes = DEFAULT_RANGE_MINUTES;
+
   let sysEverSeen = false;
+  let sysLastSeenMs = -1;
   let connected = opts.connected ?? true;
   const windowOpenedAt = Date.now();
   let openedAt = windowOpenedAt;
@@ -195,12 +384,38 @@ export const createBrokerStatusStore = (
     };
   };
 
+  // Every effective tile's snapshot, so hidden values (hero series, chip
+  // sources, facts, derived ratios) reach the view without a gauge tile.
+  const buildMetricByKey = (): Map<string, MetricSnapshot> => {
+    const out = new Map<string, MetricSnapshot>();
+    for (const t of effectiveTiles) {
+      const rt = runtime.get(t.key) ?? emptyRuntime();
+      out.set(t.key, {
+        key: t.key,
+        value: rt.value,
+        text: rt.text,
+        isDuration: rt.isDuration,
+        samples: rt.samples,
+        lastTimeMs: rt.lastTimeMs,
+        hidden: t.hidden ?? false,
+      });
+    }
+    return out;
+  };
+
   const buildState = (): BrokerStatusState => ({
-    tiles: effectiveTiles.map(buildTile),
+    tiles: effectiveTiles.filter(isVisibleTile).map(buildTile),
+    metricByKey: buildMetricByKey(),
     latestByTopic: latest,
     connected,
     sysEverSeen,
     windowOpenedAt: openedAt,
+    rangeMinutes,
+    learnedIntervalMs: learnedIntervalSec * 1000,
+    sysLastSeenMs,
+    observedSeries,
+    loudest: loudestCache,
+    health: healthChips,
   });
 
   const { subscribe, set } = writable<BrokerStatusState>(buildState());
@@ -293,6 +508,183 @@ export const createBrokerStatusStore = (
     return { count, bytes };
   };
 
+  // Message count in the observed ring for an exact wall second (0 if that
+  // second's bucket has since been overwritten — only possible >61 s back).
+  const bucketCountForSec = (sec: number): number => {
+    const idx = ((sec % OBSERVED_BUCKETS) + OBSERVED_BUCKETS) % OBSERVED_BUCKETS;
+    const b = buckets[idx];
+    return b.sec === sec ? b.count : 0;
+  };
+
+  // Pushes the settled per-second observed msgs/s (sec(now)-2, fully arrived at
+  // the ~300 ms batch lag) into observedSeries, backfilling any skipped seconds
+  // from the ring and skipping the partial first second after window-open.
+  const pushObservedSeries = (nowSec: number) => {
+    const target = nowSec - 2;
+    if (lastObservedSec < 0) {
+      // First tick: the window-open second is partial, so start pushing the
+      // second AFTER it. Never backfill before the window opened.
+      lastObservedSec = Math.max(
+        Math.floor(openedAt / 1000),
+        target - 1
+      );
+    }
+    for (let sec = lastObservedSec + 1; sec <= target; sec++) {
+      observedSeries.push({ t: sec * 1000, v: bucketCountForSec(sec) });
+      if (observedSeries.length > SPARKLINE_CAP) observedSeries.shift();
+    }
+    if (target > lastObservedSec) lastObservedSec = target;
+  };
+
+  // --- Per-topic engine ------------------------------------------------------
+  // O(1) admission-capped count of one received message. No scans, no per-entry
+  // objects beyond the (bounded) map keys.
+  const addTopicCount = (topic: string, bytes: number) => {
+    const c = curCount.get(topic);
+    if (c !== undefined) {
+      curCount.set(topic, c + 1);
+      curBytes.set(topic, (curBytes.get(topic) ?? 0) + bytes);
+    } else if (curCount.size < TOPIC_ADMISSION_CAP) {
+      curCount.set(topic, 1);
+      curBytes.set(topic, bytes);
+    } else {
+      // Cap reached: absent topics collapse into the other-scalars.
+      otherCount += 1;
+      otherBytes += bytes;
+    }
+  };
+
+  // Partial-select the interval's top-K topics by count (O(cap × K)), freeze
+  // them plus the other-bucket into a ring record, then reset the interval.
+  // Deduped by sec: a second tick landing in the same wall second overwrites.
+  const rotateTopicInterval = (sec: number) => {
+    const top: TopicRingEntry[] = [];
+    for (const [topic, count] of curCount) {
+      if (top.length < TOPIC_TOP_K) {
+        top.push({ topic, count, bytes: curBytes.get(topic) ?? 0 });
+        // Keep the running list sorted ascending by count so index 0 is the
+        // weakest incumbent — an O(K) insertion, no full sort.
+        top.sort((a, b) => a.count - b.count);
+      } else if (count > top[0].count) {
+        top[0] = { topic, count, bytes: curBytes.get(topic) ?? 0 };
+        top.sort((a, b) => a.count - b.count);
+      }
+    }
+    const record: TopicRingRecord = {
+      sec,
+      entries: top,
+      otherCount,
+      otherBytes,
+    };
+    if (topicRingHead >= 0 && topicRing[topicRingHead]?.sec === sec) {
+      topicRing[topicRingHead] = record; // same-second dedupe
+    } else {
+      topicRingHead = (topicRingHead + 1) % TOPIC_RING_CAP;
+      topicRing[topicRingHead] = record;
+      topicRingLen = Math.min(topicRingLen + 1, TOPIC_RING_CAP);
+    }
+    curCount.clear();
+    curBytes.clear();
+    otherCount = 0;
+    otherBytes = 0;
+  };
+
+  // Merge the last `windowMinutes` of ring records into the top-N loudest
+  // topics + an exact overflow rate. Runs on the tick (14,400 map ops worst
+  // case at 15 m), never on the batch path.
+  const mergeLoudest = (windowMinutes: number, now: number): LoudestState => {
+    const windowSec = windowMinutes * 60;
+    const merged = new Map<string, { count: number; bytes: number }>();
+    let mergedOtherCount = 0;
+    let seen = 0;
+    for (let i = 0; i < topicRingLen && seen < windowSec; i++) {
+      const idx =
+        ((topicRingHead - i) % TOPIC_RING_CAP + TOPIC_RING_CAP) %
+        TOPIC_RING_CAP;
+      const rec = topicRing[idx];
+      if (!rec) break;
+      seen++;
+      for (const e of rec.entries) {
+        const cur = merged.get(e.topic);
+        if (cur) {
+          cur.count += e.count;
+          cur.bytes += e.bytes;
+        } else {
+          merged.set(e.topic, { count: e.count, bytes: e.bytes });
+        }
+      }
+      mergedOtherCount += rec.otherCount;
+    }
+
+    // Divide by the seconds actually covered so a partly-elapsed window still
+    // reads a true per-second rate.
+    const divisor = Math.max(1, seen);
+
+    // Partial-select the top rows by count (O(distinct × rows)).
+    const rows: LoudestTopic[] = [];
+    let totalCount = mergedOtherCount;
+    const topEntries: TopicRingEntry[] = [];
+    for (const [topic, v] of merged) {
+      totalCount += v.count;
+      if (topEntries.length < LOUDEST_ROWS) {
+        topEntries.push({ topic, count: v.count, bytes: v.bytes });
+        topEntries.sort((a, b) => a.count - b.count);
+      } else if (v.count > topEntries[0].count) {
+        topEntries[0] = { topic, count: v.count, bytes: v.bytes };
+        topEntries.sort((a, b) => a.count - b.count);
+      }
+    }
+    // topEntries is ascending; present strongest first.
+    let shownCount = 0;
+    for (let i = topEntries.length - 1; i >= 0; i--) {
+      const e = topEntries[i];
+      shownCount += e.count;
+      rows.push({
+        topic: e.topic,
+        msgPerSec: e.count / divisor,
+        bytesPerSec: e.bytes / divisor,
+      });
+    }
+
+    const overflowTopics = Math.max(0, merged.size - rows.length);
+    const overflowMsgPerSec = (totalCount - shownCount) / divisor;
+    const elapsedSec = (now - openedAt) / 1000;
+    return {
+      rows,
+      overflowTopics,
+      overflowMsgPerSec,
+      collecting: elapsedSec < windowSec,
+    };
+  };
+
+  // --- Learned $SYS interval -------------------------------------------------
+  // Fold one live $SYS burst into the EMA. Same-wall-second arrivals collapse
+  // to a single burst; the very first burst and any gap spanning a disconnect
+  // are skipped so silence/reconnect never poison the interval.
+  const foldInterval = (sec: number) => {
+    if (sec === lastBurstSec) return; // same burst
+    if (lastBurstSec < 0) {
+      lastBurstSec = sec;
+      return;
+    }
+    if (intervalGapBroken) {
+      intervalGapBroken = false;
+      lastBurstSec = sec;
+      return; // disconnect-spanning gap excluded
+    }
+    let gap = sec - lastBurstSec;
+    lastBurstSec = sec;
+    if (gap < INTERVAL_FLOOR_SEC) gap = INTERVAL_FLOOR_SEC;
+    intervalBurstGaps++;
+    intervalEmaSec =
+      intervalBurstGaps === 1
+        ? gap
+        : INTERVAL_ALPHA * gap + (1 - INTERVAL_ALPHA) * intervalEmaSec;
+    // Seed stays until two burst gaps exist, then the EMA takes over.
+    learnedIntervalSec =
+      intervalBurstGaps >= 2 ? intervalEmaSec : INTERVAL_SEED_SEC;
+  };
+
   // Folds a set of messages into the store. `observed` feeds the rate counters
   // (live only, never backfill); `perMessageRecompute` re-derives tiles after
   // each tracked message (backfill, so sparkline history + cumulative rates
@@ -303,10 +695,21 @@ export const createBrokerStatusStore = (
   ) => {
     for (const m of messages) {
       const b64 = m.payload as unknown as string;
-      if (observed) addObserved(m.timeMs, b64.length);
-
       const topic = m.topic;
       const isSys = topic.startsWith("$SYS/");
+
+      if (observed) {
+        // base64 decodes to ~3/4 of its length — reused for both rate counters.
+        const bytes = Math.floor((b64.length * 3) / 4);
+        addObserved(m.timeMs, b64.length);
+        // Loudest topics track every received message (this client's subs).
+        addTopicCount(topic, bytes);
+        // The learned interval runs off LIVE $SYS bursts only.
+        if (isSys) foldInterval(Math.floor(m.timeMs / 1000));
+      }
+
+      if (isSys && m.timeMs > sysLastSeenMs) sysLastSeenMs = m.timeMs;
+
       if (!isSys && !trackedTopics.has(topic)) continue;
 
       const decoded = base64ToUtf8(b64);
@@ -329,6 +732,84 @@ export const createBrokerStatusStore = (
     pushSample(rt, timeMs, value);
   };
 
+  // Clears a computed/derived tile to the "no data" state (no sample pushed).
+  const clearComputedTile = (key: string) => {
+    const rt = runtime.get(key);
+    if (!rt) return;
+    rt.value = null;
+    rt.text = null;
+    rt.isDuration = false;
+  };
+
+  // Derived-rate guard: both rates positive, sampled within one learned
+  // interval of each other, and the denominator ≥ 1 /s. A counter reset clamps
+  // its rate to 0, which fails "both positive" and voids that interval.
+  const derivedRatio = (
+    numerKey: string,
+    denomKey: string,
+    learnedIntervalMs: number
+  ): number | null => {
+    const numer = runtime.get(numerKey);
+    const denom = runtime.get(denomKey);
+    if (!numer || !denom) return null;
+    if (numer.value === null || denom.value === null) return null;
+    if (numer.value <= 0 || denom.value < 1) return null;
+    if (Math.abs(numer.lastTimeMs - denom.lastTimeMs) > learnedIntervalMs) {
+      return null; // samples don't span the same interval
+    }
+    return numer.value / denom.value;
+  };
+
+  // Fan-out (out/in) and avg msg size (bytes/in), from the hidden cumulative
+  // message-total pair + bytes rate. Filled or cleared per the guards above.
+  const updateDerivedTiles = (learnedIntervalMs: number) => {
+    const fanOut = derivedRatio(
+      "messages_sent_total",
+      "messages_received_total",
+      learnedIntervalMs
+    );
+    if (fanOut !== null) updateComputedTile(FAN_OUT_KEY, fanOut, Date.now());
+    else clearComputedTile(FAN_OUT_KEY);
+
+    // Avg msg size uses the inbound byte rate over the inbound message rate;
+    // the *_total pair carries no byte counts, so the numerator is bytes_rate_in
+    // (documented deviation — see the spec's "*_total feeds ... avg msg size").
+    const avgSize = derivedRatio(
+      "bytes_rate_in",
+      "messages_received_total",
+      learnedIntervalMs
+    );
+    if (avgSize !== null) updateComputedTile(AVG_MSG_SIZE_KEY, avgSize, Date.now());
+    else clearComputedTile(AVG_MSG_SIZE_KEY);
+  };
+
+  // Snapshot a metric's runtime as a health input (value + sample trail).
+  const healthMetric = (key: string): HealthMetric => {
+    const rt = runtime.get(key);
+    return { value: rt?.value ?? null, samples: rt?.samples ?? [] };
+  };
+
+  // Evaluate the health chips on the tick, persisting hysteresis state.
+  const runHealth = (now: number, learnedIntervalMs: number) => {
+    const result = evaluateHealth(
+      {
+        msgs_dropped: healthMetric("msgs_dropped"),
+        msg_rate_in: healthMetric("msg_rate_in"),
+        delivery_backlog: healthMetric("delivery_backlog"),
+        heap_current: healthMetric("heap_current"),
+        heap_max: healthMetric("heap_max"),
+        store_msgs: healthMetric("store_msgs"),
+        store_bytes: healthMetric("store_bytes"),
+        sockets_1min: healthMetric("sockets_1min"),
+      },
+      healthStates,
+      now,
+      learnedIntervalMs
+    );
+    healthStates = result.states;
+    healthChips = result.chips;
+  };
+
   const tick = () => {
     const now = Date.now();
     const nowSec = Math.floor(now / 1000);
@@ -343,6 +824,20 @@ export const createBrokerStatusStore = (
     );
     updateComputedTile(OBSERVED_MSG_KEY, count / elapsedSec, now);
     updateComputedTile(OBSERVED_BYTE_KEY, bytes / elapsedSec, now);
+
+    // Settled per-second observed series for the hero (off the batch path).
+    pushObservedSeries(nowSec);
+
+    // Rotate the open per-topic interval into the ring, then refresh the cached
+    // loudest-topics merge. Both run here (once/sec), never per message.
+    rotateTopicInterval(nowSec);
+    loudestCache = mergeLoudest(rangeMinutes, now);
+
+    // Derived ratios + health, both reading the freshly-sampled runtime.
+    const learnedIntervalMs = learnedIntervalSec * 1000;
+    updateDerivedTiles(learnedIntervalMs);
+    runHealth(now, learnedIntervalMs);
+
     flush(); // one coalesced set per tick
   };
 
@@ -373,6 +868,41 @@ export const createBrokerStatusStore = (
     }
     for (const t of effectiveTiles) runtime.set(t.key, emptyRuntime());
     sysEverSeen = false;
+    sysLastSeenMs = -1;
+
+    // Observed instantaneous series.
+    observedSeries = [];
+    lastObservedSec = -1;
+
+    // Per-topic engine: current interval, ring, and cached merge.
+    curCount.clear();
+    curBytes.clear();
+    otherCount = 0;
+    otherBytes = 0;
+    topicRing.fill(null);
+    topicRingHead = -1;
+    topicRingLen = 0;
+    loudestCache = {
+      rows: [],
+      overflowTopics: 0,
+      overflowMsgPerSec: 0,
+      collecting: true,
+    };
+
+    // Learned $SYS interval EMA.
+    lastBurstSec = -1;
+    intervalEmaSec = INTERVAL_SEED_SEC;
+    intervalBurstGaps = 0;
+    learnedIntervalSec = INTERVAL_SEED_SEC;
+    intervalGapBroken = false;
+
+    // Health hysteresis state.
+    healthStates = new Map();
+    healthChips = [];
+
+    // NOTE: raw-browser per-topic prev-values (spec's resetData list) live in
+    // raw-browser.ts, which the surfaces commit owns — reset there.
+
     // Restart the empty-state grace period from the clear.
     openedAt = Date.now();
     // Invalidate any history backfill still in flight (see dataEpoch).
@@ -397,6 +927,9 @@ export const createBrokerStatusStore = (
     offDisconnected = Events.On(eventSet.mqttDisconnected, () => {
       connected = false;
       stopTicker(); // freeze observed rates while disconnected
+      // The next $SYS burst's gap spans the disconnected period — exclude it
+      // from the learned interval EMA.
+      intervalGapBroken = true;
       flush();
     });
   };
@@ -496,13 +1029,26 @@ export const createBrokerStatusStore = (
     stopTicker();
   };
 
+  // Sets the selected time range (minutes: 1/5/15). Drives the hero window and
+  // the loudest-topics merge; re-merges immediately so the change is visible
+  // without waiting for the next tick.
+  const setRange = (minutes: number) => {
+    if (minutes === rangeMinutes) return;
+    rangeMinutes = minutes;
+    loudestCache = mergeLoudest(rangeMinutes, Date.now());
+    flush();
+  };
+
   return {
     subscribe,
     init,
     reloadMappings,
+    setRange,
     destroy,
     /** Test/inspection helper: current state snapshot. */
     snapshot: () => get({ subscribe }),
+    /** Test/inspection helper: populated depth of the per-topic ring. */
+    topicRingSize: () => topicRingLen,
     connectionId,
   };
 };

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
@@ -242,27 +242,14 @@ const emptyRuntime = (): TileRuntime => ({
 });
 
 /**
- * v1 builtins reclassified `hidden` for v2's eventual layout but kept on the
- * gauges grid until the surfaces commit relocates them to the hero / facts row.
- * Keeping the running app unchanged in the store-engine commit.
+ * Which effective tiles render on the gauges grid. v2 (surfaces commit): a plain
+ * `!hidden` filter. The reclassified v1 builtins (`msg_rate_*`, `uptime`,
+ * `version`) and every brand-new diagnostic/derived metric are `hidden`, so they
+ * leave the grid and reach the view through `metricByKey` (hero, facts row,
+ * health chips, derived tiles) instead. Custom/override tiles and the observed
+ * computed tiles stay visible.
  */
-const KEEP_VISIBLE_WHILE_HIDDEN = new Set<string>([
-  "msg_rate_in",
-  "msg_rate_out",
-  "uptime",
-  "version",
-]);
-
-/**
- * Which effective tiles render on the gauges grid THIS commit. Non-hidden
- * tiles (custom/override tiles, the surviving v1 builtins, the observed
- * computed tiles) always show; the reclassified v1 tiles are grandfathered in;
- * the brand-new hidden diagnostic/derived metrics never do (they reach the view
- * via `metricByKey`). The surfaces commit replaces this with a plain `!hidden`
- * filter once the new consumers exist.
- */
-const isVisibleTile = (tile: MetricTile): boolean =>
-  !tile.hidden || KEEP_VISIBLE_WHILE_HIDDEN.has(tile.key);
+const isVisibleTile = (tile: MetricTile): boolean => !tile.hidden;
 
 export const createBrokerStatusStore = (
   connectionId: number,

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
@@ -31,6 +31,7 @@ import {
   formatMetricValue,
   humanizeDuration,
   type MetricTile,
+  type SelectedCandidate,
   type SysMetricMappingRow,
 } from "./sys-metrics";
 import {
@@ -74,6 +75,22 @@ export const TOPIC_TOP_K = 16;
 export const TOPIC_RING_CAP = 900;
 /** Rows shown in the loudest-topics table. */
 export const LOUDEST_ROWS = 6;
+
+/**
+ * Cap on distinct topics held in the raw-browser map. Brokers that publish a
+ * $SYS subtree per connected client (EMQX) would otherwise grow `latest`
+ * without bound on a busy broker. Past the cap, new topics are dropped (the
+ * ones already bound to tiles keep updating) and a single warning is logged.
+ */
+export const LATEST_TOPIC_CAP = 2000;
+
+/**
+ * Minimum settle time after a (re)connect before trend clauses and tile deltas
+ * may use samples again. A broker restart republishes its whole retained store,
+ * which looks exactly like a rising trend; the effective floor is the larger of
+ * this and three learned $SYS intervals.
+ */
+export const TREND_SETTLE_MIN_MS = 30_000;
 
 // --- Time-range constants ----------------------------------------------------
 export const DEFAULT_RANGE_MINUTES = 5;
@@ -148,9 +165,11 @@ export interface LoudestTopic {
 export interface LoudestState {
   rows: LoudestTopic[];
   /**
-   * Distinct topics beyond the shown rows. A LOWER BOUND (rendered with a
-   * trailing "+") because the per-second other-bucket hides an unknown number
-   * of distinct topics.
+   * Distinct topics beyond the shown rows that survived the per-second top-K
+   * capture. NOT a usable total: both the per-second top-K and the admission
+   * cap discard topics without counting them, so the true figure is unknowable
+   * from here. Treated as a boolean "there is unlisted traffic" by the table,
+   * which names the exact msg/s instead of a topic count.
    */
   overflowTopics: number;
   /** Exact msg/s not attributed to a shown row (merged tail + other-bucket). */
@@ -172,8 +191,23 @@ export interface BrokerStatusState {
   metricByKey: Map<string, MetricSnapshot>;
   /** Raw browser data: newest decoded value per $SYS/* or mapped topic. */
   latestByTopic: Map<string, LatestTopicEntry>;
-  /** Broker connection up/down, driven by the connection's Wails events. */
+  /**
+   * Broker connection up/down, driven by the connection's Wails events. The
+   * automatic reconnect loop counts as down: an unexpected outage emits
+   * `mqttReconnecting`, not `mqttDisconnected`.
+   */
   connected: boolean;
+  /**
+   * True once this store has seen the connection up. Lets the view tell "never
+   * connected" apart from "was connected, now frozen".
+   */
+  everConnected: boolean;
+  /**
+   * Samples older than this are excluded from trend rules and tile deltas, so
+   * a reconnect's retained-store repopulation is not reported as a rising
+   * broker. 0 = no floor. May sit in the future during the settle period.
+   */
+  trendFloorMs: number;
   /** True once any $SYS/* message has been seen (backfill or live). */
   sysEverSeen: boolean;
   /** Epoch ms the window/store opened — the view's 10 s empty-state grace. */
@@ -266,8 +300,17 @@ export const createBrokerStatusStore = (
   // and browsable alongside $SYS/*.
   let trackedTopics = new Set<string>();
 
-  // Raw-browser data: newest decoded value per browsed topic.
+  // Raw-browser data: newest decoded value per browsed topic. Capped at
+  // LATEST_TOPIC_CAP distinct topics; `latestCapWarned` keeps the console
+  // warning to one per cap event.
   const latest = new Map<string, LatestTopicEntry>();
+  let latestCapWarned = false;
+  // Bumped whenever `latest` gains a KEY (not on a value update). Candidate
+  // selection only depends on the key set, so recomputeTiles re-runs the
+  // pattern matching when this changes and reuses the cached winners otherwise.
+  let topicSetVersion = 0;
+  let selectionVersion = -1;
+  const selectionByTile = new Map<string, SelectedCandidate | null>();
 
   // Last {value,timeMs} per cumulative tile, for deriving a /s rate.
   const cumPrev = new Map<string, { value: number; timeMs: number }>();
@@ -330,6 +373,8 @@ export const createBrokerStatusStore = (
   let sysEverSeen = false;
   let sysLastSeenMs = -1;
   let connected = opts.connected ?? true;
+  let everConnected = connected;
+  let trendFloorMs = 0;
   const windowOpenedAt = Date.now();
   let openedAt = windowOpenedAt;
 
@@ -395,6 +440,8 @@ export const createBrokerStatusStore = (
     metricByKey: buildMetricByKey(),
     latestByTopic: latest,
     connected,
+    everConnected,
+    trendFloorMs,
     sysEverSeen,
     windowOpenedAt: openedAt,
     rangeMinutes,
@@ -413,16 +460,31 @@ export const createBrokerStatusStore = (
     if (rt.samples.length > SPARKLINE_CAP) rt.samples.shift();
   };
 
+  // Recomputes each tile's winning candidate. Pattern matching costs
+  // O(tiles × candidates × topics), so it only re-runs when the topic KEY set
+  // changed (or the mappings did) — on a broker with thousands of $SYS topics
+  // that turns a per-batch scan into a rare one.
+  const refreshSelections = () => {
+    if (selectionVersion === topicSetVersion) return;
+    const topics = Array.from(latest.keys());
+    selectionByTile.clear();
+    for (const tile of effectiveTiles) {
+      if (tile.computed) continue;
+      selectionByTile.set(tile.key, selectCandidate(tile, topics));
+    }
+    selectionVersion = topicSetVersion;
+  };
+
   // Re-evaluates every non-computed tile against the current `latest` topics.
   // Cheap (≈ a dozen tiles); the per-tile timeMs guard makes repeat calls no-op
   // when nothing new arrived, so calling it once per batch is enough.
   const recomputeTiles = () => {
-    const topics = Array.from(latest.keys());
+    refreshSelections();
     for (const tile of effectiveTiles) {
       if (tile.computed) continue;
       const rt = runtime.get(tile.key);
       if (!rt) continue;
-      const sel = selectCandidate(tile, topics);
+      const sel = selectionByTile.get(tile.key);
       if (!sel) continue;
       const entry = latest.get(sel.topic);
       if (!entry) continue;
@@ -506,21 +568,33 @@ export const createBrokerStatusStore = (
   // Pushes the settled per-second observed msgs/s (sec(now)-2, fully arrived at
   // the ~300 ms batch lag) into observedSeries, backfilling any skipped seconds
   // from the ring and skipping the partial first second after window-open.
+  //
+  // The cursor is dropped to -1 whenever the connection goes down, so a resumed
+  // series starts at "now" instead of inventing a zero for every second of the
+  // outage. The catch-up is clamped anyway: a suspended laptop can wake with
+  // hours of skipped seconds, and only the newest SPARKLINE_CAP of them could
+  // survive the trim.
   const pushObservedSeries = (nowSec: number) => {
     const target = nowSec - 2;
     if (lastObservedSec < 0) {
-      // First tick: the window-open second is partial, so start pushing the
-      // second AFTER it. Never backfill before the window opened.
+      // First tick (or the first after an outage): the current second is
+      // partial, so start pushing the second AFTER it. Never backfill before
+      // the window opened.
       lastObservedSec = Math.max(
         Math.floor(openedAt / 1000),
         target - 1
       );
     }
-    for (let sec = lastObservedSec + 1; sec <= target; sec++) {
+    if (target <= lastObservedSec) return;
+    const from = Math.max(lastObservedSec + 1, target - SPARKLINE_CAP + 1);
+    for (let sec = from; sec <= target; sec++) {
       observedSeries.push({ t: sec * 1000, v: bucketCountForSec(sec) });
-      if (observedSeries.length > SPARKLINE_CAP) observedSeries.shift();
     }
-    if (target > lastObservedSec) lastObservedSec = target;
+    // One splice, not a shift per pushed sample.
+    if (observedSeries.length > SPARKLINE_CAP) {
+      observedSeries.splice(0, observedSeries.length - SPARKLINE_CAP);
+    }
+    lastObservedSec = target;
   };
 
   // --- Per-topic engine ------------------------------------------------------
@@ -541,9 +615,48 @@ export const createBrokerStatusStore = (
     }
   };
 
+  // Folds `add` into `base`, keeping the strongest TOPIC_TOP_K topics and
+  // collapsing everything it drops into the other-scalars. Used when two ticks
+  // land in the same wall second: replacing the head record would discard the
+  // first tick's counts outright.
+  const mergeRingRecords = (
+    base: TopicRingRecord,
+    add: TopicRingRecord
+  ): TopicRingRecord => {
+    const byTopic = new Map<string, TopicRingEntry>();
+    for (const e of base.entries) {
+      byTopic.set(e.topic, { topic: e.topic, count: e.count, bytes: e.bytes });
+    }
+    for (const e of add.entries) {
+      const cur = byTopic.get(e.topic);
+      if (cur) {
+        cur.count += e.count;
+        cur.bytes += e.bytes;
+      } else {
+        byTopic.set(e.topic, { topic: e.topic, count: e.count, bytes: e.bytes });
+      }
+    }
+    // At most 2 × TOPIC_TOP_K entries, so a plain sort is cheap and exact.
+    const all = Array.from(byTopic.values()).sort((a, b) => b.count - a.count);
+    const entries = all.slice(0, TOPIC_TOP_K);
+    let dropCount = base.otherCount + add.otherCount;
+    let dropBytes = base.otherBytes + add.otherBytes;
+    for (let i = TOPIC_TOP_K; i < all.length; i++) {
+      dropCount += all[i].count;
+      dropBytes += all[i].bytes;
+    }
+    return {
+      sec: base.sec,
+      entries,
+      otherCount: dropCount,
+      otherBytes: dropBytes,
+    };
+  };
+
   // Partial-select the interval's top-K topics by count (O(cap × K)), freeze
   // them plus the other-bucket into a ring record, then reset the interval.
-  // Deduped by sec: a second tick landing in the same wall second overwrites.
+  // Deduped by sec: a second tick landing in the same wall second merges into
+  // the head record rather than replacing it.
   const rotateTopicInterval = (sec: number) => {
     const top: TopicRingEntry[] = [];
     for (const [topic, count] of curCount) {
@@ -563,8 +676,9 @@ export const createBrokerStatusStore = (
       otherCount,
       otherBytes,
     };
-    if (topicRingHead >= 0 && topicRing[topicRingHead]?.sec === sec) {
-      topicRing[topicRingHead] = record; // same-second dedupe
+    const head = topicRingHead >= 0 ? topicRing[topicRingHead] : null;
+    if (head && head.sec === sec) {
+      topicRing[topicRingHead] = mergeRingRecords(head, record);
     } else {
       topicRingHead = (topicRingHead + 1) % TOPIC_RING_CAP;
       topicRing[topicRingHead] = record;
@@ -581,6 +695,10 @@ export const createBrokerStatusStore = (
   // case at 15 m), never on the batch path.
   const mergeLoudest = (windowMinutes: number, now: number): LoudestState => {
     const windowSec = windowMinutes * 60;
+    // Records are pushed newest-first, so the first out-of-window record ends
+    // the scan. Without this age gate a ring frozen by an outage keeps feeding
+    // "over the last 5m" rates from traffic that stopped long ago.
+    const oldestSec = Math.floor(now / 1000) - windowSec;
     const merged = new Map<string, { count: number; bytes: number }>();
     let mergedOtherCount = 0;
     let seen = 0;
@@ -590,6 +708,7 @@ export const createBrokerStatusStore = (
         TOPIC_RING_CAP;
       const rec = topicRing[idx];
       if (!rec) break;
+      if (rec.sec <= oldestSec) break;
       seen++;
       for (const e of rec.entries) {
         const cur = merged.get(e.topic);
@@ -689,8 +808,10 @@ export const createBrokerStatusStore = (
         // base64 decodes to ~3/4 of its length — reused for both rate counters.
         const bytes = Math.floor((b64.length * 3) / 4);
         addObserved(m.timeMs, b64.length);
-        // Loudest topics track every received message (this client's subs).
-        addTopicCount(topic, bytes);
+        // Loudest topics are about USER traffic: $SYS is this window's own
+        // instrumentation and would otherwise fill the whole table on a quiet
+        // broker with $SYS/# subscribed.
+        if (!isSys) addTopicCount(topic, bytes);
         // The learned interval runs off LIVE $SYS bursts only.
         if (isSys) foldInterval(Math.floor(m.timeMs / 1000));
       }
@@ -698,13 +819,24 @@ export const createBrokerStatusStore = (
       if (isSys && m.timeMs > sysLastSeenMs) sysLastSeenMs = m.timeMs;
 
       if (!isSys && !trackedTopics.has(topic)) continue;
-
-      const decoded = base64ToUtf8(b64);
-      const prev = latest.get(topic);
-      if (!prev || m.timeMs >= prev.timeMs) {
-        latest.set(topic, { value: decoded, timeMs: m.timeMs });
-      }
       if (isSys) sysEverSeen = true;
+
+      const prev = latest.get(topic);
+      if (prev === undefined) {
+        if (latest.size >= LATEST_TOPIC_CAP) {
+          if (!latestCapWarned) {
+            latestCapWarned = true;
+            console.warn(
+              `broker-status: browsing at most ${LATEST_TOPIC_CAP} topics; further new topics are ignored`
+            );
+          }
+          continue;
+        }
+        latest.set(topic, { value: base64ToUtf8(b64), timeMs: m.timeMs });
+        topicSetVersion++;
+      } else if (m.timeMs >= prev.timeMs) {
+        latest.set(topic, { value: base64ToUtf8(b64), timeMs: m.timeMs });
+      }
       if (perMessageRecompute) recomputeTiles();
     }
     if (!perMessageRecompute) recomputeTiles();
@@ -791,10 +923,20 @@ export const createBrokerStatusStore = (
       },
       healthStates,
       now,
-      learnedIntervalMs
+      learnedIntervalMs,
+      trendFloorMs
     );
     healthStates = result.states;
     healthChips = result.chips;
+  };
+
+  // Greys every rendered chip. Called when the connection drops: the tick that
+  // would have recomputed staleness has just been stopped, so without this the
+  // strip keeps showing a confident green dot on a dead connection.
+  const freezeHealthChips = () => {
+    healthChips = healthChips.map((c) =>
+      c.render && !c.stale ? { ...c, stale: true, qualifier: "" } : c
+    );
   };
 
   const tick = () => {
@@ -844,9 +986,14 @@ export const createBrokerStatusStore = (
   let offClear: (() => void) | null = null;
   let offConnected: (() => void) | null = null;
   let offDisconnected: (() => void) | null = null;
+  let offReconnecting: (() => void) | null = null;
 
   const resetData = () => {
     latest.clear();
+    latestCapWarned = false;
+    topicSetVersion++;
+    selectionVersion = -1;
+    selectionByTile.clear();
     cumPrev.clear();
     for (const b of buckets) {
       b.sec = -1;
@@ -896,6 +1043,36 @@ export const createBrokerStatusStore = (
     dataEpoch++;
   };
 
+  // Connection came up (or back up). Trends and tile deltas are held off for a
+  // settle period: a restarted broker republishes its retained store, which is
+  // a genuine rise that says nothing about broker health.
+  const onConnectionUp = () => {
+    connected = true;
+    everConnected = true;
+    trendFloorMs =
+      Date.now() +
+      Math.max(TREND_SETTLE_MIN_MS, 3 * learnedIntervalSec * 1000);
+    startTicker();
+    flush();
+  };
+
+  // Connection went down, by an explicit disconnect or an outage. Freezes every
+  // live surface: rates stop, the observed series breaks rather than drawing
+  // zeros, and the chips grey.
+  const onConnectionDown = () => {
+    connected = false;
+    stopTicker(); // freeze observed rates while the broker is unreachable
+    // The next $SYS burst's gap spans the down period — exclude it from the
+    // learned interval EMA.
+    intervalGapBroken = true;
+    // Drop the settled-second cursor so the resumed series starts at "now"
+    // instead of backfilling one fabricated zero per second of the outage.
+    // The view turns the resulting time jump into a line break.
+    lastObservedSec = -1;
+    freezeHealthChips();
+    flush();
+  };
+
   const bindListeners = () => {
     offMessages = Events.On(eventSet.mqttMessages, (e: any) => {
       const messages: mqtt.MqttMessage[] = e.data ?? [];
@@ -906,19 +1083,14 @@ export const createBrokerStatusStore = (
       resetData();
       flush();
     });
-    offConnected = Events.On(eventSet.mqttConnected, () => {
-      connected = true;
-      startTicker();
-      flush();
-    });
-    offDisconnected = Events.On(eventSet.mqttDisconnected, () => {
-      connected = false;
-      stopTicker(); // freeze observed rates while disconnected
-      // The next $SYS burst's gap spans the disconnected period — exclude it
-      // from the learned interval EMA.
-      intervalGapBroken = true;
-      flush();
-    });
+    offConnected = Events.On(eventSet.mqttConnected, onConnectionUp);
+    offDisconnected = Events.On(eventSet.mqttDisconnected, onConnectionDown);
+    // An UNEXPECTED outage emits mqttReconnecting, never mqttDisconnected: the
+    // backend keeps the connection object alive while its retry loop runs. To
+    // this window that is the same thing as being down, so it takes the same
+    // path — otherwise the ticker keeps drawing a fabricated zero trace and the
+    // chips stay green for the whole outage.
+    offReconnecting = Events.On(eventSet.mqttReconnecting, onConnectionDown);
   };
 
   const applyMappings = (rows: SysMetricMappingRow[]) => {
@@ -931,6 +1103,9 @@ export const createBrokerStatusStore = (
     runtime = nextRuntime;
     effectiveTiles = tiles;
     trackedTopics = new Set(rows.map((r) => r.topic).filter((t) => t !== ""));
+    // The tile set changed, so the cached candidate winners are stale.
+    selectionVersion = -1;
+    selectionByTile.clear();
   };
 
   // Binding rows satisfy SysMetricMappingRow structurally (id + all fields), so
@@ -1012,7 +1187,9 @@ export const createBrokerStatusStore = (
     offClear?.();
     offConnected?.();
     offDisconnected?.();
-    offMessages = offClear = offConnected = offDisconnected = null;
+    offReconnecting?.();
+    offMessages = offClear = offConnected = null;
+    offDisconnected = offReconnecting = null;
     stopTicker();
   };
 

--- a/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
+++ b/frontend/src/views/BrokerStatusWindow/broker-status-store.ts
@@ -89,8 +89,13 @@ export const LATEST_TOPIC_CAP = 2000;
  * may use samples again. A broker restart republishes its whole retained store,
  * which looks exactly like a rising trend; the effective floor is the larger of
  * this and three learned $SYS intervals.
+ *
+ * Set to the longest health rule window (the store chip's 120 s) so no rule can
+ * reach its verdict on a window that is still mostly repopulation. It is a
+ * heuristic, not a guarantee: a broker whose store takes longer than this to
+ * refill will still raise the chip once.
  */
-export const TREND_SETTLE_MIN_MS = 30_000;
+export const TREND_SETTLE_MIN_MS = 120_000;
 
 // --- Time-range constants ----------------------------------------------------
 export const DEFAULT_RANGE_MINUTES = 5;

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.spec.json
@@ -2,7 +2,7 @@
   "$schema": "../../../../design-system/component-spec.schema.json",
   "name": "BrokerStatusView",
   "tier": "view",
-  "description": "Body of the Broker Status window: responsive stat-tile grid with an always-last add-tile '+', a no-$SYS empty state with an add-subscription CTA, and a collapsible raw $SYS topic browser. Reads a BrokerStatusStore and drives the MetricMappingEditor.",
+  "description": "Body of the Broker Status window (v2): sticky health strip (or capability notice), traffic hero chart, loudest-topics table, gauges grid with an always-last '+', facts row, and a collapsible raw $SYS browser with a derived rate column. Keeps the v1 no-$SYS empty state + add-subscription CTA. Reads a BrokerStatusStore and drives the MetricMappingEditor.",
   "status": "story-only",
   "figma": {
     "fileKey": "",
@@ -27,6 +27,7 @@
   ],
   "tokens": [
     "outline",
+    "elevation-0",
     "elevation-1",
     "secondary-text",
     "emphasis",
@@ -36,11 +37,15 @@
   "dependencies": [
     "StatTile",
     "MetricMappingEditor",
+    "HealthStrip",
+    "HeroChart",
+    "LoudestTopics",
+    "FactsRow",
     "Icon",
     "IconButton",
     "Tooltip",
     "Button",
     "BaseInput"
   ],
-  "notes": "Figma is not linked yet; stories use a mock BrokerStatusStore from fixtures. Age labels in the raw browser derive from a single shared 1 s tick (raw-browser.ts) referenced only while expanded, so no per-row timers run when collapsed."
+  "notes": "Figma is not linked yet; stories use a mock BrokerStatusStore from fixtures. Age labels in the raw browser derive from a single shared 1 s tick (raw-browser.ts) referenced only while expanded, so no per-row timers run when collapsed. The derived rate column tracks per-topic prev-values in a tracker owned here and reset on a history clear."
 }

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
@@ -193,13 +193,17 @@
   };
 
   // --- Gauge tiles: delta arrow + hover-panel inputs -------------------------
-  // Percentage change across the visible sparkline window (last vs first).
+  // Percentage change across the visible sparkline window (last vs first). A
+  // zero baseline makes a percentage meaningless, so growth from zero returns
+  // Infinity and the tile shows the direction glyph without a number.
   const deltaPctFor = (tile: BrokerTileView): number | undefined => {
     const s = tile.samples;
     if (!s || s.length < 2) return undefined;
     const first = s[0].v;
     const last = s[s.length - 1].v;
-    if (first === 0) return undefined;
+    if (first === 0) {
+      return last === 0 ? undefined : Number.POSITIVE_INFINITY;
+    }
     return ((last - first) / Math.abs(first)) * 100;
   };
 

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
-  // Body of the detached Broker Status window: a responsive grid of stat tiles
-  // (builtins + custom/override mappings) with an always-last "+" tile, an
-  // empty-state block for brokers that publish no $SYS, and a collapsible raw
-  // $SYS topic browser. The window shell owns the store's lifecycle; this view
-  // only reads the store and drives the mapping editor.
+  // Body of the detached Broker Status window. v2 layout, top to bottom:
+  // sticky health strip (or a capability notice when no $SYS card is showing),
+  // the traffic hero chart, the loudest-topics table, the gauges grid (with an
+  // always-last "+"), the facts row, and the collapsible raw $SYS browser. The
+  // v1 no-$SYS empty state + add-subscription CTA is kept. The window shell owns
+  // the store's lifecycle and the header (pill + range selector); this view only
+  // reads the store and drives the mapping editor.
   import { onDestroy } from "svelte";
   import { writable } from "svelte/store";
   import StatTile from "../StatTile/StatTile.svelte";
   import MetricMappingEditor from "../MetricMappingEditor/MetricMappingEditor.svelte";
+  import HealthStrip from "../HealthStrip/HealthStrip.svelte";
+  import HeroChart from "../HeroChart/HeroChart.svelte";
+  import LoudestTopics from "../LoudestTopics/LoudestTopics.svelte";
+  import FactsRow from "../FactsRow/FactsRow.svelte";
   import Icon from "@/components/Icon/Icon.svelte";
   import IconButton from "@/components/Button/IconButton.svelte";
   import Tooltip from "@/components/Tooltip/Tooltip.svelte";
@@ -15,8 +21,14 @@
   import BaseInput from "@/components/InputFields/BaseInput.svelte";
   import { addToast } from "@/components/Toast/Toast.svelte";
   import subscriptions from "@/stores/subscriptions";
-  import type { BrokerStatusStore } from "../../broker-status-store";
-  import { nowTick, formatAge } from "./raw-browser";
+  import type {
+    BrokerStatusStore,
+    BrokerStatusState,
+    BrokerTileView,
+  } from "../../broker-status-store";
+  import type { HeroSeries } from "../HeroChart/hero-chart-option";
+  import { formatMetricValue } from "../../sys-metrics";
+  import { nowTick, formatAge, createRawRateTracker } from "./raw-browser";
 
   export let store: BrokerStatusStore;
   export let connectionId: number;
@@ -24,6 +36,11 @@
   const SYS_TOPIC = "$SYS/#";
   const EMPTY_GRACE_MS = 10_000;
   const MAX_RAW_ROWS = 500;
+  // Tile sparklines always span 15 m, so the delta arrow and hover panel name it.
+  const TILE_WINDOW = "15m";
+  // Minimum gap before a null break is inserted in a hero line (across a
+  // disconnect the ticker stops, so consecutive samples jump in time).
+  const OBSERVED_GAP_MS = 5_000;
 
   // Mapping editor, owned here so the "+" tile and pin buttons can open it.
   const editorOpen = writable(false);
@@ -43,9 +60,11 @@
     editorOpen.set(true);
   };
 
-  // Empty-state grace: only offer the "no $SYS" explanation once the window
-  // has been open ~10 s without seeing any $SYS message. Re-arm when the store
-  // resets its opened-at clock (history cleared), but not on every flush.
+  // Empty-state grace: only offer the "no $SYS" explanation once the window has
+  // been open ~10 s without seeing any $SYS message. Re-arm when the store
+  // resets its opened-at clock (history cleared); reset the raw-rate tracker
+  // there too (its prev-values must not survive a clear).
+  const rateTracker = createRawRateTracker();
   let graceElapsed = false;
   let graceTimer: ReturnType<typeof setTimeout> | null = null;
   let lastOpenedAt = -1;
@@ -59,6 +78,7 @@
 
   $: if ($store.windowOpenedAt !== lastOpenedAt) {
     lastOpenedAt = $store.windowOpenedAt;
+    rateTracker.reset();
     armGrace($store.windowOpenedAt);
   }
 
@@ -68,14 +88,126 @@
 
   $: showEmptyState = !$store.sysEverSeen && $store.connected && graceElapsed;
 
+  // Health strip vs capability notice (deduplicated against the v1 empty card):
+  // the strip shows once any chip has data. The notice only stands in when no
+  // $SYS has EVER been seen (a broker with $SYS but no health signals gets
+  // neither strip nor notice, and a healthy broker's chip warm-up must not
+  // flash a false "no $SYS" claim) and the empty card is not already showing.
+  $: hasHealth = $store.health.some((c) => c.render);
+  $: showCapabilityNotice =
+    graceElapsed && !hasHealth && !showEmptyState && !$store.sysEverSeen;
+
   // In the empty state (no $SYS ever seen, grace elapsed) the builtin tiles can
   // never populate, so hide the ones with no data and show only tiles that
-  // actually carry a value (observed rates, any custom tiles with data) plus
-  // the always-present "+". During the grace window keep every tile visible so
-  // it can still fill in from retained $SYS as messages arrive.
+  // actually carry a value (observed rates, any custom tiles with data) plus the
+  // always-present "+". During the grace window keep every tile visible so it
+  // can still fill in from retained $SYS as messages arrive.
   $: visibleTiles = showEmptyState
     ? $store.tiles.filter((tile) => tile.valueKind !== "empty")
     : $store.tiles;
+
+  // --- Hero series -----------------------------------------------------------
+  // Inserts a null break wherever consecutive samples jump more than `maxGapMs`
+  // apart (a disconnect gap) so ECharts draws a break instead of bridging it.
+  const withGaps = (
+    pts: { t: number; v: number | null }[],
+    maxGapMs: number
+  ): { t: number; v: number | null }[] => {
+    if (pts.length < 2) return pts;
+    const out: { t: number; v: number | null }[] = [];
+    for (let i = 0; i < pts.length; i++) {
+      if (i > 0 && pts[i].t - pts[i - 1].t > maxGapMs) {
+        out.push({ t: (pts[i - 1].t + pts[i].t) / 2, v: null });
+      }
+      out.push(pts[i]);
+    }
+    return out;
+  };
+
+  const brokerTooltip = (state: BrokerStatusState, dir: "in" | "out"): string => {
+    const a5 = state.metricByKey.get(`msg_rate_${dir}_5min`)?.value ?? null;
+    const a15 = state.metricByKey.get(`msg_rate_${dir}_15min`)?.value ?? null;
+    let text = "1 min average, from the broker";
+    const segs: string[] = [];
+    if (a5 !== null) segs.push(`5m: ${formatMetricValue(a5)}`);
+    if (a15 !== null) segs.push(`15m: ${formatMetricValue(a15)}`);
+    if (segs.length > 0) text += `; ${segs.join(", ")}`;
+    return text;
+  };
+
+  const buildHeroSeries = (state: BrokerStatusState): HeroSeries[] => {
+    const m = state.metricByKey;
+    const inS = m.get("msg_rate_in")?.samples ?? [];
+    const outS = m.get("msg_rate_out")?.samples ?? [];
+    const observed = state.observedSeries ?? [];
+    const hasBroker = inS.length > 0 || outS.length > 0;
+    const brokerGap = Math.max(30_000, 3 * state.learnedIntervalMs);
+    const series: HeroSeries[] = [];
+    if (inS.length > 0) {
+      series.push({
+        id: "in",
+        label: "In",
+        points: withGaps(inS.map((p) => ({ t: p.t, v: p.v })), brokerGap),
+        dashed: false,
+        emphasis: true,
+        tooltip: brokerTooltip(state, "in"),
+      });
+    }
+    if (outS.length > 0) {
+      series.push({
+        id: "out",
+        label: "Out",
+        points: withGaps(outS.map((p) => ({ t: p.t, v: p.v })), brokerGap),
+        dashed: false,
+        emphasis: false,
+        tooltip: brokerTooltip(state, "out"),
+      });
+    }
+    // Observed is dashed and muted when broker series are present; promoted to a
+    // solid primary line when it stands alone.
+    series.push({
+      id: "observed",
+      label: "Observed",
+      points: withGaps(
+        observed.map((p) => ({ t: p.t, v: p.v })),
+        OBSERVED_GAP_MS
+      ),
+      dashed: hasBroker,
+      emphasis: false,
+      tooltip: "this second, as received by this client",
+    });
+    return series;
+  };
+
+  $: heroSeries = buildHeroSeries($store);
+
+  // --- Facts row -------------------------------------------------------------
+  $: facts = {
+    version: $store.metricByKey.get("version")?.text ?? null,
+    uptimeSeconds: $store.metricByKey.get("uptime")?.value ?? null,
+    clientsConnected: $store.metricByKey.get("clients_connected")?.value ?? null,
+    clientsDisconnected:
+      $store.metricByKey.get("clients_disconnected")?.value ?? null,
+    clientsExpired: $store.metricByKey.get("clients_expired")?.value ?? null,
+    avgMsgSize: $store.metricByKey.get("avg_msg_size")?.value ?? null,
+  };
+
+  // --- Gauge tiles: delta arrow + hover-panel inputs -------------------------
+  // Percentage change across the visible sparkline window (last vs first).
+  const deltaPctFor = (tile: BrokerTileView): number | undefined => {
+    const s = tile.samples;
+    if (!s || s.length < 2) return undefined;
+    const first = s[0].v;
+    const last = s[s.length - 1].v;
+    if (first === 0) return undefined;
+    return ((last - first) / Math.abs(first)) * 100;
+  };
+
+  // Exact, unabbreviated value string for the tile's hover panel.
+  const exactFor = (tile: BrokerTileView): string =>
+    tile.valueKind === "number" && !tile.isDuration && tile.value !== null
+      ? tile.value.toLocaleString()
+      : tile.display;
 
   // Whether this connection still has a $SYS/# subscription row — drives the
   // "Add $SYS/# subscription" CTA in the empty state.
@@ -119,9 +251,9 @@
   let rawFilter = "";
 
   // Only build and sort the entry list while the browser is expanded; when
-  // collapsed the header just needs the topic count, which the store's Map
-  // gives in O(1). Under a busy broker this skips a sort of every $SYS topic on
-  // every flush.
+  // collapsed the header just needs the topic count, which the store's Map gives
+  // in O(1). Under a busy broker this skips a sort of every $SYS topic on every
+  // flush.
   $: rawEntries = rawExpanded
     ? Array.from($store.latestByTopic.entries())
         .map(([topic, entry]) => ({
@@ -137,38 +269,53 @@
     rawFilterLc === ""
       ? rawEntries
       : rawEntries.filter((r) => r.topic.toLowerCase().includes(rawFilterLc));
-  $: rawShown = rawFiltered.slice(0, MAX_RAW_ROWS);
+  // Fold each shown row's newest value into the rate tracker and attach its
+  // derived /s rate (null for non-counter topics). Idempotent per (topic, time).
+  $: rawShown = rawFiltered.slice(0, MAX_RAW_ROWS).map((r) => ({
+    ...r,
+    rate: rateTracker.update(r.topic, r.value, r.timeMs),
+  }));
   $: rawHidden = rawFiltered.length - rawShown.length;
 </script>
 
-<div class="flex flex-col gap-4">
-  <!-- Tile grid: builtins + custom/override tiles, then the always-last +.
-       Dimmed while disconnected so the frozen values read as stale in the body,
-       not only in the shell's banner. -->
+<div class="flex flex-col gap-4 p-4">
+  <!-- Health strip (sticky) or capability notice. -->
+  {#if hasHealth}
+    <div class="sticky top-0 z-10 -mx-4 bg-elevation-0 px-4 pb-2 pt-1">
+      <HealthStrip health={$store.health} />
+    </div>
+  {:else if showCapabilityNotice}
+    <div class="rounded border border-outline bg-elevation-1 px-3 py-2 text-sm text-secondary-text">
+      No $SYS metrics are visible on this connection. Showing what this client
+      can measure.
+    </div>
+  {/if}
+
+  <!-- Traffic hero: msgs/s in and out with the client-observed series. -->
+  <HeroChart series={heroSeries} windowMinutes={$store.rangeMinutes} />
+
+  <!-- Loudest topics (this client's subscriptions). -->
+  <LoudestTopics loudest={$store.loudest} />
+
+  <!-- Tile grid: gauges + custom/override tiles, then the always-last +. Dimmed
+       while disconnected so the frozen values read as stale in the body, not
+       only in the shell's banner. -->
   <div
     class="grid grid-cols-[repeat(auto-fill,minmax(170px,1fr))] gap-3 transition-opacity"
     class:opacity-70={!$store.connected}
   >
     {#each visibleTiles as tile (tile.key)}
-      {#if tile.tooltip}
-        <Tooltip text={tile.tooltip} class="h-full">
-          <StatTile
-            label={tile.label}
-            value={tile.display}
-            kind={tile.valueKind === "text" ? "text" : "number"}
-            points={tile.samples}
-            noData={tile.valueKind === "empty"}
-          />
-        </Tooltip>
-      {:else}
-        <StatTile
-          label={tile.label}
-          value={tile.display}
-          kind={tile.valueKind === "text" ? "text" : "number"}
-          points={tile.samples}
-          noData={tile.valueKind === "empty"}
-        />
-      {/if}
+      <StatTile
+        label={tile.label}
+        value={tile.display}
+        kind={tile.valueKind === "text" ? "text" : "number"}
+        points={tile.samples}
+        noData={tile.valueKind === "empty"}
+        deltaPct={deltaPctFor(tile)}
+        exact={exactFor(tile)}
+        description={tile.tooltip}
+        windowName={TILE_WINDOW}
+      />
     {/each}
 
     <Tooltip text="Add metric tile" class="h-full">
@@ -213,6 +360,16 @@
     </div>
   {/if}
 
+  <!-- Facts: broker/version, uptime, sessions, avg msg size. -->
+  <FactsRow
+    version={facts.version}
+    uptimeSeconds={facts.uptimeSeconds}
+    clientsConnected={facts.clientsConnected}
+    clientsDisconnected={facts.clientsDisconnected}
+    clientsExpired={facts.clientsExpired}
+    avgMsgSize={facts.avgMsgSize}
+  />
+
   <!-- Collapsible raw $SYS browser. -->
   <div class="flex flex-col rounded border border-outline bg-elevation-1">
     <button
@@ -252,6 +409,7 @@
                 <tr class="text-left text-secondary-text">
                   <th class="py-1 pr-3 font-normal">Topic</th>
                   <th class="py-1 pr-3 font-normal">Latest</th>
+                  <th class="py-1 pr-3 font-normal">Rate</th>
                   <th class="py-1 pr-3 font-normal">Age</th>
                   <th class="py-1 font-normal"></th>
                 </tr>
@@ -266,6 +424,11 @@
                       class="max-w-[180px] truncate py-1 pr-3 font-mono tabular-nums text-secondary-text"
                     >
                       {row.value}
+                    </td>
+                    <td
+                      class="whitespace-nowrap py-1 pr-3 font-mono tabular-nums text-secondary-text"
+                    >
+                      {row.rate !== null ? `${formatMetricValue(row.rate)}/s` : ""}
                     </td>
                     <td class="whitespace-nowrap py-1 pr-3 text-secondary-text">
                       {formatAge($nowTick, row.timeMs)}

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
@@ -127,7 +127,7 @@
   const brokerTooltip = (state: BrokerStatusState, dir: "in" | "out"): string => {
     const a5 = state.metricByKey.get(`msg_rate_${dir}_5min`)?.value ?? null;
     const a15 = state.metricByKey.get(`msg_rate_${dir}_15min`)?.value ?? null;
-    let text = "1 min average, from the broker";
+    let text = "1m average, from the broker";
     const segs: string[] = [];
     if (a5 !== null) segs.push(`5m: ${formatMetricValue(a5)}`);
     if (a15 !== null) segs.push(`15m: ${formatMetricValue(a15)}`);
@@ -197,6 +197,9 @@
   // zero baseline makes a percentage meaningless, so growth from zero returns
   // Infinity and the tile shows the direction glyph without a number.
   const deltaPctFor = (tile: BrokerTileView): number | undefined => {
+    // Custom tiles with a unit can be interval scales (temperature and the
+    // like) where percent change is meaningless; skip the delta for those.
+    if (tile.key.startsWith("custom:") && tile.unit) return undefined;
     const s = tile.samples;
     if (!s || s.length < 2) return undefined;
     const first = s[0].v;
@@ -210,7 +213,7 @@
   // Exact, unabbreviated value string for the tile's hover panel.
   const exactFor = (tile: BrokerTileView): string =>
     tile.valueKind === "number" && !tile.isDuration && tile.value !== null
-      ? tile.value.toLocaleString()
+      ? tile.value.toLocaleString(undefined, { maximumFractionDigits: 2 })
       : tile.display;
 
   // Whether this connection still has a $SYS/# subscription row — drives the
@@ -285,7 +288,7 @@
 <div class="flex flex-col gap-4 p-4">
   <!-- Health strip (sticky) or capability notice. -->
   {#if hasHealth}
-    <div class="sticky top-0 z-10 -mx-4 bg-elevation-0 px-4 pb-2 pt-1">
+    <div class="sticky top-0 z-10 -mx-4 border-b border-divider bg-elevation-0 px-4 pb-2 pt-1">
       <HealthStrip health={$store.health} />
     </div>
   {:else if showCapabilityNotice}
@@ -295,18 +298,19 @@
     </div>
   {/if}
 
-  <!-- Traffic hero: msgs/s in and out with the client-observed series. -->
+  <!-- All data surfaces dim together while disconnected so the frozen values
+       read as stale in the body, not only in the shell's banner. -->
+  <div class="flex flex-col gap-4 transition-opacity" class:opacity-60={!$store.connected}>
+
+  <!-- Traffic hero: msg/s in and out with the client-observed series. -->
   <HeroChart series={heroSeries} windowMinutes={$store.rangeMinutes} />
 
   <!-- Loudest topics (this client's subscriptions). -->
   <LoudestTopics loudest={$store.loudest} />
 
-  <!-- Tile grid: gauges + custom/override tiles, then the always-last +. Dimmed
-       while disconnected so the frozen values read as stale in the body, not
-       only in the shell's banner. -->
+  <!-- Tile grid: gauges + custom/override tiles, then the always-last +. -->
   <div
-    class="grid grid-cols-[repeat(auto-fill,minmax(170px,1fr))] gap-3 transition-opacity"
-    class:opacity-70={!$store.connected}
+    class="grid grid-cols-[repeat(auto-fill,minmax(170px,1fr))] gap-3"
   >
     {#each visibleTiles as tile (tile.key)}
       <StatTile
@@ -374,7 +378,11 @@
     avgMsgSize={facts.avgMsgSize}
   />
 
-  <!-- Collapsible raw $SYS browser. -->
+  </div>
+
+  <!-- Collapsible raw $SYS browser (hidden until a first topic arrives: an
+       empty expandable under the no-$SYS card reads as dead weight). -->
+  {#if $store.latestByTopic.size > 0}
   <div class="flex flex-col rounded border border-outline bg-elevation-1">
     <button
       type="button"
@@ -408,29 +416,29 @@
           </span>
         {:else}
           <div class="max-h-[320px] overflow-auto">
-            <table class="w-full border-collapse text-sm">
+            <table class="w-full table-fixed border-collapse text-sm">
               <thead>
                 <tr class="text-left text-secondary-text">
-                  <th class="py-1 pr-3 font-normal">Topic</th>
-                  <th class="py-1 pr-3 font-normal">Latest</th>
-                  <th class="py-1 pr-3 font-normal">Rate</th>
-                  <th class="py-1 pr-3 font-normal">Age</th>
-                  <th class="py-1 font-normal"></th>
+                  <th class="w-[42%] py-1 pr-3 font-normal">Topic</th>
+                  <th class="w-[22%] py-1 pr-3 font-normal">Latest</th>
+                  <th class="w-[13%] py-1 pr-3 text-right font-normal">Rate</th>
+                  <th class="w-[15%] py-1 pr-3 font-normal">Age</th>
+                  <th class="w-[8%] py-1 font-normal"></th>
                 </tr>
               </thead>
               <tbody>
                 {#each rawShown as row (row.topic)}
                   <tr class="border-t border-divider align-middle">
-                    <td class="max-w-[220px] truncate py-1 pr-3 text-emphasis">
+                    <td class="truncate py-1 pr-3 text-emphasis" title={row.topic}>
                       {row.topic}
                     </td>
                     <td
-                      class="max-w-[180px] truncate py-1 pr-3 font-mono tabular-nums text-secondary-text"
+                      class="truncate py-1 pr-3 font-mono tabular-nums text-secondary-text"
                     >
                       {row.value}
                     </td>
                     <td
-                      class="whitespace-nowrap py-1 pr-3 font-mono tabular-nums text-secondary-text"
+                      class="whitespace-nowrap py-1 pr-3 text-right font-mono tabular-nums text-secondary-text"
                     >
                       {row.rate !== null ? `${formatMetricValue(row.rate)}/s` : ""}
                     </td>
@@ -459,6 +467,7 @@
       </div>
     {/if}
   </div>
+  {/if}
 </div>
 
 <MetricMappingEditor

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
@@ -378,10 +378,11 @@
     avgMsgSize={facts.avgMsgSize}
   />
 
-  </div>
-
   <!-- Collapsible raw $SYS browser (hidden until a first topic arrives: an
-       empty expandable under the no-$SYS card reads as dead weight). -->
+       empty expandable under the no-$SYS card reads as dead weight). Inside
+       the dim wrapper: its frozen values must fade with the rest. The health
+       strip stays outside deliberately (it is sticky and needs an opaque,
+       full-strength treatment; chips carry their own stale greying). -->
   {#if $store.latestByTopic.size > 0}
   <div class="flex flex-col rounded border border-outline bg-elevation-1">
     <button
@@ -434,6 +435,7 @@
                     </td>
                     <td
                       class="truncate py-1 pr-3 font-mono tabular-nums text-secondary-text"
+                      title={row.value}
                     >
                       {row.value}
                     </td>
@@ -468,6 +470,7 @@
     {/if}
   </div>
   {/if}
+  </div>
 </div>
 
 <MetricMappingEditor

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/BrokerStatusView.svelte
@@ -36,7 +36,7 @@
   const SYS_TOPIC = "$SYS/#";
   const EMPTY_GRACE_MS = 10_000;
   const MAX_RAW_ROWS = 500;
-  // Tile sparklines always span 15 m, so the delta arrow and hover panel name it.
+  // Fallback window name for a tile with too few samples to measure a span.
   const TILE_WINDOW = "15m";
   // Minimum gap before a null break is inserted in a hero line (across a
   // disconnect the ticker stops, so consecutive samples jump in time).
@@ -93,9 +93,15 @@
   // $SYS has EVER been seen (a broker with $SYS but no health signals gets
   // neither strip nor notice, and a healthy broker's chip warm-up must not
   // flash a false "no $SYS" claim) and the empty card is not already showing.
+  // It also needs the connection to have been up at least once: claiming a
+  // broker publishes no $SYS before ever reaching it is a guess, not a finding.
   $: hasHealth = $store.health.some((c) => c.render);
   $: showCapabilityNotice =
-    graceElapsed && !hasHealth && !showEmptyState && !$store.sysEverSeen;
+    graceElapsed &&
+    !hasHealth &&
+    !showEmptyState &&
+    !$store.sysEverSeen &&
+    $store.everConnected;
 
   // In the empty state (no $SYS ever seen, grace elapsed) the builtin tiles can
   // never populate, so hide the ones with no data and show only tiles that
@@ -195,19 +201,47 @@
   // --- Gauge tiles: delta arrow + hover-panel inputs -------------------------
   // Percentage change across the visible sparkline window (last vs first). A
   // zero baseline makes a percentage meaningless, so growth from zero returns
-  // Infinity and the tile shows the direction glyph without a number.
-  const deltaPctFor = (tile: BrokerTileView): number | undefined => {
+  // Infinity, which the tile prints as its ">999%" ceiling.
+  //
+  // Samples from before the store's trend floor are skipped: after a reconnect
+  // a delta measured against the pre-outage baseline is an artefact of the gap,
+  // not a change in the broker.
+  const deltaPctFor = (
+    tile: BrokerTileView,
+    floorMs: number
+  ): number | undefined => {
     // Custom tiles with a unit can be interval scales (temperature and the
     // like) where percent change is meaningless; skip the delta for those.
     if (tile.key.startsWith("custom:") && tile.unit) return undefined;
     const s = tile.samples;
     if (!s || s.length < 2) return undefined;
-    const first = s[0].v;
+    // Samples are time-ordered, so a forward scan finds the window start.
+    let i = 0;
+    while (i < s.length && s[i].t < floorMs) i++;
+    if (s.length - i < 2) return undefined;
+    const first = s[i].v;
     const last = s[s.length - 1].v;
     if (first === 0) {
       return last === 0 ? undefined : Number.POSITIVE_INFINITY;
     }
     return ((last - first) / Math.abs(first)) * 100;
+  };
+
+  // The sparkline buffer is capped by COUNT, not by time: at mosquitto's ~10 s
+  // $SYS cadence 900 samples span 2.5 h, not the 15 m the observed (1 Hz) tiles
+  // span. Name the window the samples actually cover.
+  const formatSpan = (ms: number): string => {
+    const minutes = ms / 60_000;
+    if (minutes < 1.5) return `${Math.max(1, Math.round(ms / 1000))}s`;
+    if (minutes < 90) return `${Math.round(minutes)}m`;
+    const hours = minutes / 60;
+    return `${hours < 10 ? hours.toFixed(1) : Math.round(hours)}h`;
+  };
+
+  const windowNameFor = (tile: BrokerTileView): string => {
+    const s = tile.samples;
+    if (!s || s.length < 2) return TILE_WINDOW;
+    return formatSpan(s[s.length - 1].t - s[0].t);
   };
 
   // Exact, unabbreviated value string for the tile's hover panel.
@@ -319,10 +353,10 @@
         kind={tile.valueKind === "text" ? "text" : "number"}
         points={tile.samples}
         noData={tile.valueKind === "empty"}
-        deltaPct={deltaPctFor(tile)}
+        deltaPct={deltaPctFor(tile, $store.trendFloorMs)}
         exact={exactFor(tile)}
         description={tile.tooltip}
-        windowName={TILE_WINDOW}
+        windowName={windowNameFor(tile)}
       />
     {/each}
 

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/raw-browser.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/raw-browser.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { createRawRateTracker, formatAge } from "./raw-browser";
+
+const T0 = 1_000_000_000;
+
+describe("formatAge", () => {
+  it("scales from seconds to days and clamps future times", () => {
+    expect(formatAge(T0, T0 - 3000)).toBe("3s ago");
+    expect(formatAge(T0, T0 - 300_000)).toBe("5m ago");
+    expect(formatAge(T0, T0 - 7_200_000)).toBe("2h ago");
+    expect(formatAge(T0, T0 + 5000)).toBe("0s ago");
+  });
+});
+
+describe("createRawRateTracker", () => {
+  it("derives a rate once a counter has strictly increased three times", () => {
+    const t = createRawRateTracker();
+    expect(t.update("$SYS/broker/messages/sent", "10", T0)).toBeNull();
+    expect(t.update("$SYS/broker/messages/sent", "20", T0 + 1000)).toBeNull();
+    expect(t.update("$SYS/broker/messages/sent", "30", T0 + 2000)).toBe(10);
+  });
+
+  it("never classifies a stable gauge as a counter", () => {
+    const t = createRawRateTracker();
+    const topic = "$SYS/broker/subscriptions/count";
+    for (let i = 0; i < 6; i++) {
+      expect(t.update(topic, "12", T0 + i * 1000)).toBeNull();
+    }
+  });
+
+  it("excludes the $SYS load subtree, which is all moving averages", () => {
+    const t = createRawRateTracker();
+    const topic = "$SYS/broker/load/bytes/sent/15min";
+    for (let i = 0; i < 6; i++) {
+      expect(t.update(topic, String(100 + i * 10), T0 + i * 1000)).toBeNull();
+    }
+  });
+
+  it("drops the rate when a counter resets, then re-derives one", () => {
+    const t = createRawRateTracker();
+    const topic = "$SYS/broker/messages/received";
+    t.update(topic, "10", T0);
+    t.update(topic, "20", T0 + 1000);
+    expect(t.update(topic, "30", T0 + 2000)).toBe(10);
+    expect(t.update(topic, "0", T0 + 3000)).toBeNull(); // broker restart
+    t.update(topic, "5", T0 + 4000);
+    expect(t.update(topic, "10", T0 + 5000)).toBe(5);
+  });
+
+  it("is idempotent for a repeated observation", () => {
+    const t = createRawRateTracker();
+    const topic = "$SYS/broker/messages/sent";
+    t.update(topic, "10", T0);
+    t.update(topic, "20", T0 + 1000);
+    expect(t.update(topic, "30", T0 + 2000)).toBe(10);
+    expect(t.update(topic, "30", T0 + 2000)).toBe(10);
+  });
+});

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/raw-browser.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/raw-browser.ts
@@ -30,3 +30,94 @@ export const formatAge = (nowMs: number, timeMs: number): string => {
   const d = Math.floor(h / 24);
   return `${d}d ago`;
 };
+
+// --- Derived rate column (counter-like $SYS topics) --------------------------
+// The raw browser shows a per-second rate for topics that behave like
+// monotonic counters. A topic is treated as counter-like once it has produced
+// `RATE_MIN_RUN` consecutive non-decreasing numeric observations (the spec's
+// monotonicity heuristic); until then, and for gauge-like topics that go up and
+// down, no rate is shown. State is kept per topic in a tracker the view owns
+// (never in the store's latestByTopic), and reset on a history clear.
+//
+// Only observations seen while the browser is expanded feed the tracker, so a
+// freshly-expanded browser starts each topic's run from scratch — acceptable,
+// since the rate column only exists while expanded.
+
+/** Consecutive non-decreasing numeric samples before a topic counts as a counter. */
+export const RATE_MIN_RUN = 3;
+
+interface RawRateTopicState {
+  /** Previous numeric value, for the /s delta. null once the streak breaks. */
+  prevValue: number | null;
+  /** Time (ms) of `prevValue`. */
+  prevTimeMs: number;
+  /** Newest observation time already folded in (idempotency guard). */
+  lastTimeMs: number;
+  /** Length of the current non-decreasing numeric run. */
+  run: number;
+  /** Derived /s rate once counter-like, else null. */
+  rate: number | null;
+}
+
+export interface RawRateTracker {
+  /**
+   * Folds a topic's newest decoded value in and returns its derived /s rate, or
+   * null when the topic is not (yet) counter-like. Idempotent for a repeated
+   * `(topic, timeMs)` so it is safe to call from a reactive block.
+   */
+  update(topic: string, rawValue: string, timeMs: number): number | null;
+  /** Drops all per-topic state (call when the connection's history is cleared). */
+  reset(): void;
+}
+
+/** Parses a bare numeric payload; null for anything non-numeric. */
+const numericPayload = (raw: string): number | null => {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+};
+
+export const createRawRateTracker = (): RawRateTracker => {
+  const byTopic = new Map<string, RawRateTopicState>();
+
+  const update = (topic: string, rawValue: string, timeMs: number): number | null => {
+    let st = byTopic.get(topic);
+    if (st === undefined) {
+      st = { prevValue: null, prevTimeMs: -1, lastTimeMs: -1, run: 0, rate: null };
+      byTopic.set(topic, st);
+    }
+    // Already folded this observation: return the cached rate unchanged.
+    if (timeMs <= st.lastTimeMs) return st.rate;
+    st.lastTimeMs = timeMs;
+
+    const num = numericPayload(rawValue);
+    if (num === null) {
+      // Non-numeric breaks the counter streak.
+      st.run = 0;
+      st.prevValue = null;
+      st.rate = null;
+      return null;
+    }
+
+    // A non-decreasing step extends the run; a decrease (counter reset) or the
+    // first numeric sample starts a fresh run of length 1.
+    if (st.prevValue !== null && num >= st.prevValue) st.run += 1;
+    else st.run = 1;
+
+    if (st.run >= RATE_MIN_RUN && st.prevValue !== null) {
+      const dt = (timeMs - st.prevTimeMs) / 1000;
+      st.rate = dt > 0 ? (num - st.prevValue) / dt : st.rate;
+    } else {
+      st.rate = null;
+    }
+
+    st.prevValue = num;
+    st.prevTimeMs = timeMs;
+    return st.rate;
+  };
+
+  const reset = () => byTopic.clear();
+
+  return { update, reset };
+};

--- a/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/raw-browser.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/BrokerStatusView/raw-browser.ts
@@ -34,17 +34,32 @@ export const formatAge = (nowMs: number, timeMs: number): string => {
 // --- Derived rate column (counter-like $SYS topics) --------------------------
 // The raw browser shows a per-second rate for topics that behave like
 // monotonic counters. A topic is treated as counter-like once it has produced
-// `RATE_MIN_RUN` consecutive non-decreasing numeric observations (the spec's
-// monotonicity heuristic); until then, and for gauge-like topics that go up and
-// down, no rate is shown. State is kept per topic in a tracker the view owns
-// (never in the store's latestByTopic), and reset on a history clear.
+// `RATE_MIN_RUN` consecutive STRICTLY INCREASING numeric observations; until
+// then, and for gauge-like topics that go up and down, no rate is shown. State
+// is kept per topic in a tracker the view owns (never in the store's
+// latestByTopic), and reset on a history clear.
+//
+// Known limitation: a smoothly ramping moving average is indistinguishable
+// from a counter by shape alone. The $SYS load subtree is all moving averages
+// on every broker that publishes it, so it is excluded by topic instead;
+// bespoke moving averages elsewhere can still show a meaningless rate.
 //
 // Only observations seen while the browser is expanded feed the tracker, so a
 // freshly-expanded browser starts each topic's run from scratch — acceptable,
 // since the rate column only exists while expanded.
 
-/** Consecutive non-decreasing numeric samples before a topic counts as a counter. */
+/** Consecutive strictly increasing numeric samples before a topic counts as a counter. */
 export const RATE_MIN_RUN = 3;
+
+/**
+ * Topics that are averages by definition, whatever their shape. `$SYS/broker/
+ * load/**` is mosquitto's (and EMQX's) set of 1/5/15 minute moving averages; a
+ * derived "/s rate" over one of those is meaningless.
+ */
+const NON_COUNTER_PREFIXES = ["$SYS/broker/load/"];
+
+const isNeverCounter = (topic: string): boolean =>
+  NON_COUNTER_PREFIXES.some((p) => topic.startsWith(p));
 
 interface RawRateTopicState {
   /** Previous numeric value, for the /s delta. null once the streak breaks. */
@@ -82,6 +97,7 @@ export const createRawRateTracker = (): RawRateTracker => {
   const byTopic = new Map<string, RawRateTopicState>();
 
   const update = (topic: string, rawValue: string, timeMs: number): number | null => {
+    if (isNeverCounter(topic)) return null;
     let st = byTopic.get(topic);
     if (st === undefined) {
       st = { prevValue: null, prevTimeMs: -1, lastTimeMs: -1, run: 0, rate: null };
@@ -100,9 +116,11 @@ export const createRawRateTracker = (): RawRateTracker => {
       return null;
     }
 
-    // A non-decreasing step extends the run; a decrease (counter reset) or the
-    // first numeric sample starts a fresh run of length 1.
-    if (st.prevValue !== null && num >= st.prevValue) st.run += 1;
+    // A strictly increasing step extends the run; a flat value, a decrease
+    // (counter reset), or the first numeric sample starts a fresh run of
+    // length 1. Equality must not extend it: a gauge that never moves would
+    // otherwise qualify as a counter and render a permanent, misleading "0/s".
+    if (st.prevValue !== null && num > st.prevValue) st.run += 1;
     else st.run = 1;
 
     if (st.run >= RATE_MIN_RUN && st.prevValue !== null) {

--- a/frontend/src/views/BrokerStatusWindow/components/FactsRow/FactsRow.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/FactsRow/FactsRow.spec.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../../../../design-system/component-spec.schema.json",
+  "name": "FactsRow",
+  "tier": "view",
+  "description": "One-line broker facts under the gauges: broker/version, uptime, session counts with word labels ('17 live, 6 offline, 2 expired'), and average message size. Each part is omitted when its metric has no data.",
+  "status": "story-only",
+  "figma": {
+    "fileKey": "",
+    "nodeId": "",
+    "url": "",
+    "lastSyncedHash": null,
+    "lastSyncedAt": null
+  },
+  "props": [
+    {
+      "name": "version",
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "Broker/version string, or null when unpublished."
+    },
+    {
+      "name": "uptimeSeconds",
+      "type": "number",
+      "required": false,
+      "default": null,
+      "description": "Uptime in seconds; rendered via humanizeDuration."
+    },
+    {
+      "name": "clientsConnected",
+      "type": "number",
+      "required": false,
+      "default": null,
+      "description": "Live sessions."
+    },
+    {
+      "name": "clientsDisconnected",
+      "type": "number",
+      "required": false,
+      "default": null,
+      "description": "Offline sessions."
+    },
+    {
+      "name": "clientsExpired",
+      "type": "number",
+      "required": false,
+      "default": null,
+      "description": "Expired sessions."
+    },
+    {
+      "name": "avgMsgSize",
+      "type": "number",
+      "required": false,
+      "default": null,
+      "description": "Average message size in bytes."
+    }
+  ],
+  "tokens": ["secondary-text"],
+  "dependencies": [],
+  "notes": "Figma is not linked yet. Values are read from the store's metricByKey by BrokerStatusView and passed in as plain props."
+}

--- a/frontend/src/views/BrokerStatusWindow/components/FactsRow/FactsRow.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/FactsRow/FactsRow.stories.svelte
@@ -1,0 +1,48 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import Component from "./FactsRow.svelte";
+  import StoryRender from "@/stories/StoryRender.svelte";
+
+  const componentName = "FactsRow";
+
+  const { Story } = defineMeta({
+    title: "Views/BrokerStatusWindow/FactsRow",
+    component: Component,
+    tags: ["autodocs"],
+    parameters: { design: { type: "figma", url: "" } },
+  });
+</script>
+
+{#snippet template(args: any)}
+  <StoryRender component={Component} {args} {componentName} />
+{/snippet}
+
+<Story
+  name="Full"
+  args={{
+    version: "mosquitto 2.0.18",
+    uptimeSeconds: 273600,
+    clientsConnected: 17,
+    clientsDisconnected: 6,
+    clientsExpired: 2,
+    avgMsgSize: 312,
+  }}
+  {template}
+/>
+<Story
+  name="PartialSessions"
+  args={{
+    version: "EMQX 5.4.1",
+    uptimeSeconds: 90000,
+    clientsConnected: 42,
+    clientsDisconnected: null,
+    clientsExpired: null,
+    avgMsgSize: null,
+  }}
+  {template}
+/>
+<Story
+  name="VersionOnly"
+  args={{ version: "VerneMQ 1.13.0" }}
+  {template}
+/>

--- a/frontend/src/views/BrokerStatusWindow/components/FactsRow/FactsRow.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/FactsRow/FactsRow.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  // One-line broker facts under the gauges: broker/version, uptime, session
+  // counts with word labels, and average message size. Each part is omitted when
+  // its metric has no data, so a sparse broker shows a shorter line rather than
+  // "unknown" placeholders. Values come from the store's metricByKey.
+  import { humanizeDuration, formatMetricValue } from "../../sys-metrics";
+
+  export let version: string | null = null;
+  export let uptimeSeconds: number | null = null;
+  export let clientsConnected: number | null = null;
+  export let clientsDisconnected: number | null = null;
+  export let clientsExpired: number | null = null;
+  export let avgMsgSize: number | null = null;
+
+  // Session counts, each dropped when its metric is absent: "17 live, 6 offline".
+  $: sessionParts = [
+    clientsConnected !== null ? `${formatMetricValue(clientsConnected)} live` : null,
+    clientsDisconnected !== null
+      ? `${formatMetricValue(clientsDisconnected)} offline`
+      : null,
+    clientsExpired !== null ? `${formatMetricValue(clientsExpired)} expired` : null,
+  ].filter((p): p is string => p !== null);
+
+  $: parts = [
+    version,
+    uptimeSeconds !== null ? `up ${humanizeDuration(uptimeSeconds)}` : null,
+    sessionParts.length > 0 ? sessionParts.join(", ") : null,
+    avgMsgSize !== null ? `${formatMetricValue(avgMsgSize)} B avg` : null,
+  ].filter((p): p is string => p !== null);
+</script>
+
+{#if parts.length > 0}
+  <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-secondary-text">
+    {#each parts as part, i (i)}
+      {#if i > 0}
+        <span class="opacity-50" aria-hidden="true">·</span>
+      {/if}
+      <span>{part}</span>
+    {/each}
+  </div>
+{/if}

--- a/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.spec.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../../../design-system/component-spec.schema.json",
+  "name": "HealthChip",
+  "tier": "view",
+  "description": "One broker-health chip: state dot (outline ok / filled warning / filled error), label, monospaced value, and a one-word qualifier. State is never colour-only; informational chips carry no dot; a stale chip keeps its value but drops the dot and qualifier.",
+  "status": "story-only",
+  "figma": {
+    "fileKey": "",
+    "nodeId": "",
+    "url": "",
+    "lastSyncedHash": null,
+    "lastSyncedAt": null
+  },
+  "props": [
+    {
+      "name": "label",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "level",
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "'ok' | 'attention' | 'problem', or null for an informational chip with no dot.",
+      "options": ["ok", "attention", "problem"]
+    },
+    {
+      "name": "informational",
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "description": "Value-only chip (heap, churn) with no state dot."
+    },
+    {
+      "name": "qualifier",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "One-word text qualifier shown beside the value; '' hides it."
+    },
+    {
+      "name": "valueText",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Preformatted monospaced value (units and any peak already composed by the caller)."
+    },
+    {
+      "name": "stale",
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "description": "Source silent past the stale threshold: greys the value and drops the dot and qualifier."
+    }
+  ],
+  "tokens": [
+    "outline",
+    "elevation-1",
+    "secondary-text",
+    "emphasis",
+    "warning",
+    "error"
+  ],
+  "dependencies": [],
+  "notes": "Figma is not linked yet. Value formatting per chip lives in HealthStrip; this component is purely presentational."
+}

--- a/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.stories.svelte
@@ -1,0 +1,69 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import Component from "./HealthChip.svelte";
+  import StoryRender from "@/stories/StoryRender.svelte";
+
+  const componentName = "HealthChip";
+
+  const { Story } = defineMeta({
+    title: "Views/BrokerStatusWindow/HealthChip",
+    component: Component,
+    tags: ["autodocs"],
+    argTypes: {
+      level: { control: "select", options: ["ok", "attention", "problem"] },
+    },
+    parameters: { design: { type: "figma", url: "" } },
+  });
+</script>
+
+{#snippet template(args: any)}
+  <StoryRender component={Component} {args} {componentName} />
+{/snippet}
+
+<Story
+  name="Ok"
+  args={{ label: "Store", level: "ok", qualifier: "", valueText: "1.3k" }}
+  {template}
+/>
+<Story
+  name="Attention"
+  args={{
+    label: "Delivery backlog",
+    level: "attention",
+    qualifier: "rising",
+    valueText: "340",
+  }}
+  {template}
+/>
+<Story
+  name="Problem"
+  args={{
+    label: "Drops",
+    level: "problem",
+    qualifier: "rising",
+    valueText: "12.4/s",
+  }}
+  {template}
+/>
+<Story
+  name="Informational"
+  args={{
+    label: "Heap",
+    level: null,
+    informational: true,
+    qualifier: "",
+    valueText: "8.6M (peak 9.1M)",
+  }}
+  {template}
+/>
+<Story
+  name="Stale"
+  args={{
+    label: "Drops",
+    level: "problem",
+    qualifier: "rising",
+    valueText: "12.4/s",
+    stale: true,
+  }}
+  {template}
+/>

--- a/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.svelte
@@ -23,8 +23,11 @@
   $: showQualifier = !stale && qualifier !== "";
 </script>
 
+<!-- The dot centres against the row; the three text spans share one baseline
+     (mono and sans sit at different heights under items-center, which made the
+     value ride high). leading-none keeps the chip height driven by padding. -->
 <div
-  class="inline-flex items-center gap-1.5 whitespace-nowrap rounded border border-outline bg-elevation-1 px-2 py-1"
+  class="inline-flex items-center gap-1.5 whitespace-nowrap rounded border border-outline bg-elevation-1 px-2.5 py-1.5"
 >
   {#if showDot}
     <span
@@ -36,21 +39,25 @@
       aria-hidden="true"
     ></span>
   {/if}
-  <span class="text-sm text-secondary-text">{label}</span>
-  <span
-    class="font-mono text-sm tabular-nums {stale ? 'text-secondary-text' : 'text-emphasis'}"
-  >
-    {valueText}
-  </span>
-  {#if showQualifier}
+  <span class="flex items-baseline gap-1.5">
+    <span class="text-xs leading-none text-secondary-text">{label}</span>
     <span
-      class="text-xs {level === 'problem'
-        ? 'text-error'
-        : level === 'attention'
-          ? 'text-warning'
-          : 'text-secondary-text'}"
+      class="font-mono text-xs font-semibold tabular-nums leading-none {stale
+        ? 'text-secondary-text'
+        : 'text-emphasis'}"
     >
-      {qualifier}
+      {valueText}
     </span>
-  {/if}
+    {#if showQualifier}
+      <span
+        class="text-[11px] leading-none {level === 'problem'
+          ? 'text-error'
+          : level === 'attention'
+            ? 'text-warning'
+            : 'text-secondary-text'}"
+      >
+        {qualifier}
+      </span>
+    {/if}
+  </span>
 </div>

--- a/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  // One health-strip chip: a state dot, label, monospaced value, and a one-word
+  // qualifier. State is never carried by colour alone (docs/broker-status-v2
+  // spec): ok is an outline dot with no qualifier; attention is a filled warning
+  // dot plus a qualifier; problem is a filled error dot plus a qualifier.
+  // Informational chips (heap, churn) carry no dot. A stale chip keeps its value
+  // but drops the dot and qualifier (greyed, like the header pill).
+  import type { HealthLevel } from "../../health";
+
+  export let label: string;
+  // null for informational chips (no state dot).
+  export let level: HealthLevel | null = null;
+  export let informational = false;
+  // One-word qualifier ("rising", "present", ...); "" hides it.
+  export let qualifier = "";
+  // Preformatted, monospaced value (units and peak already composed by caller).
+  export let valueText = "";
+  // Source has gone silent past the stale threshold: keep value, drop dot.
+  export let stale = false;
+
+  // The dot renders for state chips that are neither informational nor stale.
+  $: showDot = !informational && !stale && level !== null;
+  $: showQualifier = !stale && qualifier !== "";
+</script>
+
+<div
+  class="inline-flex items-center gap-1.5 whitespace-nowrap rounded border border-outline bg-elevation-1 px-2 py-1"
+>
+  {#if showDot}
+    <span
+      class="size-2 shrink-0 rounded-full {level === 'problem'
+        ? 'bg-error'
+        : level === 'attention'
+          ? 'bg-warning'
+          : 'border border-secondary-text'}"
+      aria-hidden="true"
+    ></span>
+  {/if}
+  <span class="text-sm text-secondary-text">{label}</span>
+  <span
+    class="font-mono text-sm tabular-nums {stale ? 'text-secondary-text' : 'text-emphasis'}"
+  >
+    {valueText}
+  </span>
+  {#if showQualifier}
+    <span
+      class="text-xs {level === 'problem'
+        ? 'text-error'
+        : level === 'attention'
+          ? 'text-warning'
+          : 'text-secondary-text'}"
+    >
+      {qualifier}
+    </span>
+  {/if}
+</div>

--- a/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthChip/HealthChip.svelte
@@ -50,7 +50,7 @@
     </span>
     {#if showQualifier}
       <span
-        class="text-[11px] leading-none {level === 'problem'
+        class="text-sm leading-none {level === 'problem'
           ? 'text-error'
           : level === 'attention'
             ? 'text-warning'

--- a/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.spec.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../../design-system/component-spec.schema.json",
+  "name": "HealthStrip",
+  "tier": "view",
+  "description": "Row of broker-health chips. Renders only chips that have their minimum samples (chip.render) and hides entirely when none do. Composes each chip's monospaced value (heap folds in its peak; rate chips carry a /s suffix).",
+  "status": "story-only",
+  "figma": {
+    "fileKey": "",
+    "nodeId": "",
+    "url": "",
+    "lastSyncedHash": null,
+    "lastSyncedAt": null
+  },
+  "props": [
+    {
+      "name": "health",
+      "type": "object",
+      "required": false,
+      "default": [],
+      "description": "HealthChip[] from the store; only entries with render:true are shown."
+    }
+  ],
+  "tokens": [],
+  "dependencies": ["HealthChip"],
+  "notes": "Figma is not linked yet; stories use local health-chip fixtures. Stickiness and the capability-notice fallback are owned by BrokerStatusView, not this component."
+}

--- a/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.stories.svelte
@@ -1,0 +1,38 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import Component from "./HealthStrip.svelte";
+  import StoryRender from "@/stories/StoryRender.svelte";
+  import { mockHealthChips } from "@/stories/fixtures";
+
+  const componentName = "HealthStrip";
+
+  // A stale variant: silence greys the value and drops the dot + qualifier.
+  const withStale = () => {
+    const chips = mockHealthChips();
+    return chips.map((c) =>
+      c.id === "drops" ? { ...c, stale: true, qualifier: "" } : c
+    );
+  };
+
+  // Below-minimum chips (render:false) must be skipped entirely.
+  const withUnrendered = () =>
+    mockHealthChips().map((c) =>
+      c.id === "churn" ? { ...c, render: false } : c
+    );
+
+  const { Story } = defineMeta({
+    title: "Views/BrokerStatusWindow/HealthStrip",
+    component: Component,
+    tags: ["autodocs"],
+    parameters: { design: { type: "figma", url: "" } },
+  });
+</script>
+
+{#snippet template(args: any)}
+  <StoryRender component={Component} {args} {componentName} />
+{/snippet}
+
+<Story name="AllStates" args={{ health: mockHealthChips() }} {template} />
+<Story name="WithStale" args={{ health: withStale() }} {template} />
+<Story name="SkipsUnrendered" args={{ health: withUnrendered() }} {template} />
+<Story name="Empty" args={{ health: [] }} {template} />

--- a/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  // Compact row of health chips at the top of the broker-status body. Reads the
+  // store's evaluated `health` array and renders only the chips that have their
+  // minimum samples (chip.render). The strip hides entirely when no chip has
+  // data; the view decides whether to show a capability notice in its place.
+  // Value formatting per chip lives here (the health rules stay pure numbers).
+  import HealthChip from "../HealthChip/HealthChip.svelte";
+  import type { HealthChip as HealthChipData } from "../../health";
+  import { formatMetricValue } from "../../sys-metrics";
+
+  export let health: HealthChipData[] = [];
+
+  $: chips = health.filter((c) => c.render);
+
+  // Composes the monospaced value string for a chip. Heap folds in its peak;
+  // rate-like chips carry a "/s" suffix; everything else is a plain count.
+  const valueTextFor = (chip: HealthChipData): string => {
+    if (chip.value === null) return "";
+    const v = formatMetricValue(chip.value);
+    if (chip.id === "heap") {
+      return chip.detail !== null
+        ? `${v} (peak ${formatMetricValue(chip.detail)})`
+        : v;
+    }
+    if (chip.id === "drops" || chip.id === "churn") return `${v}/s`;
+    return v;
+  };
+</script>
+
+{#if chips.length > 0}
+  <div
+    class="flex flex-wrap items-center gap-2"
+    role="list"
+    aria-label="Broker health"
+  >
+    {#each chips as chip (chip.id)}
+      <div role="listitem">
+        <HealthChip
+          label={chip.label}
+          level={chip.level}
+          informational={chip.informational}
+          qualifier={chip.qualifier}
+          valueText={valueTextFor(chip)}
+          stale={chip.stale}
+        />
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HealthStrip/HealthStrip.svelte
@@ -12,14 +12,21 @@
 
   $: chips = health.filter((c) => c.render);
 
+  // A positive value that rounds to "0" is shown as "<0.1" instead: a chip
+  // reading "Drops 0/s present" contradicts itself and reads as a glitch.
+  const displayValue = (value: number): string => {
+    const text = formatMetricValue(value);
+    return value > 0 && text === "0" ? "<0.1" : text;
+  };
+
   // Composes the monospaced value string for a chip. Heap folds in its peak;
   // rate-like chips carry a "/s" suffix; everything else is a plain count.
   const valueTextFor = (chip: HealthChipData): string => {
     if (chip.value === null) return "";
-    const v = formatMetricValue(chip.value);
+    const v = displayValue(chip.value);
     if (chip.id === "heap") {
       return chip.detail !== null
-        ? `${v} (peak ${formatMetricValue(chip.detail)})`
+        ? `${v} (peak ${displayValue(chip.detail)})`
         : v;
     }
     if (chip.id === "drops" || chip.id === "churn") return `${v}/s`;

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.spec.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../../../design-system/component-spec.schema.json",
+  "name": "HeroChart",
+  "tier": "view",
+  "description": "Broker-status traffic hero: msgs/s in and out co-plotted with a dashed client-observed series, ECharts line chart under a custom live-value legend row.",
+  "status": "story-only",
+  "figma": {
+    "fileKey": "",
+    "nodeId": "",
+    "url": "",
+    "lastSyncedHash": null,
+    "lastSyncedAt": null
+  },
+  "props": [
+    {
+      "name": "series",
+      "type": "object",
+      "required": false,
+      "default": null,
+      "description": "HeroSeries[] — each { id, label, points: {t, v}[], dashed, emphasis?, tooltip? }. `v` null marks a gap (line break). ids are stable ('in'/'out'/'observed')."
+    },
+    {
+      "name": "windowMinutes",
+      "type": "number",
+      "required": false,
+      "default": 5,
+      "description": "Visible span in minutes; anchors the sliding x-axis window."
+    },
+    {
+      "name": "height",
+      "type": "number",
+      "required": false,
+      "default": 160,
+      "description": "Canvas height in pixels."
+    }
+  ],
+  "tokens": ["secondary-text", "emphasis"],
+  "dependencies": ["Tooltip"],
+  "notes": "ECharts paints to canvas, so axis/tooltip chrome and series colours come from literal JS palettes (CHROME_COLORS, CHART_PALETTE) rather than tokens; the legend value swatch is coloured inline from the same shared palette. Stories inject a fixed `now` + static series for deterministic test-storybook."
+}

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.stories.svelte
@@ -6,9 +6,11 @@
 
   const componentName = "HeroChart";
 
-  // Fixed clock + static series so test-storybook renders are deterministic (no
-  // Date.now / Math.random in the render path).
-  const NOW = 1_700_000_000_000;
+  // Series anchored to load time (same approach as stories/fixtures.ts): the
+  // component's window slides with Date.now(), so points anchored to a fixed
+  // past timestamp would fall outside it and render an empty chart. The sine
+  // shapes stay deterministic; only the anchor moves.
+  const NOW = Date.now();
 
   // A gently varying msgs/s series across the last `windowMinutes`, one sample
   // per second, offset and scaled per series so the three lines read apart.

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.stories.svelte
@@ -1,0 +1,116 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import Component from "./HeroChart.svelte";
+  import StoryRender from "@/stories/StoryRender.svelte";
+  import type { HeroSeries } from "./hero-chart-option";
+
+  const componentName = "HeroChart";
+
+  // Fixed clock + static series so test-storybook renders are deterministic (no
+  // Date.now / Math.random in the render path).
+  const NOW = 1_700_000_000_000;
+
+  // A gently varying msgs/s series across the last `windowMinutes`, one sample
+  // per second, offset and scaled per series so the three lines read apart.
+  const buildSeries = (
+    id: string,
+    label: string,
+    base: number,
+    amp: number,
+    dashed: boolean,
+    tooltip: string,
+    emphasis = false,
+    windowMinutes = 5,
+    gapAt?: number
+  ): HeroSeries => {
+    const count = windowMinutes * 60;
+    const points = Array.from({ length: count }, (_, i) => {
+      const t = NOW - (count - 1 - i) * 1000;
+      const v = gapAt !== undefined && i === gapAt
+        ? null
+        : Math.max(0, base + Math.sin(i / 12 + base) * amp);
+      return { t, v };
+    });
+    return { id, label, points, dashed, emphasis, tooltip };
+  };
+
+  const inOut = (windowMinutes = 5): HeroSeries[] => [
+    buildSeries(
+      "in",
+      "In",
+      42,
+      10,
+      false,
+      "1 min average, from the broker; 5m: 40, 15m: 38",
+      true,
+      windowMinutes
+    ),
+    buildSeries(
+      "out",
+      "Out",
+      58,
+      12,
+      false,
+      "1 min average, from the broker; 5m: 55, 15m: 52",
+      false,
+      windowMinutes
+    ),
+    buildSeries(
+      "observed",
+      "Observed",
+      36,
+      8,
+      true,
+      "this second, as received by this client",
+      false,
+      windowMinutes,
+      120
+    ),
+  ];
+
+  const { Story } = defineMeta({
+    title: "Views/BrokerStatusWindow/HeroChart",
+    component: Component,
+    tags: ["autodocs"],
+    argTypes: {
+      windowMinutes: { control: { type: "number" } },
+      height: { control: { type: "number" } },
+    },
+    parameters: { design: { type: "figma", url: "" } },
+  });
+</script>
+
+{#snippet template(args: any)}
+  <div class="w-[560px]">
+    <StoryRender component={Component} {args} {componentName} />
+  </div>
+{/snippet}
+
+<Story
+  name="InOutObserved"
+  args={{ series: inOut(5), windowMinutes: 5, height: 160 }}
+  {template}
+/>
+<Story
+  name="ObservedOnly"
+  args={{
+    series: [
+      buildSeries(
+        "observed",
+        "Observed",
+        36,
+        8,
+        false,
+        "this second, as received by this client"
+      ),
+    ],
+    windowMinutes: 5,
+    height: 160,
+  }}
+  {template}
+/>
+<Story
+  name="OneMinuteWindow"
+  args={{ series: inOut(1), windowMinutes: 1, height: 160 }}
+  {template}
+/>

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.svelte
@@ -75,17 +75,20 @@
 </script>
 
 <div class="flex flex-col gap-1">
-  <div class="flex flex-wrap items-center gap-x-4 gap-y-1 px-1">
+  <!-- Values sit tight against their labels (left-aligned in a fixed-min-width
+       slot so 1 Hz updates never reflow) with the wide gap BETWEEN series, so
+       each value pairs visually with its own label, not the next swatch. -->
+  <div class="flex flex-wrap items-center gap-x-6 gap-y-1 px-1">
     {#each series as s, i (s.id)}
       <Tooltip text={s.tooltip ?? ""} placement="top">
         <div class="flex items-center gap-1.5">
           <span
             class="size-2.5 min-w-2.5 rounded-[2px]"
-            style:background-color={heroSeriesColor(s, i, series.length)}
+            style:background-color={heroSeriesColor(s, i, series.length, $theme)}
           ></span>
           <span class="text-sm text-secondary-text">{s.label}</span>
           <span
-            class="min-w-[3.5rem] text-right text-sm font-medium tabular-nums text-emphasis"
+            class="min-w-[3rem] text-sm font-medium tabular-nums text-emphasis"
             >{currentValue(s)}</span
           >
         </div>

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import * as echarts from "echarts";
+  import theme from "@/stores/theme";
+  import Tooltip from "@/components/Tooltip/Tooltip.svelte";
+  import {
+    buildHeroChartOption,
+    heroSeriesColor,
+    type HeroSeries,
+  } from "./hero-chart-option";
+
+  // Pre-aggregated msgs/s series ("in" / "out" / "observed"). Rendered from
+  // props alone so the component works in a story without a live store.
+  export let series: HeroSeries[] = [];
+  // Visible span in minutes (1 / 5 / 15); drives the sliding x-axis window.
+  export let windowMinutes = 5;
+  export let height = 160;
+
+  let container: HTMLDivElement;
+  let chart: echarts.ECharts | null = null;
+  let resizeObserver: ResizeObserver | null = null;
+  // The x-axis min/max are anchored to Date.now(), so without fresh data the
+  // view would freeze. A 1 Hz tick re-renders so the window keeps sliding even
+  // when no messages arrive (matches TopicChart).
+  let windowTick: ReturnType<typeof setInterval> | null = null;
+
+  const render = () => {
+    if (!chart) return;
+    chart.setOption(
+      buildHeroChartOption({
+        series,
+        windowMinutes,
+        now: Date.now(),
+        theme: $theme,
+      }),
+      { replaceMerge: ["series"] }
+    );
+  };
+
+  // Re-render on new series or a window change.
+  $: series, windowMinutes, render();
+  // A theme flip must restyle the axis/tooltip chrome immediately.
+  $: $theme, render();
+
+  // The last observed (non-null) value per series, for the live legend. Kept in
+  // a fixed-min-width slot so the 1 Hz update never reflows the row.
+  const currentValue = (s: HeroSeries): string => {
+    for (let i = s.points.length - 1; i >= 0; i -= 1) {
+      const v = s.points[i].v;
+      if (v !== null) return formatRate(v);
+    }
+    return "n/a";
+  };
+
+  const formatRate = (v: number): string => {
+    if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
+    if (v >= 100) return `${Math.round(v)}`;
+    return v.toFixed(1);
+  };
+
+  onMount(() => {
+    chart = echarts.init(container, undefined, { renderer: "canvas" });
+    render();
+    resizeObserver = new ResizeObserver(() => chart?.resize());
+    resizeObserver.observe(container);
+    windowTick = setInterval(render, 1000);
+  });
+
+  onDestroy(() => {
+    if (windowTick !== null) clearInterval(windowTick);
+    resizeObserver?.disconnect();
+    chart?.dispose();
+    chart = null;
+  });
+</script>
+
+<div class="flex flex-col gap-1">
+  <div class="flex flex-wrap items-center gap-x-4 gap-y-1 px-1">
+    {#each series as s, i (s.id)}
+      <Tooltip text={s.tooltip ?? ""} placement="top">
+        <div class="flex items-center gap-1.5">
+          <span
+            class="size-2.5 min-w-2.5 rounded-[2px]"
+            style:background-color={heroSeriesColor(s, i, series.length)}
+          ></span>
+          <span class="text-sm text-secondary-text">{s.label}</span>
+          <span
+            class="min-w-[3.5rem] text-right text-sm font-medium tabular-nums text-emphasis"
+            >{currentValue(s)}</span
+          >
+        </div>
+      </Tooltip>
+    {/each}
+  </div>
+  <div bind:this={container} class="w-full" style:height={`${height}px`}></div>
+</div>

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/HeroChart.svelte
@@ -37,8 +37,11 @@
     );
   };
 
-  // Re-render on new series or a window change.
-  $: series, windowMinutes, render();
+  // The store flushes several times a second, so re-rendering on every `series`
+  // change would rebuild the whole option (hundreds of points, replaceMerge)
+  // at batch cadence on top of the 1 Hz window tick, which already picks the
+  // new data up. Only a window or theme change needs an immediate redraw.
+  $: windowMinutes, render();
   // A theme flip must restyle the axis/tooltip chrome immediately.
   $: $theme, render();
 

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildHeroChartOption,
+  heroSeriesColor,
+  type HeroChartOptionParams,
+  type HeroSeries,
+} from "./hero-chart-option";
+import { CHART_PALETTE } from "@/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-series-store";
+
+const NOW = 1_700_000_000_000;
+
+const inSeries: HeroSeries = {
+  id: "in",
+  label: "In",
+  dashed: false,
+  emphasis: true,
+  points: [
+    { t: NOW - 2000, v: 10 },
+    { t: NOW - 1000, v: 12 },
+    { t: NOW, v: 11 },
+  ],
+};
+
+const outSeries: HeroSeries = {
+  id: "out",
+  label: "Out",
+  dashed: false,
+  points: [
+    { t: NOW - 2000, v: 20 },
+    { t: NOW - 1000, v: 22 },
+    { t: NOW, v: 21 },
+  ],
+};
+
+const observedSeries: HeroSeries = {
+  id: "observed",
+  label: "Observed",
+  dashed: true,
+  points: [
+    { t: NOW - 2000, v: 8 },
+    { t: NOW - 1000, v: 9 },
+    { t: NOW, v: 9 },
+  ],
+};
+
+const params = (
+  over: Partial<HeroChartOptionParams> = {}
+): HeroChartOptionParams => ({
+  series: [inSeries, outSeries, observedSeries],
+  windowMinutes: 5,
+  now: NOW,
+  ...over,
+});
+
+type Series = { id: string; name: string; data: [number, number | null][] }[];
+type Line = {
+  lineStyle: { color: string; type: string; opacity: number; width: number };
+  connectNulls: boolean;
+};
+
+const seriesOf = (p: HeroChartOptionParams) =>
+  buildHeroChartOption(p).series as unknown as (Series[number] & Line)[];
+
+const xAxis = (p: HeroChartOptionParams) =>
+  buildHeroChartOption(p).xAxis as { min: number; max: number };
+
+describe("buildHeroChartOption series mapping", () => {
+  it("maps each series by stable id, name and point pairs", () => {
+    const s = seriesOf(params());
+    expect(s.map((e) => e.id)).toEqual(["in", "out", "observed"]);
+    expect(s[0].name).toBe("In");
+    expect(s[0].data).toEqual([
+      [NOW - 2000, 10],
+      [NOW - 1000, 12],
+      [NOW, 11],
+    ]);
+  });
+
+  it("disables ECharts legend and animation", () => {
+    const opt = buildHeroChartOption(params());
+    expect((opt.legend as { show: boolean }).show).toBe(false);
+    expect(opt.animation).toBe(false);
+  });
+});
+
+describe("buildHeroChartOption window bounds", () => {
+  it("anchors x-axis min/max to now minus the window", () => {
+    const ax = xAxis(params({ windowMinutes: 5 }));
+    expect(ax.min).toBe(NOW - 5 * 60_000);
+    expect(ax.max).toBe(NOW);
+  });
+
+  it("tracks a different window width", () => {
+    const ax = xAxis(params({ windowMinutes: 15 }));
+    expect(ax.min).toBe(NOW - 15 * 60_000);
+    expect(ax.max).toBe(NOW);
+  });
+});
+
+describe("buildHeroChartOption theme", () => {
+  const tooltipBg = (p: HeroChartOptionParams) =>
+    (buildHeroChartOption(p).tooltip as { backgroundColor: string })
+      .backgroundColor;
+
+  it("defaults to the dark chrome palette", () => {
+    expect(tooltipBg(params())).toBe("#1f1e1e");
+  });
+
+  it("uses the light chrome palette when theme is light", () => {
+    const light = tooltipBg(params({ theme: "light" }));
+    expect(light).toBe("#ffffff");
+    expect(light).not.toBe(tooltipBg(params({ theme: "dark" })));
+  });
+});
+
+describe("buildHeroChartOption dashed flag", () => {
+  it("renders the observed series dashed and muted, solid series opaque", () => {
+    const s = seriesOf(params());
+    const observed = s.find((e) => e.id === "observed")!;
+    const inbound = s.find((e) => e.id === "in")!;
+    expect(observed.lineStyle.type).toBe("dashed");
+    expect(observed.lineStyle.opacity).toBeLessThan(1);
+    expect(inbound.lineStyle.type).toBe("solid");
+    expect(inbound.lineStyle.opacity).toBe(1);
+  });
+
+  it("gives the emphasis series a heavier line", () => {
+    const s = seriesOf(params());
+    expect(s.find((e) => e.id === "in")!.lineStyle.width).toBeGreaterThan(
+      s.find((e) => e.id === "out")!.lineStyle.width
+    );
+  });
+
+  it("promotes a lone non-dashed series to the primary colour", () => {
+    const solo: HeroSeries = { ...observedSeries, dashed: false };
+    const s = seriesOf(params({ series: [solo] }));
+    expect(s[0].lineStyle.color).toBe(CHART_PALETTE[1]);
+    expect(heroSeriesColor(solo, 0, 1)).toBe(CHART_PALETTE[1]);
+  });
+
+  it("colours multiple series from the shared palette in order", () => {
+    expect(heroSeriesColor(inSeries, 0, 3)).toBe(CHART_PALETTE[0]);
+    expect(heroSeriesColor(outSeries, 1, 3)).toBe(CHART_PALETTE[1]);
+  });
+});
+
+describe("buildHeroChartOption null gaps", () => {
+  it("keeps null values as gap markers and disables bridging", () => {
+    const gapped: HeroSeries = {
+      id: "in",
+      label: "In",
+      dashed: false,
+      points: [
+        { t: NOW - 2000, v: 10 },
+        { t: NOW - 1000, v: null },
+        { t: NOW, v: 12 },
+      ],
+    };
+    const s = seriesOf(params({ series: [gapped] }));
+    expect(s[0].connectNulls).toBe(false);
+    expect(s[0].data).toEqual([
+      [NOW - 2000, 10],
+      [NOW - 1000, null],
+      [NOW, 12],
+    ]);
+  });
+});
+
+describe("buildHeroChartOption empty series", () => {
+  it("builds a valid option with no series without crashing", () => {
+    const opt = buildHeroChartOption(params({ series: [] }));
+    expect(opt.series).toEqual([]);
+    const ax = opt.xAxis as { min: number; max: number };
+    expect(ax.min).toBe(NOW - 5 * 60_000);
+    expect(ax.max).toBe(NOW);
+  });
+});

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.test.ts
@@ -139,8 +139,10 @@ describe("buildHeroChartOption dashed flag", () => {
   });
 
   it("colours multiple series from the shared palette in order", () => {
-    expect(heroSeriesColor(inSeries, 0, 3)).toBe(CHART_PALETTE[0]);
-    expect(heroSeriesColor(outSeries, 1, 3)).toBe(CHART_PALETTE[1]);
+    // Non-state hues only: the hero sits under the health strip's
+    // amber/red/green state colours (review cycle 3). In is primary, out teal.
+    expect(heroSeriesColor(inSeries, 0, 3)).toBe(CHART_PALETTE[1]);
+    expect(heroSeriesColor(outSeries, 1, 3)).toBe(CHART_PALETTE[4]);
   });
 });
 

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.test.ts
@@ -177,3 +177,24 @@ describe("buildHeroChartOption empty series", () => {
     expect(ax.max).toBe(NOW);
   });
 });
+
+describe("buildHeroChartOption — visible window", () => {
+  it("only sends points inside the window, plus the one anchoring the left edge", () => {
+    const now = 1_700_000_000_000;
+    // 600 seconds of 1 Hz samples ending now; a 1 m window can show 60 of them.
+    const points = Array.from({ length: 600 }, (_, i) => ({
+      t: now - (599 - i) * 1000,
+      v: i,
+    }));
+    const option = buildHeroChartOption({
+      series: [{ id: "observed", label: "Observed", points, dashed: false }],
+      windowMinutes: 1,
+      now,
+    }) as any;
+    const data = option.series[0].data as [number, number | null][];
+    expect(data.length).toBeLessThanOrEqual(62);
+    // The newest point survives and the series still starts left of the edge.
+    expect(data[data.length - 1][0]).toBe(now);
+    expect(data[0][0]).toBeLessThanOrEqual(now - 60_000);
+  });
+});

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.ts
@@ -1,0 +1,122 @@
+// Pure builder for the ECharts option object used by the broker-status traffic
+// hero chart. Kept out of HeroChart.svelte so the axis/series math is
+// unit-testable without mounting echarts. Deliberately NOT built on
+// buildChartOption (that one is coupled to message history + payload paths);
+// the hero plots pre-aggregated msgs/s series with gap markers instead.
+import type { EChartsOption } from "echarts";
+import { CHROME_COLORS } from "@/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-option";
+import { CHART_PALETTE } from "@/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-series-store";
+
+// A single sample. `v` is null for a gap marker (e.g. across a disconnect),
+// rendered as a line break rather than a bridge (connectNulls: false).
+export interface HeroSeriesPoint {
+  t: number;
+  v: number | null;
+}
+
+export interface HeroSeries {
+  // Stable id ("in" / "out" / "observed") so replaceMerge keeps series identity
+  // across 1 Hz redraws.
+  id: string;
+  label: string;
+  points: HeroSeriesPoint[];
+  // Dashed + muted styling: the client-observed series when broker series are
+  // also present. A lone non-dashed series is promoted to solid primary.
+  dashed: boolean;
+  // Slightly heavier line for the series the reader should track first.
+  emphasis?: boolean;
+  // Legend tooltip copy. Consumed by HeroChart's custom HTML legend, not by the
+  // ECharts option; declared here so both share one series shape.
+  tooltip?: string;
+}
+
+export interface HeroChartOptionParams {
+  series: HeroSeries[];
+  // The visible span in minutes (1 / 5 / 15); always > 0 for the hero.
+  windowMinutes: number;
+  // Current time in ms; injected so the sliding window is deterministic in
+  // tests and stories.
+  now: number;
+  theme?: "dark" | "light";
+}
+
+// Primary line colour (matches the design-system `primary` token) used when a
+// single non-dashed series is shown alone.
+const PRIMARY = CHART_PALETTE[1];
+
+// Colour for a series given its position and the total count. A lone,
+// non-dashed series (the observed-only case) is promoted to primary; otherwise
+// colours come from the shared chart palette in array order.
+export const heroSeriesColor = (
+  series: HeroSeries,
+  index: number,
+  total: number
+): string => {
+  if (total === 1 && !series.dashed) return PRIMARY;
+  return CHART_PALETTE[index % CHART_PALETTE.length];
+};
+
+export const buildHeroChartOption = ({
+  series,
+  windowMinutes,
+  now,
+  theme = "dark",
+}: HeroChartOptionParams): EChartsOption => {
+  const chrome = CHROME_COLORS[theme];
+  const total = series.length;
+  return {
+    animation: false,
+    grid: { left: 44, right: 14, top: 10, bottom: 22 },
+    // No ECharts legend: a custom HTML legend row above the canvas carries the
+    // live values without 1 Hz reflow jitter (see HeroChart.svelte).
+    legend: { show: false },
+    tooltip: {
+      trigger: "axis",
+      axisPointer: { type: "cross", lineStyle: { color: chrome.axis } },
+      backgroundColor: chrome.tooltipBackground,
+      borderColor: chrome.tooltipBorder,
+      textStyle: { color: chrome.tooltipText, fontSize: 12 },
+    },
+    xAxis: {
+      type: "time",
+      // Always anchored to the sliding window: echarts merges the xAxis on
+      // setOption, so the min/max must be emitted every render or the window
+      // stops sliding when no fresh data arrives.
+      min: now - windowMinutes * 60_000,
+      max: now,
+      axisLine: { lineStyle: { color: chrome.axis } },
+      axisLabel: { color: chrome.label, fontSize: 10, hideOverlap: true },
+      splitLine: { show: false },
+    },
+    yAxis: {
+      type: "value",
+      name: "msgs/s",
+      nameTextStyle: { color: chrome.label, fontSize: 10, align: "left" },
+      // Rates are non-negative; a 0 baseline keeps the visual honest.
+      min: 0,
+      axisLine: { show: false },
+      axisLabel: { color: chrome.label, fontSize: 10 },
+      splitLine: { lineStyle: { color: chrome.splitLine } },
+    },
+    series: series.map((s, index) => {
+      const color = heroSeriesColor(s, index, total);
+      return {
+        id: s.id,
+        name: s.label,
+        type: "line",
+        showSymbol: false,
+        smooth: false,
+        // Break the line across gap markers instead of bridging them.
+        connectNulls: false,
+        lineStyle: {
+          color,
+          width: s.emphasis ? 2.5 : 2,
+          type: s.dashed ? "dashed" : "solid",
+          opacity: s.dashed ? 0.55 : 1,
+        },
+        itemStyle: { color },
+        data: s.points.map((p) => [p.t, p.v] as [number, number | null]),
+      };
+    }),
+  };
+};

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.ts
@@ -6,6 +6,7 @@
 import type { EChartsOption } from "echarts";
 import { CHROME_COLORS } from "@/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-option";
 import { CHART_PALETTE } from "@/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-series-store";
+import { formatMetricValue } from "../../sys-metrics";
 
 // A single sample. `v` is null for a gap marker (e.g. across a disconnect),
 // rendered as a line break rather than a bridge (connectNulls: false).
@@ -44,16 +45,36 @@ export interface HeroChartOptionParams {
 // single non-dashed series is shown alone.
 const PRIMARY = CHART_PALETTE[1];
 
-// Colour for a series given its position and the total count. A lone,
-// non-dashed series (the observed-only case) is promoted to primary; otherwise
-// colours come from the shared chart palette in array order.
+// Fixed hero colours by series id. The hero sits directly under the health
+// strip, which uses amber/red/green as STATE colours, so the traffic lines
+// must not reuse those hues (review cycle 3): in is primary, out is teal, and
+// the observed overlay is the theme's neutral axis-label grey. Unknown ids
+// (future series) fall back to the non-state tail of the shared palette.
+const HERO_SERIES_COLORS: Record<string, string> = {
+  in: CHART_PALETTE[1], // primary
+  out: CHART_PALETTE[4], // teal
+};
+const FALLBACK_COLORS = [CHART_PALETTE[5], CHART_PALETTE[7]]; // purple, cyan
+
 export const heroSeriesColor = (
   series: HeroSeries,
   index: number,
-  total: number
+  total: number,
+  theme: "dark" | "light" = "dark"
 ): string => {
   if (total === 1 && !series.dashed) return PRIMARY;
-  return CHART_PALETTE[index % CHART_PALETTE.length];
+  if (series.id === "observed") return CHROME_COLORS[theme].label;
+  return (
+    HERO_SERIES_COLORS[series.id] ??
+    FALLBACK_COLORS[index % FALLBACK_COLORS.length]
+  );
+};
+
+// Time-of-day for tooltip headers: a 15 minute window never needs the date.
+const fmtTime = (ms: number): string => {
+  const d = new Date(ms);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 };
 
 export const buildHeroChartOption = ({
@@ -72,10 +93,36 @@ export const buildHeroChartOption = ({
     legend: { show: false },
     tooltip: {
       trigger: "axis",
-      axisPointer: { type: "cross", lineStyle: { color: chrome.axis } },
+      // Default line pointer, matching TopicChart; a cross pointer paints a
+      // y-axis badge that clips over the axis labels.
+      axisPointer: { type: "line", lineStyle: { color: chrome.axis } },
       backgroundColor: chrome.tooltipBackground,
       borderColor: chrome.tooltipBorder,
       textStyle: { color: chrome.tooltipText, fontSize: 12 },
+      // Time-only header (the window is minutes wide) and SI-formatted values;
+      // the defaults print the full date and 13-decimal floats.
+      formatter: (params) => {
+        const list = Array.isArray(params) ? params : [params];
+        if (list.length === 0) return "";
+        const first = list[0] as { axisValue?: number | string };
+        const t = typeof first.axisValue === "number" ? first.axisValue : null;
+        const lines = list.map((p) => {
+          const item = p as {
+            marker?: string;
+            seriesName?: string;
+            value?: [number, number | null];
+          };
+          const v = item.value?.[1];
+          const text =
+            v === null || v === undefined
+              ? "no data"
+              : `${formatMetricValue(v)} msg/s`;
+          return `${item.marker ?? ""}${item.seriesName ?? ""}  ${text}`;
+        });
+        return [t !== null ? fmtTime(t) : "", ...lines]
+          .filter((l) => l !== "")
+          .join("<br/>");
+      },
     },
     xAxis: {
       type: "time",
@@ -90,7 +137,7 @@ export const buildHeroChartOption = ({
     },
     yAxis: {
       type: "value",
-      name: "msgs/s",
+      name: "msg/s",
       nameTextStyle: { color: chrome.label, fontSize: 10, align: "left" },
       // Rates are non-negative; a 0 baseline keeps the visual honest.
       min: 0,
@@ -99,7 +146,7 @@ export const buildHeroChartOption = ({
       splitLine: { lineStyle: { color: chrome.splitLine } },
     },
     series: series.map((s, index) => {
-      const color = heroSeriesColor(s, index, total);
+      const color = heroSeriesColor(s, index, total, theme);
       return {
         id: s.id,
         name: s.label,

--- a/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.ts
+++ b/frontend/src/views/BrokerStatusWindow/components/HeroChart/hero-chart-option.ts
@@ -77,6 +77,27 @@ const fmtTime = (ms: number): string => {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 };
 
+/**
+ * Trims a series to the points the sliding window can actually show, keeping
+ * the last point before the left edge so the line still reaches it. The
+ * buffers hold up to 900 points each; at a 1 m range that is 15x more data
+ * than the canvas can use, and every point is copied into the option on every
+ * redraw.
+ */
+const visiblePoints = (
+  points: HeroSeriesPoint[],
+  minTime: number
+): HeroSeriesPoint[] => {
+  let start = 0;
+  for (let i = points.length - 1; i >= 0; i--) {
+    if (points[i].t < minTime) {
+      start = i;
+      break;
+    }
+  }
+  return start === 0 ? points : points.slice(start);
+};
+
 export const buildHeroChartOption = ({
   series,
   windowMinutes,
@@ -85,6 +106,7 @@ export const buildHeroChartOption = ({
 }: HeroChartOptionParams): EChartsOption => {
   const chrome = CHROME_COLORS[theme];
   const total = series.length;
+  const minTime = now - windowMinutes * 60_000;
   return {
     animation: false,
     grid: { left: 44, right: 14, top: 10, bottom: 22 },
@@ -129,7 +151,7 @@ export const buildHeroChartOption = ({
       // Always anchored to the sliding window: echarts merges the xAxis on
       // setOption, so the min/max must be emitted every render or the window
       // stops sliding when no fresh data arrives.
-      min: now - windowMinutes * 60_000,
+      min: minTime,
       max: now,
       axisLine: { lineStyle: { color: chrome.axis } },
       axisLabel: { color: chrome.label, fontSize: 10, hideOverlap: true },
@@ -162,7 +184,9 @@ export const buildHeroChartOption = ({
           opacity: s.dashed ? 0.55 : 1,
         },
         itemStyle: { color },
-        data: s.points.map((p) => [p.t, p.v] as [number, number | null]),
+        data: visiblePoints(s.points, minTime).map(
+          (p) => [p.t, p.v] as [number, number | null]
+        ),
       };
     }),
   };

--- a/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.spec.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../../../design-system/component-spec.schema.json",
+  "name": "LoudestTopics",
+  "tier": "view",
+  "description": "Client-side loudest-topics table for the broker-status window: top rows over the selected range with msg/s, bytes/s and a share bar, a '(collecting)' header suffix while the window fills, and an overflow footer line. Topics middle-ellipsise with the full topic in a tooltip; at narrow widths the share bar drops first, then bytes/s.",
+  "status": "story-only",
+  "figma": {
+    "fileKey": "",
+    "nodeId": "",
+    "url": "",
+    "lastSyncedHash": null,
+    "lastSyncedAt": null
+  },
+  "props": [
+    {
+      "name": "loudest",
+      "type": "object",
+      "required": false,
+      "default": null,
+      "description": "LoudestState from the store: { rows: {topic, msgPerSec, bytesPerSec}[], overflowTopics, overflowMsgPerSec, collecting }."
+    }
+  ],
+  "tokens": [
+    "outline",
+    "elevation-1",
+    "elevation-2",
+    "secondary-text",
+    "emphasis",
+    "divider",
+    "primary"
+  ],
+  "dependencies": ["Tooltip"],
+  "notes": "Figma is not linked yet; stories use a local LoudestState fixture. Responsive column drops are driven by bind:clientWidth against fixed breakpoints, not the viewport."
+}

--- a/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.stories.svelte
@@ -1,0 +1,43 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import Component from "./LoudestTopics.svelte";
+  import { mockLoudest } from "@/stories/fixtures";
+
+  const collecting = () => ({ ...mockLoudest(), collecting: true });
+  const noOverflow = () => ({
+    ...mockLoudest(),
+    overflowTopics: 0,
+    overflowMsgPerSec: 0,
+  });
+  const empty = () => ({
+    rows: [],
+    overflowTopics: 0,
+    overflowMsgPerSec: 0,
+    collecting: true,
+  });
+
+  const { Story } = defineMeta({
+    title: "Views/BrokerStatusWindow/LoudestTopics",
+    component: Component,
+    tags: ["autodocs"],
+    parameters: { design: { type: "figma", url: "" } },
+  });
+</script>
+
+{#snippet template(args: any)}
+  <div class="w-[640px] max-w-full bg-elevation-0 p-4">
+    <Component {...args} />
+  </div>
+{/snippet}
+
+{#snippet narrow(args: any)}
+  <div class="w-[300px] bg-elevation-0 p-4">
+    <Component {...args} />
+  </div>
+{/snippet}
+
+<Story name="Populated" args={{ loudest: mockLoudest() }} {template} />
+<Story name="Collecting" args={{ loudest: collecting() }} {template} />
+<Story name="NoOverflow" args={{ loudest: noOverflow() }} {template} />
+<Story name="Narrow" args={{ loudest: mockLoudest() }} template={narrow} />
+<Story name="Empty" args={{ loudest: empty() }} {template} />

--- a/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  // Client-side "loudest topics" table for the broker-status window. Renders the
+  // top rows the store merged over the selected range, each with msg/s, bytes/s
+  // and a share bar. Topics middle-ellipsise (first segment + last two kept, the
+  // full topic in a tooltip). Overflow beyond the shown rows is a single footer
+  // line, never a row. At narrow container widths the share bar drops first,
+  // then bytes/s.
+  import Tooltip from "@/components/Tooltip/Tooltip.svelte";
+  import { formatMetricValue } from "../../sys-metrics";
+  import type { LoudestState } from "../../broker-status-store";
+
+  export let loudest: LoudestState = {
+    rows: [],
+    overflowTopics: 0,
+    overflowMsgPerSec: 0,
+    collecting: true,
+  };
+
+  // Width breakpoints (px) for the responsive column drops. Measured off the
+  // container so the table adapts to the pane, not the viewport.
+  const SHARE_BAR_MIN = 380;
+  const BYTES_MIN = 280;
+
+  let containerWidth = 640;
+  $: showShareBar = containerWidth >= SHARE_BAR_MIN;
+  $: showBytes = containerWidth >= BYTES_MIN;
+
+  // Loudest row sets the bar's full width; the rest scale against it.
+  $: peak = loudest.rows.reduce((m, r) => Math.max(m, r.msgPerSec), 0);
+
+  // First segment + last two segments; the full topic lives in the tooltip.
+  const middleEllipsis = (topic: string): string => {
+    const parts = topic.split("/");
+    if (parts.length <= 3) return topic;
+    return `${parts[0]}/…/${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+  };
+
+  $: hasOverflow = loudest.overflowTopics > 0;
+</script>
+
+<div
+  class="flex flex-col gap-2 rounded border border-outline bg-elevation-1 p-3"
+  bind:clientWidth={containerWidth}
+>
+  <div class="flex items-baseline gap-2">
+    <span class="text-emphasis">Loudest topics</span>
+    <span class="text-sm text-secondary-text">(this client's subscriptions)</span>
+    {#if loudest.collecting}
+      <span class="text-sm text-secondary-text opacity-70">(collecting)</span>
+    {/if}
+  </div>
+
+  {#if loudest.rows.length === 0}
+    <span class="py-2 text-sm text-secondary-text">No messages received yet.</span>
+  {:else}
+    <div class="flex flex-col">
+      {#each loudest.rows as row (row.topic)}
+        <div class="flex items-center gap-3 border-t border-divider py-1 first:border-t-0">
+          <Tooltip text={row.topic} placement="top" class="min-w-0 flex-1">
+            <span class="block truncate text-sm text-emphasis">
+              {middleEllipsis(row.topic)}
+            </span>
+          </Tooltip>
+          <span class="w-16 shrink-0 text-right font-mono text-sm tabular-nums text-secondary-text">
+            {formatMetricValue(row.msgPerSec)}/s
+          </span>
+          {#if showBytes}
+            <span class="w-20 shrink-0 text-right font-mono text-sm tabular-nums text-secondary-text">
+              {formatMetricValue(row.bytesPerSec)} B/s
+            </span>
+          {/if}
+          {#if showShareBar}
+            <span class="h-1.5 w-24 shrink-0 overflow-hidden rounded-full bg-elevation-2">
+              <span
+                class="block h-full rounded-full bg-primary opacity-70"
+                style:width={`${peak > 0 ? (row.msgPerSec / peak) * 100 : 0}%`}
+              ></span>
+            </span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    {#if hasOverflow}
+      <span class="text-sm text-secondary-text opacity-70">
+        {loudest.overflowTopics}+ more topics, {formatMetricValue(
+          loudest.overflowMsgPerSec
+        )} msg/s
+      </span>
+    {/if}
+  {/if}
+</div>

--- a/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.svelte
@@ -45,7 +45,9 @@
   <div class="flex items-baseline gap-2">
     <span class="text-emphasis">Loudest topics</span>
     <span class="text-sm text-secondary-text">(this client's subscriptions)</span>
-    {#if loudest.collecting}
+    <!-- Suppressed while the table is empty: the body already says no
+         messages have arrived, and two stacked suffixes read as clutter. -->
+    {#if loudest.collecting && loudest.rows.length > 0}
       <span class="text-sm text-secondary-text opacity-70">(collecting)</span>
     {/if}
   </div>

--- a/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/LoudestTopics/LoudestTopics.svelte
@@ -35,7 +35,10 @@
     return `${parts[0]}/…/${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
   };
 
-  $: hasOverflow = loudest.overflowTopics > 0;
+  // The footer names the exact unattributed rate, never a topic count: the
+  // per-second top-K capture and the admission cap both discard topics without
+  // counting them, so no honest total is available here.
+  $: hasOverflow = loudest.overflowTopics > 0 || loudest.overflowMsgPerSec > 0;
 </script>
 
 <div
@@ -85,9 +88,7 @@
 
     {#if hasOverflow}
       <span class="text-sm text-secondary-text opacity-70">
-        {loudest.overflowTopics}+ more topics, {formatMetricValue(
-          loudest.overflowMsgPerSec
-        )} msg/s
+        Other topics, {formatMetricValue(loudest.overflowMsgPerSec)} msg/s
       </span>
     {/if}
   {/if}

--- a/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
@@ -192,9 +192,10 @@
 >
   <div class="flex max-h-[70vh] w-[520px] max-w-[86vw] flex-col gap-5 overflow-y-auto">
     <!-- Draft form: add mode, or edit when a row was picked. The floating
-         labels sit above each input's box, so rows need the larger gap (and
-         the first row clearance from the description) to keep them readable. -->
-    <div class="flex flex-col gap-5 pt-2">
+         labels sit ABOVE each input's box, so rows need the larger gap, and
+         the first row needs enough top padding inside the scroll container's
+         clip box or the floated labels render with their tops cut off. -->
+    <div class="flex flex-col gap-5 pt-3">
       <div class="flex flex-col gap-5 sm:flex-row">
         <BaseInput
           name="mapping-label"

--- a/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
@@ -188,9 +188,9 @@
 <Dialog
   {isOpen}
   title="Metric tiles"
-  description="Redirect a builtin tile to your broker's topics, or add your own custom tiles. Changes apply to this connection."
+  description="Redirect a built-in tile to your broker's topics, or add your own custom tiles. Changes apply to this connection."
 >
-  <div class="flex w-[520px] max-w-[86vw] flex-col gap-5">
+  <div class="flex max-h-[70vh] w-[520px] max-w-[86vw] flex-col gap-5 overflow-y-auto">
     <!-- Draft form: add mode, or edit when a row was picked. The floating
          labels sit above each input's box, so rows need the larger gap (and
          the first row clearance from the description) to keep them readable. -->

--- a/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
@@ -35,9 +35,14 @@
   const NONE_VALUE = "";
   const NONE_LABEL = "None (custom tile)";
 
-  // Overridable builtins only — the computed observed_* tiles have no topic to
-  // redirect, so they are not offered as override targets.
-  const overrideTargets = BUILTIN_METRICS.filter((m) => !m.computed);
+  // Overridable builtins only, via an explicit allowlist: a metric is offered
+  // when it is an override target (overrideTarget !== false) and not a computed
+  // tile (computed tiles have no topic to redirect). This drops the v2 internal
+  // diagnostic / derived-input metrics (msgs_dropped, heap, store, ...) that
+  // carry overrideTarget: false and would only confuse a manual remap.
+  const overrideTargets = BUILTIN_METRICS.filter(
+    (m) => m.overrideTarget !== false && !m.computed
+  );
   const overrideOptions: string[] = [
     NONE_VALUE,
     ...overrideTargets.map((m) => m.key),

--- a/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
@@ -191,9 +191,11 @@
   description="Redirect a builtin tile to your broker's topics, or add your own custom tiles. Changes apply to this connection."
 >
   <div class="flex w-[520px] max-w-[86vw] flex-col gap-5">
-    <!-- Draft form: add mode, or edit when a row was picked. -->
-    <div class="flex flex-col gap-3">
-      <div class="flex flex-col gap-3 sm:flex-row">
+    <!-- Draft form: add mode, or edit when a row was picked. The floating
+         labels sit above each input's box, so rows need the larger gap (and
+         the first row clearance from the description) to keep them readable. -->
+    <div class="flex flex-col gap-5 pt-2">
+      <div class="flex flex-col gap-5 sm:flex-row">
         <BaseInput
           name="mapping-label"
           label="Label"
@@ -217,7 +219,7 @@
         errorMessage={topicError}
         onChange={() => (topicError = undefined)}
       />
-      <div class="flex flex-col gap-3 sm:flex-row">
+      <div class="flex flex-col gap-5 sm:flex-row">
         <BaseInput
           name="mapping-path"
           label="JSON path (optional)"

--- a/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/MetricMappingEditor/MetricMappingEditor.svelte
@@ -210,6 +210,7 @@
           selected={overrideSelected}
           onChange={onOverrideChange}
           sameWidth
+          menuClass="z-[10002]"
         />
       </div>
       <BaseInput

--- a/frontend/src/views/BrokerStatusWindow/components/Sparkline/Sparkline.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/Sparkline/Sparkline.stories.svelte
@@ -26,6 +26,18 @@
     { t: now - 2000, v: 10 },
     { t: now, v: 30 },
   ];
+  // 900 samples (a full 15 m window at 1 Hz) to exercise the min-max decimation
+  // down to <= 150 rendered points; peaks and troughs must survive.
+  const manyPoints = Array.from({ length: 900 }, (_, i) => ({
+    t: now - (899 - i) * 1000,
+    v: 50 + Math.sin(i / 11) * 30 + (i % 53 === 0 ? 40 : 0),
+  }));
+  // Every sample shares one timestamp (degenerate case): index bucketing must
+  // still render rather than collapse.
+  const sameTime = Array.from({ length: 400 }, (_, i) => ({
+    t: now,
+    v: 20 + (i % 9) * 5,
+  }));
 
   const { Story } = defineMeta({
     title: "Views/BrokerStatusWindow/Sparkline",
@@ -51,4 +63,6 @@
   args={{ ...storyArgs, points: [{ t: now, v: 5 }] }}
   {template}
 />
+<Story name="ManyPoints" args={{ ...storyArgs, points: manyPoints }} {template} />
+<Story name="SameTimestamp" args={{ ...storyArgs, points: sameTime }} {template} />
 <Story name="Empty" args={{ ...storyArgs, points: [] }} {template} />

--- a/frontend/src/views/BrokerStatusWindow/components/Sparkline/Sparkline.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/Sparkline/Sparkline.svelte
@@ -7,11 +7,46 @@
   const width = 100;
   const pad = 2;
 
-  const toPolylinePoints = (
-    pts: { t: number; v: number }[],
-    h: number
-  ): string => {
-    if (pts.length < 2) return "";
+  // Cap on rendered points. A 15 m sparkline holds up to 900 samples; the SVG
+  // is ~100 px wide, so more than ~150 points is invisible detail and wasted
+  // DOM. See docs/broker-status-v2-spec.md.
+  const MAX_POINTS = 150;
+
+  type Pt = { t: number; v: number };
+
+  // Min-max decimation bucketed BY ARRAY INDEX (never by time): each bucket
+  // emits its lowest and highest sample in original order, so peaks and troughs
+  // survive. Index bucketing sidesteps the degenerate case where every sample
+  // shares one timestamp (a time-bucketed pass would collapse them all). The
+  // true last sample is always emitted so the line ends where the data does.
+  const decimate = (pts: Pt[]): Pt[] => {
+    if (pts.length <= MAX_POINTS) return pts;
+    const buckets = Math.floor(MAX_POINTS / 2); // 2 emitted points per bucket
+    const bucketSize = pts.length / buckets;
+    const out: Pt[] = [];
+    for (let b = 0; b < buckets; b++) {
+      const start = Math.floor(b * bucketSize);
+      const end = Math.min(pts.length, Math.floor((b + 1) * bucketSize));
+      if (start >= end) continue;
+      let minI = start;
+      let maxI = start;
+      for (let i = start + 1; i < end; i++) {
+        if (pts[i].v < pts[minI].v) minI = i;
+        if (pts[i].v > pts[maxI].v) maxI = i;
+      }
+      const lo = Math.min(minI, maxI);
+      const hi = Math.max(minI, maxI);
+      out.push(pts[lo]);
+      if (hi !== lo) out.push(pts[hi]);
+    }
+    const last = pts[pts.length - 1];
+    if (out.length === 0 || out[out.length - 1] !== last) out.push(last);
+    return out;
+  };
+
+  const toPolylinePoints = (rawPts: Pt[], h: number): string => {
+    if (rawPts.length < 2) return "";
+    const pts = decimate(rawPts);
     let tMin = Infinity;
     let tMax = -Infinity;
     let vMin = Infinity;

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.spec.json
@@ -50,15 +50,44 @@
       "required": false,
       "default": false,
       "description": "Shows a subdued 'no data yet' placeholder instead of the value."
+    },
+    {
+      "name": "deltaPct",
+      "type": "number",
+      "required": false,
+      "default": null,
+      "description": "Percentage change across the visible window (last vs first sample). A direction arrow shows only when |deltaPct| >= 2, so steady tiles carry no flicker."
+    },
+    {
+      "name": "exact",
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "Exact, unabbreviated value string for the hover panel; falls back to `value`."
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "One-line note shown at the top of the hover panel (e.g. an observed tile's measurement note)."
+    },
+    {
+      "name": "windowName",
+      "type": "string",
+      "required": false,
+      "default": "15m",
+      "description": "Window the sparkline and delta span; named in the hover panel."
     }
   ],
   "tokens": [
     "elevation-1",
+    "elevation-2",
     "outline",
     "secondary-text",
     "emphasis",
     "primary"
   ],
   "dependencies": ["Sparkline"],
-  "notes": "Figma is not linked yet; stories use local fixtures. Sparkline color is set here via text-primary on the wrapper."
+  "notes": "Figma is not linked yet; stories use local fixtures. Sparkline color is set here via text-primary on the wrapper. The tile owns its hover/focus panel (exact value, min/max, window name) so observed tiles no longer need an outer Tooltip wrapper; the panel opens on group-hover and group-focus-within."
 }

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte
@@ -102,7 +102,7 @@
   name="DeltaUp"
   args={{
     ...storyArgs,
-    label: "Msgs/s in",
+    label: "Msg/s in",
     value: "1.2k",
     unit: undefined,
     deltaPct: 8,
@@ -141,7 +141,7 @@
   name="WithDescription"
   args={{
     ...storyArgs,
-    label: "Observed msgs/s",
+    label: "Observed msg/s",
     value: "36.5",
     unit: undefined,
     description: "Measured by this client across its subscriptions",

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte
@@ -17,6 +17,10 @@
     "kind",
     "points",
     "noData",
+    "deltaPct",
+    "exact",
+    "description",
+    "windowName",
   ];
   const storyArgs = getStoryArgs(storyId, componentName, props);
 
@@ -91,6 +95,58 @@
     unit: undefined,
     points: undefined,
     noData: true,
+  }}
+  {template}
+/>
+<Story
+  name="DeltaUp"
+  args={{
+    ...storyArgs,
+    label: "Msgs/s in",
+    value: "1.2k",
+    unit: undefined,
+    deltaPct: 8,
+    exact: "1,204",
+    points: mockSparklinePoints,
+  }}
+  {template}
+/>
+<Story
+  name="DeltaDown"
+  args={{
+    ...storyArgs,
+    label: "Connected clients",
+    value: "17",
+    unit: undefined,
+    deltaPct: -12,
+    exact: "17",
+    points: mockSparklinePoints,
+  }}
+  {template}
+/>
+<Story
+  name="SmallDeltaNoArrow"
+  args={{
+    ...storyArgs,
+    label: "Subscriptions",
+    value: "126",
+    unit: undefined,
+    deltaPct: 1,
+    exact: "126",
+    points: mockSparklinePoints,
+  }}
+  {template}
+/>
+<Story
+  name="WithDescription"
+  args={{
+    ...storyArgs,
+    label: "Observed msgs/s",
+    value: "36.5",
+    unit: undefined,
+    description: "Measured by this client across its subscriptions",
+    exact: "36.5",
+    points: mockSparklinePoints,
   }}
   {template}
 />

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.stories.svelte
@@ -125,6 +125,21 @@
   {template}
 />
 <Story
+  name="DeltaCapped"
+  args={{
+    ...storyArgs,
+    label: "Store",
+    value: "4.2k",
+    unit: undefined,
+    // Growth from a near-zero baseline (a broker restart refilling its store):
+    // the exact figure is noise, so the tile prints its ceiling.
+    deltaPct: Number.POSITIVE_INFINITY,
+    exact: "4,204",
+    points: mockSparklinePoints,
+  }}
+  {template}
+/>
+<Story
   name="SmallDeltaNoArrow"
   args={{
     ...storyArgs,

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
@@ -105,7 +105,7 @@
        no-data tiles (nothing to detail). -->
   {#if !noData}
   <div
-    class="pointer-events-none absolute left-0 top-full z-[10003] mt-1 hidden w-max max-w-[240px]
+    class="pointer-events-none absolute left-0 right-0 top-full z-[10003] mt-1 hidden
       flex-col gap-0.5 rounded border border-outline bg-elevation-2 px-3 py-2 text-xs
       shadow group-hover:flex group-focus-within:flex"
     role="tooltip"

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
@@ -42,8 +42,10 @@
   $: sampleMin = hasSamples ? Math.min(...points!.map((p) => p.v)) : null;
   $: sampleMax = hasSamples ? Math.max(...points!.map((p) => p.v)) : null;
 
+  // One number format for the whole panel (exact value and min/max): grouped,
+  // at most two decimals.
   const fmtPanelNumber = (n: number): string =>
-    Number.isInteger(n) ? n.toLocaleString() : n.toFixed(2);
+    n.toLocaleString(undefined, { maximumFractionDigits: 2 });
 </script>
 
 <!-- `group` + focus-within drive the hover panel: it opens on pointer hover and
@@ -75,7 +77,7 @@
   </div>
 
   {#if noData}
-    <span class="text-sm text-secondary-text opacity-60">no data yet</span>
+    <span class="text-sm text-secondary-text opacity-60">No data yet</span>
   {:else}
     <div class="flex min-w-0 items-baseline gap-1">
       <span
@@ -96,10 +98,15 @@
   {/if}
 
   <!-- Hover/focus panel: exact value, min/max, and the window it spans. Owned
-       by the tile so each tile has one hover surface (no outer Tooltip). -->
+       by the tile so each tile has one hover surface (no outer Tooltip). It
+       opens BELOW the tile, anchored to its left edge: above-placement clipped
+       against the sticky health strip and the scroll container's top, and a
+       centred panel overflowed the window edge on the outer columns. Hidden on
+       no-data tiles (nothing to detail). -->
+  {#if !noData}
   <div
-    class="pointer-events-none absolute left-1/2 bottom-full z-[10003] mb-1 hidden w-max max-w-[240px]
-      -translate-x-1/2 flex-col gap-0.5 rounded border border-outline bg-elevation-2 px-3 py-2 text-xs
+    class="pointer-events-none absolute left-0 top-full z-[10003] mt-1 hidden w-max max-w-[240px]
+      flex-col gap-0.5 rounded border border-outline bg-elevation-2 px-3 py-2 text-xs
       shadow group-hover:flex group-focus-within:flex"
     role="tooltip"
   >
@@ -114,4 +121,5 @@
     {/if}
     <span class="text-secondary-text">over {windowName}</span>
   </div>
+  {/if}
 </div>

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
@@ -12,14 +12,55 @@
   // text-xl, so they drop to a smaller size and wrap to two lines. Fed from the
   // tile's valueKind (empty tiles use number styling behind the noData state).
   export let kind: "number" | "text" = "number";
+  // Percentage change across the visible window (last vs first sample), supplied
+  // by the caller. A small direction arrow shows only when |delta| >= 2 %, so
+  // steady tiles carry no ambient flicker.
+  export let deltaPct: number | undefined = undefined;
+  // Exact, unabbreviated value string for the hover panel (falls back to the
+  // display `value` when absent).
+  export let exact: string | undefined = undefined;
+  // One-line description shown at the top of the hover panel (e.g. the observed
+  // tiles' "measured by this client" note — this tile owns that hover now).
+  export let description: string | undefined = undefined;
+  // Window the sparkline and delta span, named in the hover panel.
+  export let windowName = "15m";
+
+  const DELTA_THRESHOLD = 2; // percent
 
   $: isText = kind === "text";
+  $: showDelta =
+    !noData && deltaPct !== undefined && Math.abs(deltaPct) >= DELTA_THRESHOLD;
+  $: deltaUp = (deltaPct ?? 0) >= 0;
+
+  // Min/max over the visible samples, for the hover panel.
+  $: hasSamples = !!points && points.length >= 2;
+  $: sampleMin = hasSamples ? Math.min(...points!.map((p) => p.v)) : null;
+  $: sampleMax = hasSamples ? Math.max(...points!.map((p) => p.v)) : null;
+
+  const fmtPanelNumber = (n: number): string =>
+    Number.isInteger(n) ? n.toLocaleString() : n.toFixed(2);
 </script>
 
+<!-- `group` + focus-within drive the hover panel: it opens on pointer hover and
+     on keyboard focus of the tile, matching the spec's hover + focus-visible. -->
 <div
-  class="flex h-full min-w-0 flex-col gap-1 rounded border border-outline bg-elevation-1 p-3"
+  class="group relative flex h-full min-w-0 flex-col gap-1 rounded border border-outline bg-elevation-1 p-3 focus-visible:ring"
+  tabindex="0"
+  role="group"
+  aria-label={label}
 >
-  <span class="truncate text-sm text-secondary-text">{label}</span>
+  <div class="flex min-w-0 items-center gap-1">
+    <span class="min-w-0 flex-1 truncate text-sm text-secondary-text">{label}</span>
+    {#if showDelta}
+      <span
+        class="shrink-0 text-xs tabular-nums text-secondary-text"
+        aria-label={`${deltaUp ? "up" : "down"} ${Math.abs(deltaPct ?? 0).toFixed(0)} percent over ${windowName}`}
+      >
+        {deltaUp ? "↑" : "↓"}{Math.abs(deltaPct ?? 0).toFixed(0)}%
+      </span>
+    {/if}
+  </div>
+
   {#if noData}
     <span class="text-base text-secondary-text opacity-60">no data yet</span>
   {:else}
@@ -40,4 +81,24 @@
       </div>
     {/if}
   {/if}
+
+  <!-- Hover/focus panel: exact value, min/max, and the window it spans. Owned
+       by the tile so each tile has one hover surface (no outer Tooltip). -->
+  <div
+    class="pointer-events-none absolute left-1/2 bottom-full z-[10003] mb-1 hidden w-max max-w-[240px]
+      -translate-x-1/2 flex-col gap-0.5 rounded border border-outline bg-elevation-2 px-3 py-2 text-xs
+      shadow group-hover:flex group-focus-within:flex"
+    role="tooltip"
+  >
+    {#if description}
+      <span class="text-secondary-text">{description}</span>
+    {/if}
+    <span class="font-mono tabular-nums text-emphasis">{exact ?? value}</span>
+    {#if sampleMin !== null && sampleMax !== null}
+      <span class="font-mono tabular-nums text-secondary-text">
+        min {fmtPanelNumber(sampleMin)}, max {fmtPanelNumber(sampleMax)}
+      </span>
+    {/if}
+    <span class="text-secondary-text">over {windowName}</span>
+  </div>
 </div>

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
@@ -7,13 +7,13 @@
   export let points: { t: number; v: number }[] | undefined = undefined;
   export let noData = false;
   // How to render `value`. Numbers are SI-abbreviated by the caller and stay
-  // short, so they render big and tabular on one line. Text values (e.g.
-  // "mosquitto version 2.0.18") would truncate to "mosquitto versio…" at
-  // text-xl, so they drop to a smaller size and wrap to two lines. Fed from the
-  // tile's valueKind (empty tiles use number styling behind the noData state).
+  // short, so they render big and tabular on one line. Text values (e.g. a
+  // custom tile bound to a string topic) would truncate at the large size, so
+  // they drop to a smaller size and wrap to two lines. Fed from the tile's
+  // valueKind (empty tiles use number styling behind the noData state).
   export let kind: "number" | "text" = "number";
   // Percentage change across the visible window (last vs first sample), supplied
-  // by the caller. A small direction arrow shows only when |delta| >= 2 %, so
+  // by the caller. A small direction glyph shows only when |delta| >= 2 %, so
   // steady tiles carry no ambient flicker.
   export let deltaPct: number | undefined = undefined;
   // Exact, unabbreviated value string for the hover panel (falls back to the
@@ -28,8 +28,13 @@
   const DELTA_THRESHOLD = 2; // percent
 
   $: isText = kind === "text";
+  // Infinity means "grew from a zero baseline": always worth showing, but as a
+  // bare direction glyph (a percentage against zero is meaningless).
+  $: deltaUnbounded = deltaPct !== undefined && !Number.isFinite(deltaPct);
   $: showDelta =
-    !noData && deltaPct !== undefined && Math.abs(deltaPct) >= DELTA_THRESHOLD;
+    !noData &&
+    deltaPct !== undefined &&
+    (deltaUnbounded || Math.abs(deltaPct) >= DELTA_THRESHOLD);
   $: deltaUp = (deltaPct ?? 0) >= 0;
 
   // Min/max over the visible samples, for the hover panel.
@@ -44,40 +49,48 @@
 <!-- `group` + focus-within drive the hover panel: it opens on pointer hover and
      on keyboard focus of the tile, matching the spec's hover + focus-visible. -->
 <div
-  class="group relative flex h-full min-w-0 flex-col gap-1 rounded border border-outline bg-elevation-1 p-3 focus-visible:ring"
+  class="group relative flex h-full min-w-0 flex-col gap-0.5 rounded border border-outline bg-elevation-1 px-3 pb-2 pt-2.5 focus-visible:ring"
   tabindex="0"
   role="group"
   aria-label={label}
 >
-  <div class="flex min-w-0 items-center gap-1">
-    <span class="min-w-0 flex-1 truncate text-sm text-secondary-text">{label}</span>
+  <div class="flex min-w-0 items-baseline gap-1">
+    <span class="min-w-0 flex-1 truncate text-xs text-secondary-text"
+      >{label}</span
+    >
     {#if showDelta}
       <span
-        class="shrink-0 text-xs tabular-nums text-secondary-text"
-        aria-label={`${deltaUp ? "up" : "down"} ${Math.abs(deltaPct ?? 0).toFixed(0)} percent over ${windowName}`}
+        class="shrink-0 font-mono text-[10px] tabular-nums leading-none text-secondary-text"
+        aria-label={deltaUnbounded
+          ? `up from zero over ${windowName}`
+          : `${deltaUp ? "up" : "down"} ${Math.abs(deltaPct ?? 0).toFixed(0)} percent over ${windowName}`}
       >
-        {deltaUp ? "↑" : "↓"}{Math.abs(deltaPct ?? 0).toFixed(0)}%
+        {#if deltaUnbounded}
+          ▲
+        {:else}
+          {deltaUp ? "▲" : "▼"} {Math.abs(deltaPct ?? 0).toFixed(0)}%
+        {/if}
       </span>
     {/if}
   </div>
 
   {#if noData}
-    <span class="text-base text-secondary-text opacity-60">no data yet</span>
+    <span class="text-sm text-secondary-text opacity-60">no data yet</span>
   {:else}
     <div class="flex min-w-0 items-baseline gap-1">
       <span
         class={isText
-          ? "line-clamp-2 text-base font-medium leading-snug text-emphasis"
-          : "truncate text-xl font-medium tabular-nums text-emphasis"}
+          ? "line-clamp-2 text-sm font-medium leading-snug text-emphasis"
+          : "truncate font-mono text-lg font-semibold tabular-nums leading-tight text-emphasis"}
         >{value}</span
       >
       {#if unit}
-        <span class="shrink-0 text-sm text-secondary-text">{unit}</span>
+        <span class="shrink-0 text-xs text-secondary-text">{unit}</span>
       {/if}
     </div>
     {#if points && points.length >= 2}
-      <div class="mt-1 text-primary opacity-70">
-        <Sparkline {points} />
+      <div class="mt-1.5 text-primary opacity-70">
+        <Sparkline {points} height={26} />
       </div>
     {/if}
   {/if}

--- a/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/StatTile/StatTile.svelte
@@ -14,7 +14,8 @@
   export let kind: "number" | "text" = "number";
   // Percentage change across the visible window (last vs first sample), supplied
   // by the caller. A small direction glyph shows only when |delta| >= 2 %, so
-  // steady tiles carry no ambient flicker.
+  // steady tiles carry no ambient flicker. Anything past 999 % (including
+  // Infinity, from a zero baseline) prints as ">999%".
   export let deltaPct: number | undefined = undefined;
   // Exact, unabbreviated value string for the hover panel (falls back to the
   // display `value` when absent).
@@ -22,25 +23,49 @@
   // One-line description shown at the top of the hover panel (e.g. the observed
   // tiles' "measured by this client" note — this tile owns that hover now).
   export let description: string | undefined = undefined;
-  // Window the sparkline and delta span, named in the hover panel.
+  // Window the sparkline and delta span, named in the hover panel. The caller
+  // derives it from the samples actually held, not a fixed constant.
   export let windowName = "15m";
 
   const DELTA_THRESHOLD = 2; // percent
+  // Ceiling on the printed percentage. Past this the exact figure carries no
+  // information ("up 12,364%" reads as a bug), and a near-zero baseline can
+  // make it arbitrarily large or infinite.
+  const DELTA_MAX_PCT = 999;
 
   $: isText = kind === "text";
-  // Infinity means "grew from a zero baseline": always worth showing, but as a
-  // bare direction glyph (a percentage against zero is meaningless).
-  $: deltaUnbounded = deltaPct !== undefined && !Number.isFinite(deltaPct);
+  // Growth from a zero (or vanishing) baseline: a percentage against it is
+  // meaningless, so it shares the ">999%" ceiling rather than printing a bare
+  // arrow with no number.
+  $: deltaCapped =
+    deltaPct !== undefined &&
+    (!Number.isFinite(deltaPct) || Math.abs(deltaPct) > DELTA_MAX_PCT);
   $: showDelta =
     !noData &&
     deltaPct !== undefined &&
-    (deltaUnbounded || Math.abs(deltaPct) >= DELTA_THRESHOLD);
+    (deltaCapped || Math.abs(deltaPct) >= DELTA_THRESHOLD);
   $: deltaUp = (deltaPct ?? 0) >= 0;
+  $: deltaText = deltaCapped
+    ? `>${DELTA_MAX_PCT}%`
+    : `${Math.abs(deltaPct ?? 0).toFixed(0)}%`;
 
-  // Min/max over the visible samples, for the hover panel.
-  $: hasSamples = !!points && points.length >= 2;
-  $: sampleMin = hasSamples ? Math.min(...points!.map((p) => p.v)) : null;
-  $: sampleMax = hasSamples ? Math.max(...points!.map((p) => p.v)) : null;
+  // Min/max over the visible samples, for the hover panel. One pass, no spread:
+  // this recomputes on every store flush, for every tile.
+  const extent = (
+    pts: { t: number; v: number }[] | undefined
+  ): { min: number; max: number } | null => {
+    if (!pts || pts.length < 2) return null;
+    let min = pts[0].v;
+    let max = pts[0].v;
+    for (let i = 1; i < pts.length; i++) {
+      const v = pts[i].v;
+      if (v < min) min = v;
+      else if (v > max) max = v;
+    }
+    return { min, max };
+  };
+
+  $: sampleExtent = extent(points);
 
   // One number format for the whole panel (exact value and min/max): grouped,
   // at most two decimals.
@@ -62,16 +87,12 @@
     >
     {#if showDelta}
       <span
-        class="shrink-0 font-mono text-[10px] tabular-nums leading-none text-secondary-text"
-        aria-label={deltaUnbounded
-          ? `up from zero over ${windowName}`
-          : `${deltaUp ? "up" : "down"} ${Math.abs(deltaPct ?? 0).toFixed(0)} percent over ${windowName}`}
+        class="shrink-0 font-mono text-xs tabular-nums leading-none text-secondary-text"
+        aria-label={`${deltaUp ? "up" : "down"} ${
+          deltaCapped ? "more than 999" : Math.abs(deltaPct ?? 0).toFixed(0)
+        } percent over ${windowName}`}
       >
-        {#if deltaUnbounded}
-          ▲
-        {:else}
-          {deltaUp ? "▲" : "▼"} {Math.abs(deltaPct ?? 0).toFixed(0)}%
-        {/if}
+        {deltaUp ? "▲" : "▼"} {deltaText}
       </span>
     {/if}
   </div>
@@ -114,9 +135,9 @@
       <span class="text-secondary-text">{description}</span>
     {/if}
     <span class="font-mono tabular-nums text-emphasis">{exact ?? value}</span>
-    {#if sampleMin !== null && sampleMax !== null}
+    {#if sampleExtent}
       <span class="font-mono tabular-nums text-secondary-text">
-        min {fmtPanelNumber(sampleMin)}, max {fmtPanelNumber(sampleMax)}
+        min {fmtPanelNumber(sampleExtent.min)}, max {fmtPanelNumber(sampleExtent.max)}
       </span>
     {/if}
     <span class="text-secondary-text">over {windowName}</span>

--- a/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.spec.json
+++ b/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.spec.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../../../design-system/component-spec.schema.json",
+  "name": "TimeRangeSelector",
+  "tier": "view",
+  "description": "Small segmented control for the broker-status window range (1m / 5m / 15m); emits a legacy `change` event with the selected minutes.",
+  "status": "story-only",
+  "figma": {
+    "fileKey": "",
+    "nodeId": "",
+    "url": "",
+    "lastSyncedHash": null,
+    "lastSyncedAt": null
+  },
+  "props": [
+    {
+      "name": "value",
+      "type": "number",
+      "required": false,
+      "default": 5,
+      "description": "Selected window in minutes; one of `options`."
+    },
+    {
+      "name": "options",
+      "type": "object",
+      "required": false,
+      "default": [1, 5, 15],
+      "description": "Selectable windows in minutes."
+    },
+    {
+      "name": "sparseNote",
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "Optional tooltip on the group explaining sparse broker series at short ranges. Nothing is ever disabled."
+    }
+  ],
+  "tokens": ["outline", "elevation-1", "selected", "emphasis", "secondary-text"],
+  "dependencies": ["Tooltip"],
+  "notes": "Emits on:change (legacy createEventDispatcher) with the selected minutes as detail."
+}

--- a/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.stories.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.stories.svelte
@@ -1,0 +1,37 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import Component from "./TimeRangeSelector.svelte";
+  import StoryRender from "@/stories/StoryRender.svelte";
+
+  const componentName = "TimeRangeSelector";
+
+  const { Story } = defineMeta({
+    title: "Views/BrokerStatusWindow/TimeRangeSelector",
+    component: Component,
+    tags: ["autodocs"],
+    argTypes: {
+      value: { control: { type: "number" } },
+    },
+    parameters: { design: { type: "figma", url: "" } },
+  });
+</script>
+
+{#snippet template(args: any)}
+  <StoryRender component={Component} {args} {componentName} />
+{/snippet}
+
+<Story
+  name="Default"
+  args={{ value: 5, options: [1, 5, 15] }}
+  {template}
+/>
+<Story name="OneMinute" args={{ value: 1, options: [1, 5, 15] }} {template} />
+<Story
+  name="SparseNote"
+  args={{
+    value: 1,
+    options: [1, 5, 15],
+    sparseNote: "broker publishes about every 10s",
+  }}
+  {template}
+/>

--- a/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import Tooltip from "@/components/Tooltip/Tooltip.svelte";
+
+  // Selected window in minutes; one of `options`.
+  export let value = 5;
+  export let options: number[] = [1, 5, 15];
+  // Optional note explaining sparse broker series at short ranges; shown as a
+  // tooltip on the whole group when set (nothing is ever disabled).
+  export let sparseNote: string | undefined = undefined;
+
+  const dispatch = createEventDispatcher<{ change: number }>();
+
+  const select = (minutes: number) => {
+    if (minutes === value) return;
+    value = minutes;
+    dispatch("change", minutes);
+  };
+</script>
+
+<Tooltip text={sparseNote ?? ""} placement="bottom">
+  <div
+    class="inline-flex items-center gap-0.5 rounded border border-outline bg-elevation-1 p-0.5"
+    role="group"
+    aria-label="Time range"
+  >
+    {#each options as minutes (minutes)}
+      <button
+        type="button"
+        aria-pressed={minutes === value}
+        class={`rounded px-2 py-0.5 text-sm tabular-nums transition-colors ${
+          minutes === value
+            ? "bg-selected text-emphasis"
+            : "text-secondary-text hover:text-emphasis"
+        }`}
+        on:click={() => select(minutes)}
+      >
+        {minutes}m
+      </button>
+    {/each}
+  </div>
+</Tooltip>

--- a/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.svelte
+++ b/frontend/src/views/BrokerStatusWindow/components/TimeRangeSelector/TimeRangeSelector.svelte
@@ -18,7 +18,7 @@
   };
 </script>
 
-<Tooltip text={sparseNote ?? ""} placement="bottom">
+<Tooltip text={sparseNote ?? ""} placement="bottom" class="inline-flex w-fit">
   <div
     class="inline-flex items-center gap-0.5 rounded border border-outline bg-elevation-1 p-0.5"
     role="group"

--- a/frontend/src/views/BrokerStatusWindow/health.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/health.test.ts
@@ -136,21 +136,28 @@ describe("applyHysteresis", () => {
 // --- evaluateHealth: rendering + minimum samples -----------------------------
 
 describe("evaluateHealth — rendering gate", () => {
-  it("renders nothing for a chip with fewer than 2 samples", () => {
-    const chips = evalHealth(
-      { msgs_dropped: metric(0, series([0], 10_000)) },
-      10_000
-    );
+  it("renders nothing for a chip with no samples", () => {
+    const chips = evalHealth({ msgs_dropped: metric(null, []) }, 10_000);
     expect(chips.drops.render).toBe(false);
     expect(chips.drops.level).toBeNull();
   });
 
-  it("1-sample degenerate case at 60 s cadence: still nothing", () => {
+  it("renders ok from one gauge sample (change-only republishers never re-emit a flat zero)", () => {
+    const chips = evalHealth(
+      { msgs_dropped: metric(0, series([0], 10_000)) },
+      10_000
+    );
+    expect(chips.drops.render).toBe(true);
+    expect(chips.drops.level).toBe("ok");
+  });
+
+  it("one backlog gauge sample at 60 s cadence renders without a trend state", () => {
     const chips = evalHealth(
       { delivery_backlog: metric(7, series([7], 60_000)) },
       60_000
     );
-    expect(chips.backlog.render).toBe(false);
+    expect(chips.backlog.render).toBe(true);
+    expect(chips.backlog.level).toBe("ok");
   });
 });
 

--- a/frontend/src/views/BrokerStatusWindow/health.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/health.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyHysteresis,
+  evaluateHealth,
+  isRising,
+  HYSTERESIS_MIN_MS,
+  type HealthChip,
+  type HealthChipId,
+  type HealthChipState,
+  type HealthMetric,
+  type TrendSample,
+} from "./health";
+
+const NOW = 1_000_000_000;
+
+// Build a sample trail ending at `now`, one point per `cadenceMs`, in time
+// order (oldest first) — the shape the store's runtime produces.
+const series = (
+  values: number[],
+  cadenceMs: number,
+  now = NOW
+): TrendSample[] =>
+  values.map((v, i) => ({
+    t: now - (values.length - 1 - i) * cadenceMs,
+    v,
+  }));
+
+const metric = (
+  value: number | null,
+  samples: TrendSample[]
+): HealthMetric => ({ value, samples });
+
+const chipsById = (chips: HealthChip[]): Record<string, HealthChip> =>
+  Object.fromEntries(chips.map((c) => [c.id, c]));
+
+const evalHealth = (
+  inputs: Parameters<typeof evaluateHealth>[0],
+  interval: number,
+  prev: Map<HealthChipId, HealthChipState> = new Map(),
+  now = NOW
+) => chipsById(evaluateHealth(inputs, prev, now, interval).chips);
+
+// --- isRising: cadence-robust trend ------------------------------------------
+
+describe("isRising", () => {
+  it("rises on 3 strictly increasing in-window samples (10 s cadence)", () => {
+    expect(isRising(series([1, 2, 3], 10_000), NOW, 60_000, 10_000)).toBe(true);
+  });
+
+  it("does not rise when the value held flat", () => {
+    expect(isRising(series([3, 3, 3], 10_000), NOW, 60_000, 10_000)).toBe(false);
+  });
+
+  it("needs at least 3 in-window samples", () => {
+    expect(isRising(series([1, 2], 10_000), NOW, 60_000, 10_000)).toBe(false);
+  });
+
+  it("is false when the newest sample is older than 2x the interval", () => {
+    // 3 rising samples but the freshest is 30 s old at a 10 s interval.
+    const stale = series([1, 2, 3], 10_000, NOW - 30_000);
+    expect(isRising(stale, NOW, 60_000, 10_000)).toBe(false);
+  });
+
+  it("uses max(ruleWindow, 3x interval) so a 60 s cadence still qualifies", () => {
+    // At a 60 s interval, 3 samples span 120 s — inside the 180 s effective
+    // window (3 × 60 s), and the fixed 60 s rule window alone would exclude the
+    // two older points.
+    expect(isRising(series([1, 2, 3], 60_000), NOW, 60_000, 60_000)).toBe(true);
+  });
+
+  it("holds for a 20 s cadence", () => {
+    expect(isRising(series([5, 7, 9, 11], 20_000), NOW, 60_000, 20_000)).toBe(
+      true
+    );
+  });
+});
+
+// --- applyHysteresis ---------------------------------------------------------
+
+describe("applyHysteresis", () => {
+  const hold = HYSTERESIS_MIN_MS;
+
+  it("adopts the first level immediately", () => {
+    const s = applyHysteresis(undefined, "problem", NOW, hold);
+    expect(s.level).toBe("problem");
+    expect(s.since).toBe(NOW);
+  });
+
+  it("upgrades immediately and clears any pending downgrade", () => {
+    const prev: HealthChipState = {
+      level: "attention",
+      since: NOW - 5000,
+      pendingLevel: "ok",
+      pendingSince: NOW - 1000,
+    };
+    const s = applyHysteresis(prev, "problem", NOW, hold);
+    expect(s.level).toBe("problem");
+    expect(s.pendingLevel).toBeNull();
+  });
+
+  it("holds a downgrade until the lower level persists for holdMs", () => {
+    const start: HealthChipState = {
+      level: "problem",
+      since: NOW,
+      pendingLevel: null,
+      pendingSince: 0,
+    };
+    // Raw drops to ok: begins the hold, still shows problem.
+    const s1 = applyHysteresis(start, "ok", NOW + 1000, hold);
+    expect(s1.level).toBe("problem");
+    expect(s1.pendingLevel).toBe("ok");
+
+    // Just before the hold elapses: still problem.
+    const s2 = applyHysteresis(s1, "ok", NOW + 1000 + hold - 1, hold);
+    expect(s2.level).toBe("problem");
+
+    // Hold elapsed: now ok.
+    const s3 = applyHysteresis(s1, "ok", NOW + 1000 + hold, hold);
+    expect(s3.level).toBe("ok");
+  });
+
+  it("restarts the hold if the raw level bounces back up mid-hold", () => {
+    const start: HealthChipState = {
+      level: "problem",
+      since: NOW,
+      pendingLevel: null,
+      pendingSince: 0,
+    };
+    const holding = applyHysteresis(start, "ok", NOW + 1000, hold);
+    const bounced = applyHysteresis(holding, "problem", NOW + 2000, hold);
+    expect(bounced.level).toBe("problem");
+    expect(bounced.pendingLevel).toBeNull();
+  });
+});
+
+// --- evaluateHealth: rendering + minimum samples -----------------------------
+
+describe("evaluateHealth — rendering gate", () => {
+  it("renders nothing for a chip with fewer than 2 samples", () => {
+    const chips = evalHealth(
+      { msgs_dropped: metric(0, series([0], 10_000)) },
+      10_000
+    );
+    expect(chips.drops.render).toBe(false);
+    expect(chips.drops.level).toBeNull();
+  });
+
+  it("1-sample degenerate case at 60 s cadence: still nothing", () => {
+    const chips = evalHealth(
+      { delivery_backlog: metric(7, series([7], 60_000)) },
+      60_000
+    );
+    expect(chips.backlog.render).toBe(false);
+  });
+});
+
+// --- evaluateHealth: Drops ---------------------------------------------------
+
+describe("evaluateHealth — Drops", () => {
+  it("ok when the drop rate is zero", () => {
+    const chips = evalHealth(
+      { msgs_dropped: metric(0, series([0, 0], 10_000)) },
+      10_000
+    );
+    expect(chips.drops.level).toBe("ok");
+    expect(chips.drops.qualifier).toBe("");
+  });
+
+  it("attention when dropping steadily but not rising", () => {
+    const chips = evalHealth(
+      { msgs_dropped: metric(2, series([2, 2], 10_000)) },
+      10_000
+    );
+    expect(chips.drops.level).toBe("attention");
+    expect(chips.drops.qualifier).toBe("present");
+  });
+
+  it("problem when the drop rate is rising", () => {
+    const chips = evalHealth(
+      { msgs_dropped: metric(3, series([1, 2, 3], 10_000)) },
+      10_000
+    );
+    expect(chips.drops.level).toBe("problem");
+    expect(chips.drops.qualifier).toBe("rising");
+  });
+
+  it("problem when drops exceed 5% of inbound (flat, guarded by inbound >= 1)", () => {
+    const chips = evalHealth(
+      {
+        msgs_dropped: metric(5, series([5, 5], 10_000)),
+        msg_rate_in: metric(50, series([50, 50], 10_000)),
+      },
+      10_000
+    );
+    expect(chips.drops.level).toBe("problem");
+  });
+
+  it("never fires the relative rule on inbound below 1 msg/s", () => {
+    const chips = evalHealth(
+      {
+        msgs_dropped: metric(5, series([5, 5], 10_000)),
+        msg_rate_in: metric(0.5, series([0.5, 0.5], 10_000)),
+      },
+      10_000
+    );
+    expect(chips.drops.level).toBe("attention"); // not problem
+  });
+});
+
+// --- evaluateHealth: Delivery backlog ----------------------------------------
+
+describe("evaluateHealth — Delivery backlog", () => {
+  it("ok on an idle plateau (packet/out/count flat)", () => {
+    const chips = evalHealth(
+      { delivery_backlog: metric(10, series([10, 10, 10, 10], 10_000)) },
+      10_000
+    );
+    expect(chips.backlog.level).toBe("ok");
+  });
+
+  it("attention when rising only inside the 60 s window", () => {
+    // Flat for the first ~60 s (inside the 120 s problem window), rising only in
+    // the last 60 s → the attention window sees a rise, the problem window sees
+    // an earlier plateau.
+    const values = [10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 14, 15, 16];
+    const chips = evalHealth(
+      { delivery_backlog: metric(16, series(values, 10_000)) },
+      10_000
+    );
+    expect(chips.backlog.level).toBe("attention");
+  });
+
+  it("problem when rising across the whole 120 s window", () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+    const chips = evalHealth(
+      { delivery_backlog: metric(13, series(values, 10_000)) },
+      10_000
+    );
+    expect(chips.backlog.level).toBe("problem");
+  });
+});
+
+// --- evaluateHealth: Store (never red), Heap + Churn (informational) ---------
+
+describe("evaluateHealth — Store / Heap / Churn", () => {
+  it("store goes attention while rising and never problem", () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+    const chips = evalHealth(
+      { store_msgs: metric(13, series(values, 10_000)) },
+      10_000
+    );
+    expect(chips.store.level).toBe("attention");
+  });
+
+  it("store ok when flat", () => {
+    const chips = evalHealth(
+      { store_msgs: metric(5, series([5, 5, 5], 10_000)) },
+      10_000
+    );
+    expect(chips.store.level).toBe("ok");
+  });
+
+  it("heap is informational: value + peak, no state dot", () => {
+    const chips = evalHealth(
+      {
+        heap_current: metric(8_200_000, series([8_000_000, 8_200_000], 10_000)),
+        heap_max: metric(9_100_000, series([9_100_000, 9_100_000], 10_000)),
+      },
+      10_000
+    );
+    expect(chips.heap.informational).toBe(true);
+    expect(chips.heap.level).toBeNull();
+    expect(chips.heap.value).toBe(8_200_000);
+    expect(chips.heap.detail).toBe(9_100_000);
+  });
+
+  it("churn is informational", () => {
+    const chips = evalHealth(
+      { sockets_1min: metric(1.5, series([1.5, 1.5], 10_000)) },
+      10_000
+    );
+    expect(chips.churn.informational).toBe(true);
+    expect(chips.churn.value).toBe(1.5);
+  });
+});
+
+// --- evaluateHealth: staleness ------------------------------------------------
+
+describe("evaluateHealth — staleness", () => {
+  it("greys a chip whose source has been silent past 3x interval + 30 s", () => {
+    // Newest sample 200 s old at a 10 s interval → threshold 60 s → stale.
+    const chips = evalHealth(
+      { store_msgs: metric(5, series([5, 5], 10_000, NOW - 200_000)) },
+      10_000
+    );
+    expect(chips.store.render).toBe(true);
+    expect(chips.store.stale).toBe(true);
+    expect(chips.store.qualifier).toBe(""); // qualifier drops when stale
+  });
+
+  it("is not stale while samples arrive within the threshold", () => {
+    const chips = evalHealth(
+      { store_msgs: metric(5, series([5, 5], 10_000)) },
+      10_000
+    );
+    expect(chips.store.stale).toBe(false);
+  });
+});
+
+// --- evaluateHealth: hysteresis persistence via the state map ----------------
+
+describe("evaluateHealth — hysteresis across ticks", () => {
+  it("holds a problem→ok downgrade for max(30 s, interval)", () => {
+    const rising = series([1, 2, 3], 10_000);
+    // Tick 1: rising drops → problem.
+    const first = evaluateHealth(
+      { msgs_dropped: metric(3, rising) },
+      new Map(),
+      NOW,
+      10_000
+    );
+    expect(chipsById(first.chips).drops.level).toBe("problem");
+
+    // Tick 2 (+1 s): drops cleared to flat zero → still problem (hysteresis).
+    const flatZero = series([0, 0], 10_000, NOW + 1000);
+    const second = evaluateHealth(
+      { msgs_dropped: metric(0, flatZero) },
+      first.states,
+      NOW + 1000,
+      10_000
+    );
+    expect(chipsById(second.chips).drops.level).toBe("problem");
+
+    // Tick 3 (+31 s from the clear): the 30 s hold elapsed → ok.
+    const later = series([0, 0], 10_000, NOW + 32_000);
+    const third = evaluateHealth(
+      { msgs_dropped: metric(0, later) },
+      second.states,
+      NOW + 32_000,
+      10_000
+    );
+    expect(chipsById(third.chips).drops.level).toBe("ok");
+  });
+});

--- a/frontend/src/views/BrokerStatusWindow/health.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/health.test.ts
@@ -349,3 +349,28 @@ describe("evaluateHealth — hysteresis across ticks", () => {
     expect(chipsById(third.chips).drops.level).toBe("ok");
   });
 });
+
+describe("trend floor", () => {
+  it("ignores samples from before the floor", () => {
+    const rising = series([1, 2, 3, 4], 10_000);
+    expect(isRising(rising, NOW, 60_000, 10_000)).toBe(true);
+    // Floor set just past the second-oldest sample: only two samples remain,
+    // which is under the three-sample minimum.
+    expect(isRising(rising, NOW, 60_000, 10_000, NOW - 15_000)).toBe(false);
+  });
+
+  it("suppresses every trend while the floor is in the future", () => {
+    const climbing = series([10, 20, 30, 40], 10_000);
+    const { chips } = evaluateHealth(
+      { store_msgs: metric(40, climbing) },
+      new Map<HealthChipId, HealthChipState>(),
+      NOW,
+      10_000,
+      NOW + 30_000 // settle period after a reconnect
+    );
+    const store = chipsById(chips).store;
+    expect(store.render).toBe(true);
+    expect(store.level).toBe("ok");
+    expect(store.qualifier).toBe("");
+  });
+});

--- a/frontend/src/views/BrokerStatusWindow/health.ts
+++ b/frontend/src/views/BrokerStatusWindow/health.ts
@@ -16,7 +16,8 @@
 //   - a missing new sample means the value held flat (change-only
 //     republishers like mosquitto only re-emit changed values, so silence is
 //     signal, not a gap);
-//   - a chip renders nothing until it has ≥ 2 samples.
+//   - a chip renders nothing until it has a sample (cumulative sources only
+//     produce their first, rate, sample after two raw counter readings).
 //
 // See the health table in docs/broker-status-v2-spec.md.
 
@@ -41,8 +42,16 @@ export type HealthChipId =
   | "store"
   | "churn";
 
-/** Minimum samples before a chip renders at all (never paint "ok" off one). */
-export const MIN_RENDER_SAMPLES = 2;
+/**
+ * Minimum samples before a chip renders. One suffices: gauge sources are
+ * meaningful from their first (often retained) value, and change-only
+ * republishers like mosquitto never re-emit a permanently-zero gauge, so a
+ * two-sample gate would hide the drops/backlog chips on a healthy broker
+ * forever. Cumulative sources stay protected implicitly — the store only
+ * emits their first sample once a rate exists (two raw counter readings), so
+ * a single EMQX counter snapshot still renders nothing.
+ */
+export const MIN_RENDER_SAMPLES = 1;
 /** A trend clause needs at least this many in-window samples to be considered. */
 export const TREND_MIN_SAMPLES = 3;
 /** Hysteresis floor; the effective hold is max(this, learnedInterval). */

--- a/frontend/src/views/BrokerStatusWindow/health.ts
+++ b/frontend/src/views/BrokerStatusWindow/health.ts
@@ -1,0 +1,369 @@
+// Pure health rules for the Broker Status window's health strip. The store
+// evaluates these on its 1 s tick and keeps the returned per-chip state
+// (hysteresis timestamps live in the store, are passed back in, and are cleared
+// by resetData). Nothing here reads a store or the clock — `now` and the
+// learned $SYS interval are always passed in, so every rule is deterministic
+// and unit-testable against fixed sample fixtures.
+//
+// Cadence-robust trend semantics (identical for every trend chip, so a 60 s
+// EMQX broker and a 10 s mosquitto are judged on the same footing):
+//   - effective window = max(ruleWindow, 3 × learnedInterval)
+//   - "rising" needs ≥ 3 samples inside that window, strictly increasing, AND
+//     the newest sample no older than 2 × learnedInterval (a stale series is
+//     not "rising", it is silent);
+//   - with < 3 in-window samples the trend clause is simply false — the state
+//     falls back to its non-trend column, never "hold previous";
+//   - a missing new sample means the value held flat (change-only
+//     republishers like mosquitto only re-emit changed values, so silence is
+//     signal, not a gap);
+//   - a chip renders nothing until it has ≥ 2 samples.
+//
+// See the health table in docs/broker-status-v2-spec.md.
+
+/** One value-over-time sample. Structurally the store's SparklineSample. */
+export interface TrendSample {
+  t: number;
+  v: number;
+}
+
+/** What the store hands each chip evaluator: current value + its sample trail. */
+export interface HealthMetric {
+  value: number | null;
+  samples: readonly TrendSample[];
+}
+
+export type HealthLevel = "ok" | "attention" | "problem";
+
+export type HealthChipId =
+  | "drops"
+  | "backlog"
+  | "heap"
+  | "store"
+  | "churn";
+
+/** Minimum samples before a chip renders at all (never paint "ok" off one). */
+export const MIN_RENDER_SAMPLES = 2;
+/** A trend clause needs at least this many in-window samples to be considered. */
+export const TREND_MIN_SAMPLES = 3;
+/** Hysteresis floor; the effective hold is max(this, learnedInterval). */
+export const HYSTERESIS_MIN_MS = 30_000;
+/** A chip greys out once its source has been silent this long. */
+export const STALE_EXTRA_MS = 30_000; // added to 3 × learnedInterval
+
+const RANK: Record<HealthLevel, number> = { ok: 0, attention: 1, problem: 2 };
+
+/**
+ * Persisted per-chip hysteresis state. `level`/`since` are the displayed level
+ * and when it began; `pendingLevel`/`pendingSince` track a lower level that is
+ * waiting out the hysteresis hold before it may take effect.
+ */
+export interface HealthChipState {
+  level: HealthLevel;
+  since: number;
+  pendingLevel: HealthLevel | null;
+  pendingSince: number;
+}
+
+/** A rendered chip (or a placeholder with render:false while below min samples). */
+export interface HealthChip {
+  id: HealthChipId;
+  label: string;
+  /** null for the informational chips (heap, churn) that never carry a dot. */
+  level: HealthLevel | null;
+  /** Value-only chips with no state dot (heap, churn). */
+  informational: boolean;
+  /** One-word text qualifier; "" for ok / informational / stale. */
+  qualifier: string;
+  /** Primary numeric value (rate, count, or bytes depending on the chip). */
+  value: number | null;
+  /** Secondary numeric (heap peak); null otherwise. */
+  detail: number | null;
+  /** Epoch ms the current level began (for "since" copy). */
+  since: number;
+  /** Source has been silent past the stale threshold: keep value, drop dot. */
+  stale: boolean;
+  /** False until the chip has its minimum samples; the strip skips it. */
+  render: boolean;
+}
+
+/**
+ * True when `samples` are rising over the effective window: ≥ 3 strictly
+ * increasing in-window samples with a fresh newest point. See the module
+ * header for the full semantics.
+ */
+export function isRising(
+  samples: readonly TrendSample[],
+  now: number,
+  ruleWindowMs: number,
+  learnedIntervalMs: number
+): boolean {
+  const effectiveWindow = Math.max(ruleWindowMs, 3 * learnedIntervalMs);
+  const cutoff = now - effectiveWindow;
+  // Samples are appended in time order, so a linear tail scan is enough.
+  const win: TrendSample[] = [];
+  for (const s of samples) if (s.t >= cutoff) win.push(s);
+  if (win.length < TREND_MIN_SAMPLES) return false;
+  const newest = win[win.length - 1];
+  if (now - newest.t > 2 * learnedIntervalMs) return false; // series went stale
+  for (let i = 1; i < win.length; i++) {
+    if (win[i].v <= win[i - 1].v) return false;
+  }
+  return true;
+}
+
+const newestTime = (samples: readonly TrendSample[]): number =>
+  samples.length > 0 ? samples[samples.length - 1].t : -1;
+
+const isStale = (
+  samples: readonly TrendSample[],
+  now: number,
+  learnedIntervalMs: number
+): boolean => {
+  const last = newestTime(samples);
+  if (last < 0) return false;
+  return now - last > 3 * learnedIntervalMs + STALE_EXTRA_MS;
+};
+
+/**
+ * Applies downgrade hysteresis. Upgrades (and the first ever level) take effect
+ * immediately; a downgrade is held at the current level until the lower raw
+ * level has persisted for `holdMs`. Returns the next persisted state.
+ */
+export function applyHysteresis(
+  prev: HealthChipState | undefined,
+  raw: HealthLevel,
+  now: number,
+  holdMs: number
+): HealthChipState {
+  if (prev === undefined) {
+    return { level: raw, since: now, pendingLevel: null, pendingSince: 0 };
+  }
+  if (RANK[raw] >= RANK[prev.level]) {
+    // Same level or an upgrade: adopt at once and drop any pending downgrade.
+    return {
+      level: raw,
+      since: raw === prev.level ? prev.since : now,
+      pendingLevel: null,
+      pendingSince: 0,
+    };
+  }
+  // Downgrade candidate. Start (or continue) the hold clock for this raw level.
+  if (prev.pendingLevel === raw) {
+    if (now - prev.pendingSince >= holdMs) {
+      return { level: raw, since: now, pendingLevel: null, pendingSince: 0 };
+    }
+    return prev; // still holding the higher level
+  }
+  return {
+    level: prev.level,
+    since: prev.since,
+    pendingLevel: raw,
+    pendingSince: now,
+  };
+}
+
+/** ok/attention/problem chips share this hysteresis + stale + render wrapper. */
+function stateChip(
+  id: HealthChipId,
+  label: string,
+  raw: HealthLevel,
+  qualifierFor: (level: HealthLevel) => string,
+  metric: HealthMetric,
+  prev: Map<HealthChipId, HealthChipState>,
+  now: number,
+  learnedIntervalMs: number,
+  next: Map<HealthChipId, HealthChipState>
+): HealthChip {
+  const render = metric.samples.length >= MIN_RENDER_SAMPLES;
+  if (!render) {
+    // Not enough data yet: carry no state forward, render nothing.
+    return {
+      id,
+      label,
+      level: null,
+      informational: false,
+      qualifier: "",
+      value: metric.value,
+      detail: null,
+      since: now,
+      stale: false,
+      render: false,
+    };
+  }
+  const holdMs = Math.max(HYSTERESIS_MIN_MS, learnedIntervalMs);
+  const state = applyHysteresis(prev.get(id), raw, now, holdMs);
+  next.set(id, state);
+  const stale = isStale(metric.samples, now, learnedIntervalMs);
+  return {
+    id,
+    label,
+    level: state.level,
+    informational: false,
+    // Silence drops the qualifier (and, in the view, the dot); ok has none.
+    qualifier: stale || state.level === "ok" ? "" : qualifierFor(state.level),
+    value: metric.value,
+    detail: null,
+    since: state.since,
+    stale,
+    render: true,
+  };
+}
+
+/** heap/churn: a plain value, no dot, no hysteresis. */
+function infoChip(
+  id: HealthChipId,
+  label: string,
+  metric: HealthMetric,
+  detail: number | null,
+  now: number,
+  learnedIntervalMs: number
+): HealthChip {
+  const render = metric.samples.length >= MIN_RENDER_SAMPLES;
+  return {
+    id,
+    label,
+    level: null,
+    informational: true,
+    qualifier: "",
+    value: metric.value,
+    detail,
+    since: now,
+    stale: render && isStale(metric.samples, now, learnedIntervalMs),
+    render,
+  };
+}
+
+/** The metric snapshots each chip needs, keyed by registry id. */
+export interface HealthInputs {
+  msgs_dropped: HealthMetric;
+  msg_rate_in: HealthMetric;
+  delivery_backlog: HealthMetric;
+  heap_current: HealthMetric;
+  heap_max: HealthMetric;
+  store_msgs: HealthMetric;
+  store_bytes: HealthMetric;
+  sockets_1min: HealthMetric;
+}
+
+const empty = (m?: HealthMetric): HealthMetric => m ?? { value: null, samples: [] };
+
+/** Rule windows (ms) from the health table. */
+const DROPS_RISE_MS = 60_000;
+const BACKLOG_ATTENTION_MS = 60_000;
+const BACKLOG_PROBLEM_MS = 120_000;
+const STORE_RISE_MS = 120_000;
+/** Drops go red once they exceed this fraction of the inbound rate... */
+const DROPS_RELATIVE_FRACTION = 0.05;
+/** ...but never on a trickle of inbound traffic. */
+const DROPS_MIN_INBOUND = 1;
+
+/**
+ * Evaluates every health chip. Returns the renderable chips plus the next
+ * hysteresis-state map (which the store persists and passes back next tick).
+ */
+export function evaluateHealth(
+  inputs: Partial<HealthInputs>,
+  prev: Map<HealthChipId, HealthChipState>,
+  now: number,
+  learnedIntervalMs: number
+): { chips: HealthChip[]; states: Map<HealthChipId, HealthChipState> } {
+  const next = new Map<HealthChipId, HealthChipState>();
+
+  const drops = empty(inputs.msgs_dropped);
+  const inbound = empty(inputs.msg_rate_in);
+  const backlog = empty(inputs.delivery_backlog);
+  const heapCur = empty(inputs.heap_current);
+  const heapMax = empty(inputs.heap_max);
+  const storeMsgs = empty(inputs.store_msgs);
+  const storeBytes = empty(inputs.store_bytes);
+  const sockets = empty(inputs.sockets_1min);
+
+  // --- Drops -----------------------------------------------------------------
+  const dropRate = drops.value ?? 0;
+  const dropsRising = isRising(drops.samples, now, DROPS_RISE_MS, learnedIntervalMs);
+  const inboundRate = inbound.value;
+  const dropsRelativeHigh =
+    inboundRate !== null &&
+    inboundRate >= DROPS_MIN_INBOUND &&
+    dropRate > DROPS_RELATIVE_FRACTION * inboundRate;
+  let dropsRaw: HealthLevel;
+  if (dropRate <= 0) dropsRaw = "ok";
+  else if (dropsRising || dropsRelativeHigh) dropsRaw = "problem";
+  else dropsRaw = "attention";
+  const dropsChip = stateChip(
+    "drops",
+    "Drops",
+    dropsRaw,
+    (lvl) => (lvl === "problem" ? "rising" : "present"),
+    drops,
+    prev,
+    now,
+    learnedIntervalMs,
+    next
+  );
+
+  // --- Delivery backlog ------------------------------------------------------
+  // A longer sustained rise is worse: test the 120 s window first.
+  const backlogProblem = isRising(backlog.samples, now, BACKLOG_PROBLEM_MS, learnedIntervalMs);
+  const backlogAttention = isRising(backlog.samples, now, BACKLOG_ATTENTION_MS, learnedIntervalMs);
+  const backlogRaw: HealthLevel = backlogProblem
+    ? "problem"
+    : backlogAttention
+      ? "attention"
+      : "ok";
+  const backlogChip = stateChip(
+    "backlog",
+    "Delivery backlog",
+    backlogRaw,
+    () => "rising",
+    backlog,
+    prev,
+    now,
+    learnedIntervalMs,
+    next
+  );
+
+  // --- Store (never red) -----------------------------------------------------
+  const storeRising =
+    isRising(storeMsgs.samples, now, STORE_RISE_MS, learnedIntervalMs) ||
+    isRising(storeBytes.samples, now, STORE_RISE_MS, learnedIntervalMs);
+  // Drive rendering off whichever series has the deeper trail.
+  const storeMetric: HealthMetric =
+    storeMsgs.samples.length >= storeBytes.samples.length ? storeMsgs : storeBytes;
+  const storeChip = stateChip(
+    "store",
+    "Store",
+    storeRising ? "attention" : "ok",
+    () => "rising",
+    storeMetric,
+    prev,
+    now,
+    learnedIntervalMs,
+    next
+  );
+
+  // --- Heap (informational, never colours) -----------------------------------
+  const heapChip = infoChip(
+    "heap",
+    "Heap",
+    heapCur,
+    heapMax.value,
+    now,
+    learnedIntervalMs
+  );
+
+  // --- Churn (informational) -------------------------------------------------
+  const churnChip = infoChip(
+    "churn",
+    "Churn",
+    sockets,
+    null,
+    now,
+    learnedIntervalMs
+  );
+
+  return {
+    chips: [dropsChip, backlogChip, storeChip, heapChip, churnChip],
+    states: next,
+  };
+}

--- a/frontend/src/views/BrokerStatusWindow/health.ts
+++ b/frontend/src/views/BrokerStatusWindow/health.ts
@@ -17,7 +17,9 @@
 //     republishers like mosquitto only re-emit changed values, so silence is
 //     signal, not a gap);
 //   - a chip renders nothing until it has a sample (cumulative sources only
-//     produce their first, rate, sample after two raw counter readings).
+//     produce their first, rate, sample after two raw counter readings);
+//   - `trendFloorMs` excludes samples from before a reconnect, so a restarted
+//     broker refilling its retained store never reads as "rising".
 //
 // See the health table in docs/broker-status-v2-spec.md.
 
@@ -104,10 +106,14 @@ export function isRising(
   samples: readonly TrendSample[],
   now: number,
   ruleWindowMs: number,
-  learnedIntervalMs: number
+  learnedIntervalMs: number,
+  trendFloorMs = 0
 ): boolean {
   const effectiveWindow = Math.max(ruleWindowMs, 3 * learnedIntervalMs);
-  const cutoff = now - effectiveWindow;
+  // The floor excludes samples from before a reconnect (and, while it sits in
+  // the future, every sample) so a restarted broker's retained-store
+  // repopulation is not read as a rising trend.
+  const cutoff = Math.max(now - effectiveWindow, trendFloorMs);
   // Samples are appended in time order, so a linear tail scan is enough.
   const win: TrendSample[] = [];
   for (const s of samples) if (s.t >= cutoff) win.push(s);
@@ -274,9 +280,12 @@ export function evaluateHealth(
   inputs: Partial<HealthInputs>,
   prev: Map<HealthChipId, HealthChipState>,
   now: number,
-  learnedIntervalMs: number
+  learnedIntervalMs: number,
+  trendFloorMs = 0
 ): { chips: HealthChip[]; states: Map<HealthChipId, HealthChipState> } {
   const next = new Map<HealthChipId, HealthChipState>();
+  const rising = (samples: readonly TrendSample[], ruleWindowMs: number) =>
+    isRising(samples, now, ruleWindowMs, learnedIntervalMs, trendFloorMs);
 
   const drops = empty(inputs.msgs_dropped);
   const inbound = empty(inputs.msg_rate_in);
@@ -289,7 +298,7 @@ export function evaluateHealth(
 
   // --- Drops -----------------------------------------------------------------
   const dropRate = drops.value ?? 0;
-  const dropsRising = isRising(drops.samples, now, DROPS_RISE_MS, learnedIntervalMs);
+  const dropsRising = rising(drops.samples, DROPS_RISE_MS);
   const inboundRate = inbound.value;
   const dropsRelativeHigh =
     inboundRate !== null &&
@@ -313,8 +322,8 @@ export function evaluateHealth(
 
   // --- Delivery backlog ------------------------------------------------------
   // A longer sustained rise is worse: test the 120 s window first.
-  const backlogProblem = isRising(backlog.samples, now, BACKLOG_PROBLEM_MS, learnedIntervalMs);
-  const backlogAttention = isRising(backlog.samples, now, BACKLOG_ATTENTION_MS, learnedIntervalMs);
+  const backlogProblem = rising(backlog.samples, BACKLOG_PROBLEM_MS);
+  const backlogAttention = rising(backlog.samples, BACKLOG_ATTENTION_MS);
   const backlogRaw: HealthLevel = backlogProblem
     ? "problem"
     : backlogAttention
@@ -334,8 +343,8 @@ export function evaluateHealth(
 
   // --- Store (never red) -----------------------------------------------------
   const storeRising =
-    isRising(storeMsgs.samples, now, STORE_RISE_MS, learnedIntervalMs) ||
-    isRising(storeBytes.samples, now, STORE_RISE_MS, learnedIntervalMs);
+    rising(storeMsgs.samples, STORE_RISE_MS) ||
+    rising(storeBytes.samples, STORE_RISE_MS);
   // Drive rendering off whichever series has the deeper trail.
   const storeMetric: HealthMetric =
     storeMsgs.samples.length >= storeBytes.samples.length ? storeMsgs : storeBytes;

--- a/frontend/src/views/BrokerStatusWindow/sys-metrics.test.ts
+++ b/frontend/src/views/BrokerStatusWindow/sys-metrics.test.ts
@@ -464,6 +464,162 @@ describe("mergeMappings", () => {
   });
 });
 
+// --- v2 registry: hidden/overrideTarget flags + new metric bindings ----------
+
+// mosquitto 2.x $SYS leaves for the v2 diagnostic metrics.
+const MOSQUITTO_V2_TOPICS = [
+  "$SYS/broker/load/publish/dropped/1min",
+  "$SYS/broker/packet/out/count",
+  "$SYS/broker/heap/current",
+  "$SYS/broker/heap/maximum",
+  "$SYS/broker/store/messages/count",
+  "$SYS/broker/store/messages/bytes",
+  "$SYS/broker/clients/disconnected",
+  "$SYS/broker/clients/expired",
+  "$SYS/broker/load/sockets/1min",
+  "$SYS/broker/load/messages/received/5min",
+  "$SYS/broker/load/messages/received/15min",
+  "$SYS/broker/load/messages/sent/5min",
+  "$SYS/broker/load/messages/sent/15min",
+  "$SYS/broker/messages/received",
+  "$SYS/broker/messages/sent",
+];
+
+// aedes-stats publishes under $SYS/<random-id>/… with `+`-matched heap leaves.
+const AEDES_TOPICS = [
+  "$SYS/aedes8f3a/memory/heap/current",
+  "$SYS/aedes8f3a/memory/heap/maximum",
+];
+
+describe("v2 registry flags", () => {
+  it("marks the relocated v1 builtins hidden but keeps them override targets", () => {
+    for (const key of ["msg_rate_in", "msg_rate_out", "uptime", "version"]) {
+      const t = builtin(key);
+      expect(t.hidden, key).toBe(true);
+      expect(t.overrideTarget, key).not.toBe(false); // still an override target
+    }
+  });
+
+  it("keeps bytes_rate_* and the core gauges visible (not hidden)", () => {
+    for (const key of [
+      "clients_connected",
+      "bytes_rate_in",
+      "bytes_rate_out",
+      "subscriptions",
+      "retained",
+    ]) {
+      expect(builtin(key).hidden, key).not.toBe(true);
+    }
+  });
+
+  it("marks every new diagnostic metric hidden and not an override target", () => {
+    for (const key of [
+      "msgs_dropped",
+      "delivery_backlog",
+      "heap_current",
+      "heap_max",
+      "store_msgs",
+      "store_bytes",
+      "clients_disconnected",
+      "clients_expired",
+      "sockets_1min",
+      "messages_received_total",
+      "messages_sent_total",
+      "fan_out",
+      "avg_msg_size",
+    ]) {
+      const t = builtin(key);
+      expect(t.hidden, key).toBe(true);
+      expect(t.overrideTarget, key).toBe(false);
+    }
+  });
+
+  it("keeps the observed computed tiles last (facts/derived slot in between)", () => {
+    expect(BUILTIN_METRICS.at(-1)?.key).toBe("observed_byte_rate");
+    expect(BUILTIN_METRICS.at(-2)?.key).toBe("observed_msg_rate");
+  });
+});
+
+describe("v2 metric bindings", () => {
+  it("binds every new diagnostic metric to its exact mosquitto candidate", () => {
+    const expected: Record<string, string> = {
+      msgs_dropped: "$SYS/broker/load/publish/dropped/1min",
+      delivery_backlog: "$SYS/broker/packet/out/count",
+      heap_current: "$SYS/broker/heap/current",
+      heap_max: "$SYS/broker/heap/maximum",
+      store_msgs: "$SYS/broker/store/messages/count",
+      store_bytes: "$SYS/broker/store/messages/bytes",
+      clients_disconnected: "$SYS/broker/clients/disconnected",
+      clients_expired: "$SYS/broker/clients/expired",
+      sockets_1min: "$SYS/broker/load/sockets/1min",
+      messages_received_total: "$SYS/broker/messages/received",
+      messages_sent_total: "$SYS/broker/messages/sent",
+    };
+    for (const [key, topic] of Object.entries(expected)) {
+      const sel = selectCandidate(builtin(key), MOSQUITTO_V2_TOPICS);
+      expect(sel?.topic, key).toBe(topic);
+    }
+  });
+
+  it("scales the mosquitto drop average to drops/s and treats it as a gauge", () => {
+    const sel = selectCandidate(builtin("msgs_dropped"), MOSQUITTO_V2_TOPICS)!;
+    expect(sel.candidate.kind).toBe("gauge");
+    // 120 dropped/min → 2 dropped/s.
+    const sample = parseSample(sel.candidate, "120");
+    expect(sample).toEqual({ kind: "number", value: 2 });
+  });
+
+  it("treats delivery_backlog (packet/out/count) as a gauge, not a counter", () => {
+    // mosquitto-8: a queue length that legitimately plateaus on an idle broker.
+    // If it were mis-typed cumulative, a flat value would derive a 0 rate and a
+    // rising queue would be lost. Assert the gauge kind so the idle plateau is
+    // read at face value.
+    const sel = selectCandidate(builtin("delivery_backlog"), MOSQUITTO_V2_TOPICS)!;
+    expect(sel.candidate.kind).toBe("gauge");
+    expect(parseSample(sel.candidate, "0")).toEqual({ kind: "number", value: 0 });
+  });
+
+  it("derives a rate from the cumulative message totals", () => {
+    expect(
+      selectCandidate(builtin("messages_received_total"), MOSQUITTO_V2_TOPICS)
+        ?.candidate.kind
+    ).toBe("cumulative");
+    expect(
+      selectCandidate(builtin("messages_sent_total"), MOSQUITTO_V2_TOPICS)
+        ?.candidate.kind
+    ).toBe("cumulative");
+  });
+
+  it("binds aedes heap via the + wildcard candidate", () => {
+    const cur = selectCandidate(builtin("heap_current"), AEDES_TOPICS);
+    expect(cur?.topic).toBe("$SYS/aedes8f3a/memory/heap/current");
+    const max = selectCandidate(builtin("heap_max"), AEDES_TOPICS);
+    expect(max?.topic).toBe("$SYS/aedes8f3a/memory/heap/maximum");
+  });
+
+  it("does not cross-family mislabel: mosquitto heap ignores aedes-only leaves", () => {
+    // A mosquitto broker with only its own heap leaf must not resolve via the
+    // aedes `+/memory/heap/current` wildcard onto some unrelated topic.
+    const sel = selectCandidate(builtin("heap_current"), [
+      "$SYS/broker/heap/current",
+    ]);
+    expect(sel?.topic).toBe("$SYS/broker/heap/current");
+    // And an unrelated node topic must not satisfy the exact mosquitto slot.
+    expect(
+      selectCandidate(builtin("delivery_backlog"), [
+        "$SYS/broker/packet/received",
+      ])
+    ).toBeNull();
+  });
+
+  it("does not bind heap to Mochi's process-memory topic", () => {
+    // Mochi's system/memory is process memory, deliberately unbound.
+    expect(
+      selectCandidate(builtin("heap_current"), ["$SYS/broker/system/memory"])
+    ).toBeNull();
+  });
+});
+
 describe("humanizeDuration", () => {
   it("formats sub-minute durations", () => {
     expect(humanizeDuration(45)).toBe("45s");

--- a/frontend/src/views/BrokerStatusWindow/sys-metrics.ts
+++ b/frontend/src/views/BrokerStatusWindow/sys-metrics.ts
@@ -57,11 +57,30 @@ export interface MetricTile {
   unit?: string;
   /** Ordered candidates; first with data wins. Empty for computed tiles. */
   candidates: MetricCandidate[];
-  /** Client-side computed tiles (observed rates) — no topics. */
+  /** Client-side computed tiles (observed rates, derived ratios) — no topics. */
   computed?: boolean;
   tooltip?: string;
   /** Kind used when a user override redirects this builtin to their topic. */
   overrideKind?: MetricKind;
+  /**
+   * v2: the metric is tracked (value + samples fold into runtime and are
+   * exposed via the store's `metricByKey`) but has no gauge tile of its own —
+   * its samples feed the traffic hero, health chips, the facts row, or a
+   * derived ratio instead. Independent of `overrideTarget`: `uptime`/`version`
+   * are hidden yet remain override targets.
+   *
+   * NOTE (commit-staging): the hidden→no-tile filter is applied by the store's
+   * visible-tile predicate, and in the store-engine commit that predicate still
+   * keeps the reclassified v1 tiles (`msg_rate_*`, `uptime`, `version`) on
+   * screen. The brand-new hidden metrics below never surface as tiles.
+   */
+  hidden?: boolean;
+  /**
+   * v2: excluded from the mapping editor's override Select. Defaults to true
+   * (absent = an override target). Set false for the internal diagnostic /
+   * derived-input metrics that would only confuse a manual remap.
+   */
+  overrideTarget?: boolean;
 }
 
 /**
@@ -108,6 +127,8 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   {
     key: "msg_rate_in",
     label: "Msgs/s in",
+    // v2: samples feed the traffic hero's inbound series, not a gauge tile.
+    hidden: true,
     overrideKind: "gauge",
     candidates: [
       {
@@ -124,6 +145,8 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   {
     key: "msg_rate_out",
     label: "Msgs/s out",
+    // v2: samples feed the traffic hero's outbound series, not a gauge tile.
+    hidden: true,
     overrideKind: "gauge",
     candidates: [
       {
@@ -198,6 +221,8 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   {
     key: "uptime",
     label: "Uptime",
+    // v2: feeds the facts row, not a gauge tile — but stays an override target.
+    hidden: true,
     overrideKind: "duration",
     candidates: [
       // mosquitto: "3672 seconds"
@@ -212,6 +237,8 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   {
     key: "version",
     label: "Broker",
+    // v2: feeds the facts row, not a gauge tile — but stays an override target.
+    hidden: true,
     overrideKind: "string",
     candidates: [
       { pattern: "$SYS/broker/version", payloadPath: "", kind: "string" },
@@ -220,6 +247,240 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
       // VerneMQ systree publishes no version metric.
     ],
   },
+
+  // --- v2 hidden diagnostic / facts / legend metrics -------------------------
+  // All `hidden` (no gauge tile of their own) and NOT override targets (they
+  // are broker-family-specific signals; a manual remap would only confuse).
+  // Their samples are tracked in runtime and reach the view via `metricByKey`.
+  {
+    key: "msgs_dropped",
+    label: "Dropped msgs/s",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      // mosquitto: per-minute average count of dropped publishes → per-second.
+      {
+        pattern: "$SYS/broker/load/publish/dropped/1min",
+        payloadPath: "",
+        kind: "gauge",
+        scale: MINUTE_AVG,
+      },
+      // Cumulative dropped counters across broker families; the store derives a
+      // /s rate from successive samples (same as the msg-rate tiles).
+      { pattern: "$SYS/broker/mqtt/publish/dropped", payloadPath: "", kind: "cumulative" },
+      { pattern: "$SYS/broker/publish/messages/dropped", payloadPath: "", kind: "cumulative" },
+      { pattern: "$SYS/broker/messages/publish/dropped", payloadPath: "", kind: "cumulative" },
+      { pattern: "$SYS/broker/messages/dropped", payloadPath: "", kind: "cumulative" },
+      { pattern: "$SYS/brokers/+/metrics/messages/dropped", payloadPath: "", kind: "cumulative" },
+    ],
+  },
+  {
+    key: "delivery_backlog",
+    label: "Delivery backlog",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      // mosquitto-8: "current number of packets queued" — a gauge, not a
+      // counter (an idle-broker fixture asserts it plateaus before the chip
+      // binds; see the registry tests).
+      { pattern: "$SYS/broker/packet/out/count", payloadPath: "", kind: "gauge" },
+    ],
+  },
+  {
+    key: "heap_current",
+    label: "Heap in use",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      { pattern: "$SYS/broker/heap/current", payloadPath: "", kind: "gauge" },
+      // aedes-stats + similar `+`-node brokers. NOT Mochi's system/memory
+      // (process memory, deliberately unbound per the spec).
+      { pattern: "$SYS/+/memory/heap/current", payloadPath: "", kind: "gauge" },
+    ],
+  },
+  {
+    key: "heap_max",
+    label: "Heap peak",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      // A high-watermark, not a capacity ceiling.
+      { pattern: "$SYS/broker/heap/maximum", payloadPath: "", kind: "gauge" },
+      { pattern: "$SYS/+/memory/heap/maximum", payloadPath: "", kind: "gauge" },
+    ],
+  },
+  {
+    key: "store_msgs",
+    label: "Stored messages",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      { pattern: "$SYS/broker/store/messages/count", payloadPath: "", kind: "gauge" },
+      { pattern: "$SYS/broker/messages/stored", payloadPath: "", kind: "gauge" },
+    ],
+  },
+  {
+    key: "store_bytes",
+    label: "Stored bytes",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      { pattern: "$SYS/broker/store/messages/bytes", payloadPath: "", kind: "gauge" },
+    ],
+  },
+  {
+    key: "clients_disconnected",
+    label: "Disconnected clients",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      { pattern: "$SYS/broker/clients/disconnected", payloadPath: "", kind: "gauge" },
+    ],
+  },
+  {
+    key: "clients_expired",
+    label: "Expired clients",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      { pattern: "$SYS/broker/clients/expired", payloadPath: "", kind: "gauge" },
+    ],
+  },
+  {
+    key: "sockets_1min",
+    label: "Socket churn/s",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      {
+        pattern: "$SYS/broker/load/sockets/1min",
+        payloadPath: "",
+        kind: "gauge",
+        scale: MINUTE_AVG,
+      },
+      {
+        pattern: "$SYS/broker/load/connections/1min",
+        payloadPath: "",
+        kind: "gauge",
+        scale: MINUTE_AVG,
+      },
+    ],
+  },
+  // Broker-published 5m/15m load averages — legend-tooltip context only.
+  {
+    key: "msg_rate_in_5min",
+    label: "Msgs/s in (5m avg)",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      {
+        pattern: "$SYS/broker/load/messages/received/5min",
+        payloadPath: "",
+        kind: "gauge",
+        scale: MINUTE_AVG,
+      },
+    ],
+  },
+  {
+    key: "msg_rate_in_15min",
+    label: "Msgs/s in (15m avg)",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      {
+        pattern: "$SYS/broker/load/messages/received/15min",
+        payloadPath: "",
+        kind: "gauge",
+        scale: MINUTE_AVG,
+      },
+    ],
+  },
+  {
+    key: "msg_rate_out_5min",
+    label: "Msgs/s out (5m avg)",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      {
+        pattern: "$SYS/broker/load/messages/sent/5min",
+        payloadPath: "",
+        kind: "gauge",
+        scale: MINUTE_AVG,
+      },
+    ],
+  },
+  {
+    key: "msg_rate_out_15min",
+    label: "Msgs/s out (15m avg)",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "gauge",
+    candidates: [
+      {
+        pattern: "$SYS/broker/load/messages/sent/15min",
+        payloadPath: "",
+        kind: "gauge",
+        scale: MINUTE_AVG,
+      },
+    ],
+  },
+  // Cumulative message totals: feed the fan-out ratio and avg-msg-size derived
+  // tiles (the store diffs successive samples into a /s rate).
+  {
+    key: "messages_received_total",
+    label: "Messages received",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "cumulative",
+    candidates: [
+      { pattern: "$SYS/broker/messages/received", payloadPath: "", kind: "cumulative" },
+      { pattern: "$SYS/brokers/+/metrics/messages/received", payloadPath: "", kind: "cumulative" },
+    ],
+  },
+  {
+    key: "messages_sent_total",
+    label: "Messages sent",
+    hidden: true,
+    overrideTarget: false,
+    overrideKind: "cumulative",
+    candidates: [
+      { pattern: "$SYS/broker/messages/sent", payloadPath: "", kind: "cumulative" },
+      { pattern: "$SYS/brokers/+/metrics/messages/sent", payloadPath: "", kind: "cumulative" },
+    ],
+  },
+
+  // Derived ratios computed on the tick from the hidden cumulative pair above.
+  // Hidden here (they reach the gauges grid via `metricByKey`); the store fills
+  // or clears them per the derived-rate guards.
+  {
+    key: "fan_out",
+    label: "Fan-out",
+    hidden: true,
+    overrideTarget: false,
+    computed: true,
+    candidates: [],
+  },
+  {
+    key: "avg_msg_size",
+    label: "Avg msg size",
+    hidden: true,
+    overrideTarget: false,
+    computed: true,
+    candidates: [],
+  },
+
   // Client-side computed tiles — always present, no topics; the store fills
   // their values from its observed-rate ring buffer.
   {

--- a/frontend/src/views/BrokerStatusWindow/sys-metrics.ts
+++ b/frontend/src/views/BrokerStatusWindow/sys-metrics.ts
@@ -126,7 +126,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   },
   {
     key: "msg_rate_in",
-    label: "Msgs/s in",
+    label: "Msg/s in",
     // v2: samples feed the traffic hero's inbound series, not a gauge tile.
     hidden: true,
     overrideKind: "gauge",
@@ -144,7 +144,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   },
   {
     key: "msg_rate_out",
-    label: "Msgs/s out",
+    label: "Msg/s out",
     // v2: samples feed the traffic hero's outbound series, not a gauge tile.
     hidden: true,
     overrideKind: "gauge",
@@ -254,7 +254,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   // Their samples are tracked in runtime and reach the view via `metricByKey`.
   {
     key: "msgs_dropped",
-    label: "Dropped msgs/s",
+    label: "Dropped msg/s",
     hidden: true,
     overrideTarget: false,
     overrideKind: "gauge",
@@ -378,7 +378,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   // Broker-published 5m/15m load averages — legend-tooltip context only.
   {
     key: "msg_rate_in_5min",
-    label: "Msgs/s in (5m avg)",
+    label: "Msg/s in (5m avg)",
     hidden: true,
     overrideTarget: false,
     overrideKind: "gauge",
@@ -393,7 +393,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   },
   {
     key: "msg_rate_in_15min",
-    label: "Msgs/s in (15m avg)",
+    label: "Msg/s in (15m avg)",
     hidden: true,
     overrideTarget: false,
     overrideKind: "gauge",
@@ -408,7 +408,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   },
   {
     key: "msg_rate_out_5min",
-    label: "Msgs/s out (5m avg)",
+    label: "Msg/s out (5m avg)",
     hidden: true,
     overrideTarget: false,
     overrideKind: "gauge",
@@ -423,7 +423,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   },
   {
     key: "msg_rate_out_15min",
-    label: "Msgs/s out (15m avg)",
+    label: "Msg/s out (15m avg)",
     hidden: true,
     overrideTarget: false,
     overrideKind: "gauge",
@@ -485,7 +485,7 @@ export const BUILTIN_METRICS: readonly MetricTile[] = [
   // their values from its observed-rate ring buffer.
   {
     key: "observed_msg_rate",
-    label: "Observed msgs/s",
+    label: "Observed msg/s",
     candidates: [],
     computed: true,
     tooltip: OBSERVED_TOOLTIP,

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-option.test.ts
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-option.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildChartOption, type ChartOptionParams } from "./chart-option";
+import {
+  buildChartOption,
+  CHROME_COLORS,
+  type ChartOptionParams,
+} from "./chart-option";
 import type { ChartSeries } from "./chart-series-store";
 import type { MqttHistoryMessage } from "../../../../stores/selected-topic-store";
 
@@ -76,6 +80,32 @@ describe("buildChartOption theme", () => {
     expect(light.backgroundColor).toBe("#ffffff");
     expect(light.backgroundColor).not.toBe(dark.backgroundColor);
     expect(light.textStyle.color).not.toBe(dark.textStyle.color);
+  });
+});
+
+describe("CHROME_COLORS export", () => {
+  // Pinned because hero-chart-option.ts consumes this exact palette; a silent
+  // hue change here would drift the broker-status hero axis/tooltip chrome.
+  it("pins the dark chrome palette", () => {
+    expect(CHROME_COLORS.dark).toEqual({
+      axis: "#525252",
+      label: "#aeaeae",
+      splitLine: "#2e2e2e",
+      tooltipBackground: "#1f1e1e",
+      tooltipBorder: "#525252",
+      tooltipText: "#eee",
+    });
+  });
+
+  it("pins the light chrome palette", () => {
+    expect(CHROME_COLORS.light).toEqual({
+      axis: "#b8b8c0",
+      label: "#5f5f69",
+      splitLine: "#e4e4e8",
+      tooltipBackground: "#ffffff",
+      tooltipBorder: "#c8c8ce",
+      tooltipText: "#26262b",
+    });
   });
 });
 

--- a/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-option.ts
+++ b/frontend/src/views/Connection/DataView/components/SelectedTopicPanel/components/Chart/chart-option.ts
@@ -19,8 +19,10 @@ export interface ChartOptionParams {
 }
 
 // echarts paints to canvas, so CSS variables can't be used here; each theme
-// gets its own literal palette, matching the tones in src/style.css.
-const CHROME_COLORS = {
+// gets its own literal palette, matching the tones in src/style.css. Exported
+// so the broker-status hero chart (hero-chart-option.ts) reuses the exact same
+// axis/tooltip chrome instead of forking a second literal palette.
+export const CHROME_COLORS = {
   dark: {
     axis: "#525252",
     label: "#aeaeae",


### PR DESCRIPTION
Upgrades the broker status window (PR #118) from a status display into a diagnostic tool. The design went through per-broker $SYS research (mosquitto, EMQX 4/5, VerneMQ, Mochi, Aedes, NanoMQ, HiveMQ, plus the managed brokers that publish nothing) and two adversarial review cycles before implementation; the full rationale and every decision is in `docs/broker-status-v2-spec.md`.

## What changed for users

- **Health strip**: chips for dropped msgs/s, delivery backlog, heap, store size and client churn. Colour fires on trend, not absolute values (a flat drop counter is calm, a climbing one is not), state is never colour-only (dot shape + one-word qualifier), and each chip appears only when its broker actually publishes the signal.
- **Traffic hero chart**: msgs/s in and out co-plotted with the client-observed rate as a third series, live values in a custom HTML legend, 1m/5m/15m range selector. Broker series are 1-min moving averages; the observed series is true per-second, so bursts show as sharp edges while the broker lines lag - that contrast is the point.
- **Loudest topics**: client-computed top topics by msg/s with share bars. No other desktop MQTT client has per-topic rates.
- **Facts row** replaces the version/uptime tiles; tiles gain delta arrows and a hover panel with exact value and min/max; the raw $SYS browser gains a derived rate column for counter topics; the header gains a $SYS staleness pill.
- Degradation is explicit: no-$SYS brokers get a capability notice plus the observed-only chart, never a page of silently missing sections.

## Review guide (5 commits, in dependency order)

1. `04a0b69` docs: the spec. Read this first; the health rules table and the per-broker matrix explain everything downstream.
2. `2a90121` store engine: per-topic top-K ring (O(1) admission-capped batch path), observed instantaneous series, burst-collapsed $SYS interval EMA, pure health module with cadence-robust trends and hysteresis. The perf contract lives here.
3. `8f2159b` hero chart + range selector (standalone components, landed unused).
4. `e67e026` surfaces + wiring: new components, layout, shell header, fixtures truth-up, hidden-metric filter flip.
5. `6db2ec9` fix from live verification: gauge-backed chips render from one sample (change-only republishers never re-emit a flat zero), capability notice scoped to never-seen-$SYS.

## Verification

- `go build` / `go vet` / `just test` green (TestV3PubSub fails in-suite due to the known OrbStack port 1883 squat; passes solo).
- `pnpm check` 0 errors, `pnpm test:run` 230/230, `pnpm build`, `pnpm ds:validate` (120 components), `pnpm test-storybook` 161/161.
- Perf: store flood benchmark at the two-broker 2x2000 msg/s profile with ~9.4k distinct topics: mean 0.11-0.16 ms/batch against the 5 ms bar, 900-sample cap exercised, separate ring-wrap test bounds the per-topic ring.
- Live (Wails server mode + dockerised mosquitto 2.1.2): retained $SYS backfill, health chips incl. one-sample gauges, hero under a 60 s 2000 msg/s flood (observed square wave vs lagging broker averages, exactly as designed), loudest topics with middle-ellipsis names, sticky health strip under scroll, raw browser rate column, staleness pill, range switching, disconnected banner + frozen values, capability notice on a fresh no-$SYS connection.

Design mockup used during review: https://claude.ai/code/artifact/1a893070-502e-4d53-a618-09fb8dfa822b

Follow-ups deliberately cut from this PR (recorded in the spec): user-configurable thresholds, CONNACK v5 capability display (needs bindings work), NanoMQ event-derived churn, topic-prefix aggregation in loudest topics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
