### PR TITLE
docs(docker): app store templates ready for submission

### DIFF
--- a/docker/templates/README.md
+++ b/docker/templates/README.md
@@ -1,0 +1,103 @@
+# App store templates
+
+Manifests for submitting `ghcr.io/mqtt-viewer/mqtt-viewer` to the app stores
+that surface self-hosted Docker apps. Nothing here is live. These are ready
+to send once the image itself is published; see `docs/DOCKER.md`.
+
+Every template says the same thing about auth: the web UI has no built-in
+login, so it belongs on a trusted network or behind an authenticating
+reverse proxy. Say that wherever the platform lets you write a description.
+
+Before submitting any of these, check and update:
+
+- The image tag. `latest` is fine for Unraid, Portainer and CasaOS, all of
+  which resolve it at pull time. Umbrel and Runtipi review conventions
+  prefer a pinned version (Umbrel wants a `@sha256:` digest too), so bump
+  the placeholder `1.0.0` version strings to the actual release you are
+  submitting once the image exists.
+- Port numbers that must be unique across a store (Umbrel's `port` field
+  in `umbrel/umbrel-app.yml`, Runtipi's `port` in `runtipi/config.json`).
+  Pick one that does not collide, using each platform's existing app list.
+
+## Files
+
+### `unraid-template.xml`
+
+Unraid Community Applications template, `Container version="2"` XML.
+Declares the repository, the `WebUI` URL pattern
+(`http://[IP]:[PORT:8080]/`), a `Port` config entry for 8080 and a `Path`
+config entry mapping `/data` to `/mnt/user/appdata/mqtt-viewer`, plus
+`Support`, `Overview`, `Category` and `Icon`.
+
+Submit by opening a PR against the Community Applications feed, following
+the guide at <https://forums.unraid.net/topic/38619-docker-template-xml-schema/>
+and the submission portal at <https://ca.unraid.net/submit>. Community
+Applications indexes templates hosted in your own GitHub repo; the usual
+path is a PR to a template list such as
+<https://github.com/selfhosters/unRAID-CA-templates>, or hosting the XML in
+this repo and registering the raw URL with the CA feed.
+
+### `portainer-template.json`
+
+Portainer app template format v3 (`"version": "3"`), one `type: 1`
+(container) entry. Declares image, port mapping, the `/data` volume,
+restart policy and a `note` field carrying the no-auth warning.
+
+Submit by opening a PR against a community template list Portainer users
+point their app template URL at, for example
+<https://github.com/portainer/templates> or one of the actively maintained
+community forks. Portainer itself does not host a central submission queue;
+users add a template URL in Settings, so getting listed means getting into
+one of the popular community JSON files. See
+<https://docs.portainer.io/advanced/app-templates/build>.
+
+### `casaos/docker-compose.yml`
+
+CasaOS / ZimaOS app store entry: a normal Compose file with a top-level
+`x-casaos` extension block (`id`, `main`, `port_map`, `icon`, localized
+`title`/`tagline`/`description`, `category`, `architectures`, `repo`,
+`support`, `docs`).
+
+Submit by opening a PR against <https://github.com/IceWhaleTech/CasaOS-AppStore>,
+adding a new `Apps/mqtt-viewer/` directory containing this compose file plus
+an icon asset. Follow
+<https://github.com/IceWhaleTech/CasaOS-AppStore/blob/main/docs/quick-start/overview.md>.
+
+### `umbrel/umbrel-app.yml` + `umbrel/docker-compose.yml`
+
+Umbrel app package: the manifest (`umbrel-app.yml`) plus the compose file
+wiring an `app_proxy` service in front of the app container, per Umbrel's
+current packaging guide. `data/.gitkeep` reserves the persistent data
+directory the compose file bind-mounts.
+
+Submit by opening a PR against <https://github.com/getumbrel/umbrel-apps>
+with a new top-level `mqtt-viewer/` directory containing these files. See
+that repo's `AGENTS.md` and `.claude/skills/umbrel-package-app/SKILL.md` for
+the current review checklist, or browse the store at
+<https://apps.umbrel.com> to see what a merged app looks like.
+
+### `runtipi/config.json` + `runtipi/docker-compose.yml`
+
+Runtipi app store entry: `config.json` (name, ports, categories,
+architectures) paired with a dynamic-compose `docker-compose.yml`
+(`x-runtipi` block marking the main service and its internal port).
+
+Submit by opening a PR against <https://github.com/runtipi/runtipi-appstore>
+with a new `apps/mqtt-viewer/` directory containing these two files plus a
+`metadata/logo.jpg` and `metadata/description.md`. See
+<https://runtipi.io/docs/guides/create-your-own-app-store> and the reference
+app in <https://github.com/runtipi/example-appstore>.
+
+## Facts these templates encode
+
+- Web UI on port 8080, `WAILS_SERVER_PORT` env var, bound to `0.0.0.0` via
+  `WAILS_SERVER_HOST`.
+- Single persistent volume at `/data`, `MQTT_VIEWER_DATA_DIR` env var.
+- Healthcheck: `GET /health`.
+- Runs as uid 1000 inside the container.
+- No built-in authentication.
+- Multi-arch: `linux/amd64` and `linux/arm64`.
+- Licence: GPL-3.0-or-later.
+- Homepage: <https://mqttviewer.app>. Repo:
+  <https://github.com/mqtt-viewer/mqtt-viewer>. Docs:
+  `docs/DOCKER.md`.

--- a/docker/templates/casaos/docker-compose.yml
+++ b/docker/templates/casaos/docker-compose.yml
@@ -1,0 +1,59 @@
+# CasaOS app store entry for MQTT Viewer.
+#
+# Schema followed: CasaOS-AppStore v2 protocol, specifically the top-level
+# x-casaos block described in
+# https://github.com/IceWhaleTech/CasaOS-AppStore/blob/main/docs/specs/compose-and-x-casaos.md
+# (fetched July 2026). Service-level x-casaos blocks are the legacy v1
+# format and are not used here.
+#
+# See docker/templates/README.md for where a human submits this.
+name: mqtt-viewer
+services:
+  mqtt-viewer:
+    image: ghcr.io/mqtt-viewer/mqtt-viewer:latest
+    restart: unless-stopped
+    ports:
+      - target: 8080
+        published: "8080"
+        protocol: tcp
+    volumes:
+      - type: bind
+        source: /DATA/AppData/mqtt-viewer
+        target: /data
+    environment:
+      WAILS_SERVER_HOST: "0.0.0.0"
+      WAILS_SERVER_PORT: "8080"
+x-casaos:
+  id: app.mqttviewer.mqtt-viewer
+  main: mqtt-viewer
+  index: /
+  port_map: "8080"
+  scheme: http
+  icon: https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/main/build/appicon.png
+  title:
+    en_US: MQTT Viewer
+  tagline:
+    en_US: Watch MQTT traffic live in your browser
+  description:
+    en_US: >-
+      MQTT Viewer connects to one or more MQTT brokers and shows you the
+      topic tree, live message history and charts as data arrives. It is
+      the same Go backend and Svelte frontend as the desktop app, running
+      headless.
+
+
+      There is no login screen built into the app. Anyone who can reach
+      this port can use your saved broker connections, so keep it on a
+      trusted network or put an authenticating reverse proxy in front of
+      it.
+  author: Sam Webster
+  developer: Sam Webster
+  category: Developer
+  architectures:
+    - amd64
+    - arm64
+  version: "1.0.0"
+  website: https://mqttviewer.app
+  repo: https://github.com/mqtt-viewer/mqtt-viewer
+  support: https://github.com/mqtt-viewer/mqtt-viewer/issues
+  docs: https://github.com/mqtt-viewer/mqtt-viewer/blob/main/docs/DOCKER.md

--- a/docker/templates/portainer-template.json
+++ b/docker/templates/portainer-template.json
@@ -1,0 +1,24 @@
+{
+  "version": "3",
+  "templates": [
+    {
+      "id": 1,
+      "type": 1,
+      "title": "MQTT Viewer",
+      "description": "Browser-based MQTT client. Connects to one or more brokers and shows the topic tree, live message history and charts as data arrives. No built-in login: keep it on a trusted network or put an authenticating reverse proxy in front.",
+      "categories": ["network", "utilities"],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/main/build/appicon.png",
+      "image": "ghcr.io/mqtt-viewer/mqtt-viewer:latest",
+      "name": "mqtt-viewer",
+      "ports": ["8080:8080/tcp"],
+      "volumes": [
+        {
+          "container": "/data"
+        }
+      ],
+      "restart_policy": "unless-stopped",
+      "note": "There is no login screen in the web UI. Anyone who can reach the published port can use your saved broker connections. Run it on a trusted network or behind an authenticating reverse proxy. Documentation: https://github.com/mqtt-viewer/mqtt-viewer/blob/main/docs/DOCKER.md"
+    }
+  ]
+}

--- a/docker/templates/runtipi/config.json
+++ b/docker/templates/runtipi/config.json
@@ -1,0 +1,18 @@
+{
+  "name": "MQTT Viewer",
+  "id": "mqtt-viewer",
+  "available": true,
+  "short_desc": "Browser-based MQTT client with a live topic tree, history and charts.",
+  "author": "Sam Webster",
+  "port": 8080,
+  "categories": ["utilities", "network"],
+  "description": "MQTT Viewer connects to one or more MQTT brokers and shows you the topic tree, live message history and charts as data arrives. It is the same Go backend and Svelte frontend as the desktop app, running headless. There is no login screen built into the app itself, so put it on a trusted network or behind Runtipi's own authentication.",
+  "tipi_version": 1,
+  "version": "1.0.0",
+  "source": "https://github.com/mqtt-viewer/mqtt-viewer",
+  "website": "https://mqttviewer.app",
+  "exposable": true,
+  "supported_architectures": ["arm64", "amd64"],
+  "dynamic_config": true,
+  "form_fields": []
+}

--- a/docker/templates/runtipi/docker-compose.yml
+++ b/docker/templates/runtipi/docker-compose.yml
@@ -1,0 +1,18 @@
+# Runtipi dynamic-compose entry for MQTT Viewer. Pairs with config.json.
+#
+# Schema followed: Runtipi's dynamic compose reference
+# (https://runtipi.io/docs/reference/dynamic-compose, fetched July 2026) and
+# the runtipi/example-appstore reference app's config.json/docker-compose.yml
+# pair. See docker/templates/README.md for the submission flow.
+services:
+  mqtt-viewer:
+    image: ghcr.io/mqtt-viewer/mqtt-viewer:latest
+    restart: unless-stopped
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    x-runtipi:
+      is_main: true
+      internal_port: 8080
+
+x-runtipi:
+  schema_version: 2

--- a/docker/templates/umbrel/docker-compose.yml
+++ b/docker/templates/umbrel/docker-compose.yml
@@ -1,0 +1,20 @@
+# Umbrel compose file for MQTT Viewer. Pairs with umbrel-app.yml.
+#
+# Schema followed: the current umbrel-package-app skill in
+# getumbrel/umbrel-apps (.claude/skills/umbrel-package-app/SKILL.md, fetched
+# July 2026). Every Umbrel app needs an app_proxy service; umbrelOS injects
+# the real container name as <app-id>_<service-name>_1 at install time.
+#
+# The image tag below needs a version + sha256 digest pin (Umbrel App Store
+# rule) once a real image exists. See docker/templates/README.md.
+services:
+  app_proxy:
+    environment:
+      APP_HOST: mqtt-viewer_web_1
+      APP_PORT: 8080
+
+  web:
+    image: ghcr.io/mqtt-viewer/mqtt-viewer:latest
+    restart: on-failure
+    volumes:
+      - ${APP_DATA_DIR}/data:/data

--- a/docker/templates/umbrel/umbrel-app.yml
+++ b/docker/templates/umbrel/umbrel-app.yml
@@ -1,0 +1,42 @@
+# Umbrel app manifest for MQTT Viewer.
+#
+# Schema and field order followed: the current umbrel-package-app skill in
+# getumbrel/umbrel-apps (.claude/skills/umbrel-package-app/SKILL.md, fetched
+# July 2026), which is the app store's own packaging guidance.
+#
+# `port` below is a placeholder. Umbrel host ports must be unique across the
+# whole App Store; pick a free one and confirm it does not collide before
+# opening a PR. `submission` is filled in with the PR URL once one exists.
+# See docker/templates/README.md for the submission flow.
+manifestVersion: 1
+id: mqtt-viewer
+category: networking
+name: MQTT Viewer
+version: "1.0.0"
+tagline: Watch MQTT traffic live in your browser
+description: >-
+  MQTT Viewer connects to one or more MQTT brokers and shows you the topic
+  tree, live message history and charts as data arrives. It is the same Go
+  backend and Svelte frontend as the desktop app, running headless.
+
+
+  There is no login screen built into the app itself. Umbrel's own sign-in
+  protects this page, so nobody else on your network can see your broker
+  connections or credentials without your Umbrel login.
+releaseNotes: ""
+
+developer: Sam Webster
+website: https://mqttviewer.app
+dependencies: []
+repo: https://github.com/mqtt-viewer/mqtt-viewer
+support: https://github.com/mqtt-viewer/mqtt-viewer/issues
+
+port: 3495
+gallery: []
+path: ""
+
+defaultUsername: ""
+defaultPassword: ""
+
+submitter: Sam Webster
+submission: ""

--- a/docker/templates/unraid-template.xml
+++ b/docker/templates/unraid-template.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+  Unraid Community Applications template for MQTT Viewer.
+
+  Schema followed: Unraid's Container version="2" template XML, cross-checked
+  against ca.unraid.net/submit/help/repository-xml and current community
+  templates (cross-seed/unraid-template, ibracorp/unraid-templates) in
+  July 2026. Config tag attributes (Name, Target, Default, Mode, Description,
+  Type, Display, Required, Mask) follow the same reference.
+
+  See docker/templates/README.md for where a human submits this.
+-->
+<Container version="2">
+  <Name>mqtt-viewer</Name>
+  <Repository>ghcr.io/mqtt-viewer/mqtt-viewer:latest</Repository>
+  <Registry>https://github.com/mqtt-viewer/mqtt-viewer/pkgs/container/mqtt-viewer</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/mqtt-viewer/mqtt-viewer/issues</Support>
+  <Project>https://mqttviewer.app</Project>
+  <Overview>MQTT Viewer connects to one or more MQTT brokers and shows you the topic tree, live message history and charts as data arrives. It is the same Go backend and Svelte frontend as the desktop app, running headless. There is no login screen built into the app: anyone who can reach this port can use your saved broker connections, so keep it on a trusted network or put an authenticating reverse proxy in front of it.</Overview>
+  <Category>Network:Tools:</Category>
+  <WebUI>http://[IP]:[PORT:8080]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/main/docker/templates/unraid-template.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/mqtt-viewer/mqtt-viewer/main/build/appicon.png</Icon>
+  <ExtraParams/>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="WebUI Port" Target="8080" Default="8080" Mode="tcp" Description="Port the web UI listens on. Maps to WAILS_SERVER_PORT inside the container." Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+  <Config Name="Data" Target="/data" Default="/mnt/user/appdata/mqtt-viewer" Mode="rw" Description="All persistent state: the SQLite database, machine id and Sparkplug proto files. Mount this or your connections vanish with the container." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/mqtt-viewer</Config>
+</Container>

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -111,6 +111,14 @@ handle yet. If you want this, say so in
 [issue #119](https://github.com/mqtt-viewer/mqtt-viewer/issues/119) so I know
 to prioritise it.
 
+## App store templates
+
+Ready-to-submit manifests for Unraid Community Applications, Portainer,
+CasaOS, Umbrel and Runtipi live in
+[docker/templates](../docker/templates/README.md). Nothing there is live
+yet: I submit them to each platform once the image itself is published, and
+that README has the submission URL and process for each one.
+
 ## Troubleshooting
 
 - **Container exits immediately**: check `docker logs mqtt-viewer`. A


### PR DESCRIPTION
Stacked on #123. Adds docker/templates/ with ready-to-submit manifests for Unraid Community Applications, Portainer (v3), CasaOS (current v2 x-casaos protocol), Umbrel (with the required app_proxy wiring) and Runtipi (dynamic-compose schema 2), plus a README with each platform's submission process, and a pointer section in docs/DOCKER.md.

Nothing has been submitted anywhere; every submission needs a human decision and happens per platform once the image is live on GHCR. Formats were checked against each platform's current reference (cited in templates README) and validated with xmllint, jq and a YAML parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)