### PR TITLE
feat(env): dev-only MQTT_VIEWER_SERVER_ADDRESS override for portal address

### DIFF
--- a/backend/env/env.go
+++ b/backend/env/env.go
@@ -4,7 +4,13 @@ import (
 	"fmt"
 	"log/slog"
 	"mqtt-viewer/backend/machine"
+	"os"
 	"strings"
+)
+
+const (
+	prodServerAddress      = "https://cloud.mqttviewer.app"
+	serverAddressEnvVarKey = "MQTT_VIEWER_SERVER_ADDRESS"
 )
 
 var (
@@ -22,8 +28,8 @@ func init() {
 	if !strings.Contains(Version, "-dev") {
 		IsDev = false
 	}
+	ServerAddress = resolveServerAddress(IsDev, ServerAddress, os.Getenv(serverAddressEnvVarKey))
 	if !IsDev {
-		ServerAddress = "https://cloud.mqttviewer.app"
 		slog.Info("running in prod mode")
 	} else {
 		slog.Info("running in dev mode")
@@ -40,4 +46,16 @@ func init() {
 	}
 
 	slog.Info(fmt.Sprintf("using server address %s", ServerAddress))
+}
+
+// resolveServerAddress picks the portal address. The env var override only
+// applies to dev builds so prod binaries always talk to the real portal.
+func resolveServerAddress(isDev bool, devDefault string, devOverride string) string {
+	if !isDev {
+		return prodServerAddress
+	}
+	if devOverride != "" {
+		return devOverride
+	}
+	return devDefault
 }

--- a/backend/env/env_test.go
+++ b/backend/env/env_test.go
@@ -1,0 +1,50 @@
+package env
+
+import "testing"
+
+func TestResolveServerAddress(t *testing.T) {
+	tests := []struct {
+		name        string
+		isDev       bool
+		devDefault  string
+		devOverride string
+		want        string
+	}{
+		{
+			name:       "prod ignores empty override",
+			isDev:      false,
+			devDefault: "http://localhost:8090",
+			want:       prodServerAddress,
+		},
+		{
+			name:        "prod ignores set override",
+			isDev:       false,
+			devDefault:  "http://localhost:8090",
+			devOverride: "http://localhost:9999",
+			want:        prodServerAddress,
+		},
+		{
+			name:       "dev without override keeps default",
+			isDev:      true,
+			devDefault: "http://localhost:8090",
+			want:       "http://localhost:8090",
+		},
+		{
+			name:        "dev with override uses override",
+			isDev:       true,
+			devDefault:  "http://localhost:8090",
+			devOverride: "http://localhost:9999",
+			want:        "http://localhost:9999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveServerAddress(tt.isDev, tt.devDefault, tt.devOverride)
+			if got != tt.want {
+				t.Errorf("resolveServerAddress(%v, %q, %q) = %q, want %q",
+					tt.isDev, tt.devDefault, tt.devOverride, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

`backend/env/env.go` bakes `ServerAddress` (dev portal `http://localhost:8090`) at build time with no runtime override. Two sessions have hit :8090 being squatted by a VS Code helper, forcing ldflags workarounds for local portal-stub testing.

## What

- Dev builds now read `MQTT_VIEWER_SERVER_ADDRESS` at startup; when set and non-empty it replaces the baked-in dev portal address, so stub-portal tests can pick a free port.
- Prod behaviour is unchanged: the override is ignored when `!IsDev` and the address is always `https://cloud.mqttviewer.app` (now a named constant).
- Extracted the decision into `resolveServerAddress` and covered it with a table-driven unit test (prod ignores override, dev with/without override).

## Testing

- `go build ./backend/...` and `go vet ./backend/...` clean
- `go test ./backend/env/` passes, including with the env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)