### PR TITLE
feat(sort): unified ordering and filtering across topic List and Graph views

### DIFF
--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -31,6 +31,10 @@ export const CHANGELOG: ChangelogEntry[] = [
       "Here's what's landed since 1.0.0. I'll tidy these notes up and give them a version when the update ships.",
     sections: [
       {
+        title: "Sort topics by how busy they are",
+        body: "The topic list can now order itself by what matters in the moment: busiest first, most messages, newest first or silent first, alongside the usual A to Z. The graph view offers the same choices and remembers the one you pick per connection. Its filter box also understands MQTT wildcards now, like sensors/+/temperature, just as the list does, and whatever you type in the filter follows you when you switch between list and graph.",
+      },
+      {
         title: "A status page for your broker",
         body: "There's a new broker status window showing what your broker is up to: connected clients, message and byte rates, subscriptions, retained messages, uptime and version, each with a little trend line. It reads the $SYS topics mosquitto, EMQX and VerneMQ publish, and I also measure message rates client-side so you still get numbers on brokers that publish nothing. Open it from the pulse icon above the topic tree, or hover the $SYS row.",
       },

--- a/frontend/src/design-system/component-index.json
+++ b/frontend/src/design-system/component-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-16T14:38:26.607Z",
+  "generatedAt": "2026-07-18T08:06:39.528Z",
   "tokensRef": "src/design-system/design-tokens.json",
   "components": [
     {
@@ -3349,6 +3349,11 @@
         },
         {
           "name": "messageSource",
+          "type": "object",
+          "required": false
+        },
+        {
+          "name": "searchStore",
           "type": "object",
           "required": false
         }

--- a/frontend/src/util/decay-score.ts
+++ b/frontend/src/util/decay-score.ts
@@ -1,0 +1,62 @@
+// EWMA decaying-score rate estimator. Pure, framework-agnostic.
+//
+// A `score` is an exponentially-weighted recent event count: each event bumps
+// it, and it decays continuously toward zero with time-constant `tauMs` (a
+// leaky integrator). This is the shared engine behind both the Topic Graph's
+// "Busiest" ordering and the topic List's rate sort. The graph re-exports these
+// from its `cooldown.ts` so its existing imports keep working unchanged.
+
+export type DecayScore = { score: number; lastMs: number };
+
+// Time-constant for the topic List's "Busiest" rate estimator, fixed at the
+// Topic Graph's default tau so both views rank busyness equivalently. Lives in
+// this pure module (not the store) so the List sort can share it without
+// dragging the Wails-coupled store into node-env unit tests.
+export const LIST_RATE_TAU_MS = 14000;
+
+// Age `s` to `nowMs` in place and return the decayed score. Mutates `s`
+// (updates score + lastMs); callers that must not perturb the live state use
+// `peekScore` instead.
+export function decayScore(s: DecayScore, nowMs: number, tauMs: number): number {
+  if (s.lastMs === 0) {
+    s.lastMs = nowMs;
+    return s.score;
+  }
+  const dt = nowMs - s.lastMs;
+  if (dt > 0) {
+    s.score *= Math.exp(-dt / tauMs);
+    s.lastMs = nowMs;
+  }
+  return s.score;
+}
+
+// Read-only variant of `decayScore`: returns the score decayed to `nowMs`
+// WITHOUT writing it back. Used by sort passes that compute many nodes' scores
+// against one shared `now` and must not corrupt live store objects.
+export function peekScore(s: DecayScore, nowMs: number, tauMs: number): number {
+  if (s.lastMs === 0) return s.score;
+  const dt = nowMs - s.lastMs;
+  if (dt <= 0) return s.score;
+  return s.score * Math.exp(-dt / tauMs);
+}
+
+// Decay `s` to `nowMs`, then add `by` (default 1). `by` lets a batched caller
+// that collapsed N messages for one topic into a single insert still credit all
+// N events: decay to now, then `score += N`.
+export function bumpScore(
+  s: DecayScore,
+  nowMs: number,
+  tauMs: number,
+  by = 1
+): void {
+  decayScore(s, nowMs, tauMs);
+  s.score += by;
+}
+
+// Convert a decayed score to an approximate message rate in msg/s. At steady
+// state the accumulator converges to rate x tau, so score / tau recovers the
+// real unit — comparable across smoothing (tau) settings, unlike the raw score.
+export function rateFromScore(score: number, tauMs: number): number {
+  if (tauMs <= 0) return 0;
+  return score / (tauMs / 1000);
+}

--- a/frontend/src/util/topic-filter.test.ts
+++ b/frontend/src/util/topic-filter.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import {
+  topicMatchesQuery,
+  topicMatchesSubscription,
+  validateTopic,
+} from "./topic-filter";
+
+describe("validateTopic", () => {
+  test("plain topics are valid", () => {
+    expect(validateTopic("house/kitchen/temp")).toBe(true);
+  });
+
+  test("single-level wildcard is valid anywhere", () => {
+    expect(validateTopic("house/+/temp")).toBe(true);
+    expect(validateTopic("+")).toBe(true);
+  });
+
+  test("multi-level wildcard is only valid as the final level", () => {
+    expect(validateTopic("house/#")).toBe(true);
+    expect(validateTopic("#")).toBe(true);
+    expect(validateTopic("house/#/temp")).toBe(false);
+  });
+
+  test("wildcards embedded within a level are invalid", () => {
+    expect(validateTopic("house/kit+chen")).toBe(false);
+    expect(validateTopic("house/kitchen#")).toBe(false);
+  });
+});
+
+describe("topicMatchesSubscription", () => {
+  test("exact match", () => {
+    expect(topicMatchesSubscription("a/b/c", "a/b/c")).toBe(true);
+  });
+
+  test("single-level wildcard matches exactly one level", () => {
+    expect(topicMatchesSubscription("a/b/c", "a/+/c")).toBe(true);
+    expect(topicMatchesSubscription("a/c", "a/+/c")).toBe(false);
+  });
+
+  test("multi-level wildcard matches remaining levels", () => {
+    expect(topicMatchesSubscription("a/b/c/d", "a/#")).toBe(true);
+    // Per MQTT, "a/#" also matches the parent "a" itself (# spans the parent
+    // level and everything beneath it).
+    expect(topicMatchesSubscription("a", "a/#")).toBe(true);
+    expect(topicMatchesSubscription("b/c", "a/#")).toBe(false);
+  });
+
+  test("subscription shorter than topic without # does not match", () => {
+    expect(topicMatchesSubscription("a/b/c", "a/b")).toBe(false);
+  });
+});
+
+describe("topicMatchesQuery", () => {
+  test("empty query matches everything", () => {
+    expect(topicMatchesQuery("any/topic", "")).toBe(true);
+  });
+
+  test("case-insensitive substring on topic", () => {
+    expect(topicMatchesQuery("House/Kitchen", "kitchen")).toBe(true);
+    expect(topicMatchesQuery("house/kitchen", "GARAGE")).toBe(false);
+  });
+
+  test("matches on an extra haystack (payload)", () => {
+    expect(topicMatchesQuery("house/kitchen", "22.5", ["temp=22.5C"])).toBe(
+      true
+    );
+    expect(topicMatchesQuery("house/kitchen", "99", ["temp=22.5C"])).toBe(
+      false
+    );
+  });
+
+  test("wildcard query matches via MQTT subscription semantics", () => {
+    expect(topicMatchesQuery("house/kitchen/temp", "house/+/temp")).toBe(true);
+    expect(topicMatchesQuery("house/hall/humidity", "house/#")).toBe(true);
+  });
+
+  test("invalid wildcard query falls back to substring only", () => {
+    // "house/#/temp" is not a valid filter (# not final), so only substring
+    // matching applies — and the literal string isn't a substring of the topic.
+    expect(topicMatchesQuery("house/kitchen/temp", "house/#/temp")).toBe(false);
+  });
+
+  // A5: an intermediate node's own path does NOT wildcard-match a deeper
+  // pattern; the List view keeps it only because a descendant leaf matches
+  // (that keep-set behaviour is filter.ts's job, exercised in filter.test.ts).
+  test("intermediate node does not wildcard-match a leaf-level pattern", () => {
+    expect(topicMatchesQuery("house", "house/+")).toBe(false);
+    expect(topicMatchesQuery("house/kitchen", "house/+")).toBe(true);
+  });
+});

--- a/frontend/src/util/topic-filter.ts
+++ b/frontend/src/util/topic-filter.ts
@@ -1,0 +1,95 @@
+// Shared topic matching for the search/filter boxes. Pure, framework-agnostic.
+//
+// A query matches a topic when it is a case-insensitive substring of the topic
+// (or of any extra haystack the caller supplies, e.g. the decoded payload in the
+// List view), OR — when the query looks like an MQTT topic filter (contains `+`
+// or `#`) and is a valid one — when it matches the topic as an MQTT
+// subscription. The List view feeds payloads in as extra haystacks; the Graph
+// view passes none (it stores no payloads).
+
+// Does `subscription` (an MQTT topic filter with `+`/`#` wildcards) match
+// `topic`? Both are compared level by level on `/`.
+export const topicMatchesSubscription = (
+  topic: string,
+  subscription: string
+): boolean => {
+  const topicLevels = topic.split("/");
+  const subscriptionLevels = subscription.split("/");
+
+  for (let i = 0; i < subscriptionLevels.length; i++) {
+    const subLevel = subscriptionLevels[i];
+    const topicLevel = topicLevels[i];
+
+    if (subLevel === "#") {
+      // Multi-level wildcard matches any remaining levels
+      return true;
+    }
+
+    if (subLevel === "+") {
+      // Single-level wildcard matches exactly one level
+      continue;
+    }
+
+    if (subLevel !== topicLevel) {
+      // If levels do not match and it's not a wildcard, return false
+      return false;
+    }
+  }
+
+  // If the subscription is shorter than the topic, it doesn't match
+  return topicLevels.length === subscriptionLevels.length;
+};
+
+// Is `topic` a valid MQTT topic filter? `#` must be the final level; `+` and
+// `#` may not be embedded within a level.
+export const validateTopic = (topic: string): boolean => {
+  const parts = topic.split("/");
+
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i] === "+") {
+      continue;
+    }
+
+    if (parts[i] === "#") {
+      // # is only valid as the last level
+      return i === parts.length - 1;
+    }
+
+    if (parts[i].indexOf("+") !== -1 || parts[i].indexOf("#") !== -1) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+// The substring-vs-wildcard dispatch shared by both views. `topic` and
+// `extraHaystacks` are matched as case-insensitive substrings of `query`; when
+// `query` is a valid MQTT pattern the topic is additionally tried as an MQTT
+// subscription. An empty query matches everything.
+export const topicMatchesQuery = (
+  topic: string,
+  query: string,
+  extraHaystacks: string[] = []
+): boolean => {
+  const q = query.toLowerCase();
+  if (!q) {
+    return true;
+  }
+
+  const lowerTopic = topic.toLowerCase();
+  const substringMatch =
+    lowerTopic.includes(q) ||
+    extraHaystacks.some((h) => h.toLowerCase().includes(q));
+
+  const queryIsMqttPattern = q.includes("#") || q.includes("+");
+  if (!queryIsMqttPattern) {
+    return substringMatch;
+  }
+
+  if (!validateTopic(q)) {
+    return substringMatch;
+  }
+
+  return substringMatch || topicMatchesSubscription(lowerTopic, q);
+};

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/MqttDataPanel.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/MqttDataPanel.svelte
@@ -82,6 +82,7 @@
         {selectedTopicStore}
         {width}
         initialData={$mqttDataStore}
+        {searchStore}
       >
         <ViewToggle slot="leading" {view} onChange={(v) => (view = v)} />
       </MqttGraphView>

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/MqttDataPanel.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/MqttDataPanel.svelte
@@ -11,8 +11,7 @@
   import {
     createSortStore,
     DEFAULT_SORT_PERSIST_KEY,
-    type MqttDataSortDirection,
-    type MqttDataSortKey,
+    validateSort,
   } from "./stores/sort";
   import type { Connection } from "@/stores/connections";
   import type { SelectedTopicStore } from "../../stores/selected-topic-store";
@@ -37,10 +36,10 @@
   const searchStore = createSearchStore();
   const sortStore = createSortStore(
     defaultSortState
-      ? {
-          key: defaultSortState.sortCriteria as MqttDataSortKey,
-          dir: defaultSortState.sortDirection as MqttDataSortDirection,
-        }
+      ? validateSort(
+          defaultSortState.sortCriteria,
+          defaultSortState.sortDirection
+        )
       : undefined
   );
 </script>

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/filter.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/filter.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import type { MqttData } from "../../stores/mqtt-data";
+import { topicMatchesQuery } from "@/util/topic-filter";
 
 export const filterData = (data: MqttData, searchText: string) => {
   if (!searchText) {
@@ -43,73 +44,10 @@ const dataMatchesSearch = (data: MqttData[string], searchText: string) => {
   if (!searchText) {
     return true;
   }
-  const topic = data.topic.toLowerCase();
   const message = data.message?.toString();
-  const text = searchText.toLowerCase();
-
-  const matchesSearch =
-    topic.toLowerCase().includes(text) ||
-    (message !== undefined && message.toLowerCase().includes(text));
-
-  const searchIsMqttPattern = text.includes("#") || text.includes("+");
-  if (!searchIsMqttPattern) {
-    return matchesSearch;
-  }
-
-  const isValidSearchTopic = validateTopic(text);
-  if (!isValidSearchTopic) {
-    return matchesSearch;
-  }
-
-  const topicMatchesSearch = topicMatchesSubscription(topic, text);
-  return matchesSearch || topicMatchesSearch;
-};
-
-const topicMatchesSubscription = (topic: string, subscription: string) => {
-  const topicLevels = topic.split("/");
-  const subscriptionLevels = subscription.split("/");
-
-  for (let i = 0; i < subscriptionLevels.length; i++) {
-    const subLevel = subscriptionLevels[i];
-    const topicLevel = topicLevels[i];
-
-    if (subLevel === "#") {
-      // Multi-level wildcard matches any remaining levels
-      return true;
-    }
-
-    if (subLevel === "+") {
-      // Single-level wildcard matches exactly one level
-      continue;
-    }
-
-    if (subLevel !== topicLevel) {
-      // If levels do not match and it's not a wildcard, return false
-      return false;
-    }
-  }
-
-  // If the subscription is shorter than the topic, it doesn't match
-  return topicLevels.length === subscriptionLevels.length;
-};
-
-const validateTopic = (topic: string) => {
-  const parts = topic.split("/");
-
-  for (let i = 0; i < parts.length; i++) {
-    if (parts[i] === "+") {
-      continue;
-    }
-
-    if (parts[i] === "#") {
-      // for Rule #2
-      return i === parts.length - 1;
-    }
-
-    if (parts[i].indexOf("+") !== -1 || parts[i].indexOf("#") !== -1) {
-      return false;
-    }
-  }
-
-  return true;
+  return topicMatchesQuery(
+    data.topic,
+    searchText,
+    message !== undefined ? [message] : []
+  );
 };

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/sort.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/sort.ts
@@ -34,11 +34,14 @@ export const getSortedDataKeys = (
     } else if (sortKey === "rate") {
       const aRate = rateByKey![a];
       const bRate = rateByKey![b];
-      res = bRate <= aRate ? 1 : -1;
-    } else if (sortKey === "count") {
+      // Equal rates fall through to the alphabetical order the "topic" key uses
+      // (b.localeCompare(a), so ties render A -> Z under dir "desc") instead of
+      // a constant 1, which left tie order dependent on Object.keys iteration.
+      res = aRate === bRate ? b.localeCompare(a) : bRate < aRate ? 1 : -1;
+    } else if (sortKey === "msgs") {
       const aCount = data[a].messageCount ?? 0;
       const bCount = data[b].messageCount ?? 0;
-      res = bCount <= aCount ? 1 : -1;
+      res = aCount === bCount ? b.localeCompare(a) : bCount < aCount ? 1 : -1;
     }
     return sortDirection === "desc" ? res * -1 : res;
   });

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/sort.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/sort.ts
@@ -1,3 +1,4 @@
+import { peekScore, LIST_RATE_TAU_MS } from "@/util/decay-score";
 import type { MqttData } from "../../stores/mqtt-data";
 import type { MqttDataSortDirection, MqttDataSortKey } from "../../stores/sort";
 
@@ -6,6 +7,22 @@ export const getSortedDataKeys = (
   sortKey: MqttDataSortKey,
   sortDirection: MqttDataSortDirection
 ) => {
+  // Capture one `now` for the whole pass and precompute each key's decayed rate
+  // via a NON-mutating peek. When the search box is empty, `data` is the live
+  // store (uncloned), so a mutating decay here would corrupt the score objects
+  // the next arrival depends on. Precomputing also keeps it to one decay per
+  // node instead of one per comparison. Uniform decay preserves sibling rank
+  // between arrivals, so no re-sort ticker is needed.
+  let rateByKey: Record<string, number> | undefined;
+  if (sortKey === "rate") {
+    const now = Date.now();
+    rateByKey = {};
+    for (const key of Object.keys(data)) {
+      const rate = data[key].rate;
+      rateByKey[key] = rate ? peekScore(rate, now, LIST_RATE_TAU_MS) : 0;
+    }
+  }
+
   const sortedDataKeys = Object.keys(data).sort((a, b) => {
     let res = 0;
     if (sortKey === "time") {
@@ -14,6 +31,14 @@ export const getSortedDataKeys = (
       res = bTime <= aTime ? 1 : -1;
     } else if (sortKey === "topic") {
       res = b.localeCompare(a);
+    } else if (sortKey === "rate") {
+      const aRate = rateByKey![a];
+      const bRate = rateByKey![b];
+      res = bRate <= aRate ? 1 : -1;
+    } else if (sortKey === "count") {
+      const aCount = data[a].messageCount ?? 0;
+      const bCount = data[b].messageCount ?? 0;
+      res = bCount <= aCount ? 1 : -1;
     }
     return sortDirection === "desc" ? res * -1 : res;
   });

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/tests/filter.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/tests/filter.test.ts
@@ -255,6 +255,47 @@ test("parent that matches is kept when no children match", () => {
   expect(filteredData).toEqual(expectedResult);
 });
 
+// A5: the top node "house" (topic "house", one level) does NOT itself
+// wildcard-match "house/+", yet the tree keeps it because its child leaf
+// "house/kitchen" matches. A shallow sibling "garage" that matches neither is
+// pruned. Prune semantics: parents of matches are retained.
+test("wildcard pattern keeps a parent via a matching leaf, prunes non-matches", () => {
+  const unfilteredData: MqttData = {
+    house: {
+      topic: "house",
+      isDecodedProto: false,
+      latestMessageTime: new Date(),
+      message: undefined,
+      messageCount: 1,
+      subtopicCount: 1,
+      children: {
+        kitchen: {
+          topic: "house/kitchen",
+          isDecodedProto: false,
+          latestMessageTime: new Date(),
+          message: "22.5",
+          messageCount: 1,
+          subtopicCount: 0,
+          children: {},
+        },
+      },
+    },
+    garage: {
+      topic: "garage",
+      isDecodedProto: false,
+      latestMessageTime: new Date(),
+      message: "closed",
+      messageCount: 1,
+      subtopicCount: 0,
+      children: {},
+    },
+  };
+
+  const filteredData = filterData(unfilteredData, "house/+");
+  expect(Object.keys(filteredData)).toEqual(["house"]);
+  expect(Object.keys(filteredData.house.children)).toEqual(["kitchen"]);
+});
+
 test("search string with trailing empty space filters correctly", () => {
   const unfilteredData = {
     aaaaa: {

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/tests/sort.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/tests/sort.test.ts
@@ -47,7 +47,7 @@ test("data keys are sorted by topic ascending", () => {
   expect(sortedKeys).toEqual(SORTED_TOPIC_DESC.toReversed());
 });
 
-// ---- count sort ----
+// ---- msgs sort ----
 
 const COUNT_DATA = {
   quiet: { messageCount: 3 },
@@ -56,14 +56,35 @@ const COUNT_DATA = {
   silent: { messageCount: 0 },
 } as unknown as MqttData;
 
-test("count sort desc puts the most-messages topic first", () => {
-  const sortedKeys = getSortedDataKeys(COUNT_DATA, "count", "desc");
+test("msgs sort desc puts the most-messages topic first", () => {
+  const sortedKeys = getSortedDataKeys(COUNT_DATA, "msgs", "desc");
   expect(sortedKeys).toEqual(["loud", "medium", "quiet", "silent"]);
 });
 
-test("count sort asc reverses to fewest-messages first", () => {
-  const sortedKeys = getSortedDataKeys(COUNT_DATA, "count", "asc");
+test("msgs sort asc reverses to fewest-messages first", () => {
+  const sortedKeys = getSortedDataKeys(COUNT_DATA, "msgs", "asc");
   expect(sortedKeys).toEqual(["silent", "quiet", "medium", "loud"]);
+});
+
+test("msgs sort breaks equal-count ties alphabetically (A -> Z under desc)", () => {
+  const data = {
+    charlie: { messageCount: 5 },
+    alpha: { messageCount: 5 },
+    bravo: { messageCount: 5 },
+  } as unknown as MqttData;
+  const sortedKeys = getSortedDataKeys(data, "msgs", "desc");
+  expect(sortedKeys).toEqual(["alpha", "bravo", "charlie"]);
+});
+
+test("rate sort breaks equal-rate ties alphabetically (A -> Z under desc)", () => {
+  const now = Date.now();
+  const data = {
+    charlie: { rate: { score: 9, lastMs: now } },
+    alpha: { rate: { score: 9, lastMs: now } },
+    bravo: { rate: { score: 9, lastMs: now } },
+  } as unknown as MqttData;
+  const sortedKeys = getSortedDataKeys(data, "rate", "desc");
+  expect(sortedKeys).toEqual(["alpha", "bravo", "charlie"]);
 });
 
 // ---- rate sort ----

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/tests/sort.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/MqttTopicTree/tests/sort.test.ts
@@ -46,3 +46,70 @@ test("data keys are sorted by topic ascending", () => {
   const sortedKeys = getSortedDataKeys(UNSORTED_DATA, "topic", "asc");
   expect(sortedKeys).toEqual(SORTED_TOPIC_DESC.toReversed());
 });
+
+// ---- count sort ----
+
+const COUNT_DATA = {
+  quiet: { messageCount: 3 },
+  loud: { messageCount: 100 },
+  medium: { messageCount: 42 },
+  silent: { messageCount: 0 },
+} as unknown as MqttData;
+
+test("count sort desc puts the most-messages topic first", () => {
+  const sortedKeys = getSortedDataKeys(COUNT_DATA, "count", "desc");
+  expect(sortedKeys).toEqual(["loud", "medium", "quiet", "silent"]);
+});
+
+test("count sort asc reverses to fewest-messages first", () => {
+  const sortedKeys = getSortedDataKeys(COUNT_DATA, "count", "asc");
+  expect(sortedKeys).toEqual(["silent", "quiet", "medium", "loud"]);
+});
+
+// ---- rate sort ----
+
+test("rate sort desc puts the busiest topic first", () => {
+  const now = Date.now();
+  const data = {
+    quiet: { rate: { score: 1, lastMs: now } },
+    busy: { rate: { score: 50, lastMs: now } },
+    medium: { rate: { score: 10, lastMs: now } },
+  } as unknown as MqttData;
+  const sortedKeys = getSortedDataKeys(data, "rate", "desc");
+  expect(sortedKeys).toEqual(["busy", "medium", "quiet"]);
+});
+
+test("rate sort treats a missing rate field as score 0 and sorts it last", () => {
+  const now = Date.now();
+  const data = {
+    hasRate: { rate: { score: 5, lastMs: now } },
+    noRate: {},
+  } as unknown as MqttData;
+  const sortedKeys = getSortedDataKeys(data, "rate", "desc");
+  expect(sortedKeys).toEqual(["hasRate", "noRate"]);
+});
+
+test("rate sort ranks by decayed value: a fresher score outranks an older equal one", () => {
+  const now = Date.now();
+  const data = {
+    stale: { rate: { score: 20, lastMs: now - 120_000 } }, // decayed hard
+    fresh: { rate: { score: 20, lastMs: now } }, // barely decayed
+  } as unknown as MqttData;
+  const sortedKeys = getSortedDataKeys(data, "rate", "desc");
+  expect(sortedKeys).toEqual(["fresh", "stale"]);
+});
+
+test("rate sort never mutates the score objects (live store is uncloned)", () => {
+  const now = Date.now();
+  const rateA = { score: 30, lastMs: now - 5_000 };
+  const rateB = { score: 8, lastMs: now - 5_000 };
+  const data = {
+    a: { rate: rateA },
+    b: { rate: rateB },
+  } as unknown as MqttData;
+
+  getSortedDataKeys(data, "rate", "desc");
+
+  expect(rateA).toEqual({ score: 30, lastMs: now - 5_000 });
+  expect(rateB).toEqual({ score: 8, lastMs: now - 5_000 });
+});

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/SearchActionBar/SearchActionBar.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/SearchActionBar/SearchActionBar.svelte
@@ -12,6 +12,7 @@
   import DropdownMenu from "@/components/DropdownMenu/DropdownMenu.svelte";
   import DropdownMenuItem from "@/components/DropdownMenu/DropdownMenuItem.svelte";
   import _ from "lodash";
+  import { onDestroy } from "svelte";
   import Tooltip from "@/components/Tooltip/Tooltip.svelte";
   import {
     ClearConnectionHistory,
@@ -29,6 +30,10 @@
 
   let searchText = $searchStore.text;
   const debouncedSetSearchText = _.debounce(searchStore.setSearchText, 200);
+  // Flush any pending debounced text on unmount so a List -> Graph toggle within
+  // 200ms of typing doesn't leave the graph opening unfiltered (the filter would
+  // otherwise flash in late once the trailing call fires against a dead view).
+  onDestroy(() => debouncedSetSearchText.flush());
   $: searchText,
     (() => {
       if (searchText === "") {
@@ -89,7 +94,7 @@
       return dir === "desc" ? "Newest" : "Silent";
     } else if (key === "rate") {
       return "Busiest";
-    } else if (key === "count") {
+    } else if (key === "msgs") {
       return "Messages";
     } else {
       return dir === "desc" ? "A → Z" : "Z → A";
@@ -152,8 +157,8 @@
             >Busiest first</DropdownMenuItem
           >
           <DropdownMenuItem
-            isSelected={$sortStore.key === "count"}
-            onClick={() => sortStore.setSort("count", "desc")}
+            isSelected={$sortStore.key === "msgs"}
+            onClick={() => sortStore.setSort("msgs", "desc")}
             >Most messages</DropdownMenuItem
           >
         </div>

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/SearchActionBar/SearchActionBar.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/components/SearchActionBar/SearchActionBar.svelte
@@ -86,7 +86,11 @@
     dir: MqttDataSortDirection
   ) => {
     if (key === "time") {
-      return dir === "desc" ? "Newest" : "Oldest";
+      return dir === "desc" ? "Newest" : "Silent";
+    } else if (key === "rate") {
+      return "Busiest";
+    } else if (key === "count") {
+      return "Messages";
     } else {
       return dir === "desc" ? "A → Z" : "Z → A";
     }
@@ -120,7 +124,7 @@
     </Tooltip>
 
     <Tooltip placement="bottom">
-      <DropdownMenu triggerText={sortButtonText} triggerClass="w-[100px]">
+      <DropdownMenu triggerText={sortButtonText} triggerClass="w-[110px]">
         <div class="flex flex-col" slot="menu-content">
           <DropdownMenuItem
             isSelected={$sortStore.key === "topic" && $sortStore.dir === "desc"}
@@ -140,7 +144,17 @@
           <DropdownMenuItem
             isSelected={$sortStore.key === "time" && $sortStore.dir === "asc"}
             onClick={() => sortStore.setSort("time", "asc")}
-            >Oldest first</DropdownMenuItem
+            >Silent first</DropdownMenuItem
+          >
+          <DropdownMenuItem
+            isSelected={$sortStore.key === "rate"}
+            onClick={() => sortStore.setSort("rate", "desc")}
+            >Busiest first</DropdownMenuItem
+          >
+          <DropdownMenuItem
+            isSelected={$sortStore.key === "count"}
+            onClick={() => sortStore.setSort("count", "desc")}
+            >Most messages</DropdownMenuItem
           >
         </div>
       </DropdownMenu>

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/mqtt-data.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/mqtt-data.test.ts
@@ -200,3 +200,77 @@ describe("processMessages batching", () => {
     unsub();
   });
 });
+
+describe("rate score bumps", () => {
+  it("initialises and bumps rate on the leaf and every ancestor by the batch count", () => {
+    const highlightStore = createHighlightedMqttTopicsStore();
+    const store = createMqttDataStore(highlightStore, connectionEventSet);
+    const unsub = store.subscribe(() => {});
+
+    const t = 1000;
+    fireMessages([
+      makeMessage("1", "home/sensors/a", "x", t),
+      makeMessage("2", "home/sensors/a", "y", t),
+      makeMessage("3", "home/sensors/a", "z", t),
+    ]);
+
+    const data = get(store);
+    const leaf = data.home.children.sensors.children.a;
+
+    // A fresh node's score equals the batch count (decay is a no-op on the
+    // very first bump), and lastMs is the batch timestamp.
+    expect(leaf.rate?.score).toBe(3);
+    expect(leaf.rate?.lastMs).toBe(t);
+    // Every ancestor carries the same subtree-aggregate score.
+    expect(data.home.children.sensors.rate?.score).toBe(3);
+    expect(data.home.rate?.score).toBe(3);
+
+    unsub();
+  });
+
+  it("aggregates sibling counts into shared ancestors within one batch", () => {
+    const highlightStore = createHighlightedMqttTopicsStore();
+    const store = createMqttDataStore(highlightStore, connectionEventSet);
+    const unsub = store.subscribe(() => {});
+
+    const t = 2000;
+    fireMessages([
+      makeMessage("1", "home/sensors/a", "x", t),
+      makeMessage("2", "home/sensors/a", "y", t),
+      makeMessage("3", "home/sensors/a", "z", t), // a: 3
+      makeMessage("4", "home/sensors/b", "p", t),
+      makeMessage("5", "home/sensors/b", "q", t), // b: 2
+    ]);
+
+    const data = get(store);
+    const sensors = data.home.children.sensors;
+
+    expect(sensors.children.a.rate?.score).toBe(3);
+    expect(sensors.children.b.rate?.score).toBe(2);
+    // Ancestor rate is the subtree aggregate: 3 + 2.
+    expect(sensors.rate?.score).toBe(5);
+    expect(data.home.rate?.score).toBe(5);
+
+    unsub();
+  });
+
+  it("decays a topic's rate score across batches at later timestamps", () => {
+    const highlightStore = createHighlightedMqttTopicsStore();
+    const store = createMqttDataStore(highlightStore, connectionEventSet);
+    const unsub = store.subscribe(() => {});
+
+    // First batch seeds score 1. (Uses a realistic non-zero timestamp: the
+    // shared decay engine treats lastMs === 0 as "uninitialised", so an epoch-0
+    // timestamp would skip the first decay — a non-issue for real MQTT stamps.)
+    fireMessages([makeMessage("1", "a/b", "first", 1_000)]);
+    // Second batch 14000ms later (one tau) decays the old score by e^-1
+    // (~0.368) then adds 1.
+    fireMessages([makeMessage("2", "a/b", "second", 15_000)]);
+
+    const data = get(store);
+    const score = data.a.children.b.rate?.score ?? 0;
+    expect(score).toBeCloseTo(Math.exp(-1) + 1, 5);
+
+    unsub();
+  });
+});

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/mqtt-data.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/mqtt-data.ts
@@ -3,6 +3,11 @@ import type * as events from "bindings/mqtt-viewer/events/models";
 import type * as mqtt from "bindings/mqtt-viewer/backend/mqtt/models";
 import { Events } from "@wailsio/runtime";
 import { base64ToUtf8 } from "@/components/CodeEditor/codec";
+import {
+  bumpScore,
+  LIST_RATE_TAU_MS,
+  type DecayScore,
+} from "@/util/decay-score";
 import type {
   HighlightCause,
   HighlightedMqttTopicsStore,
@@ -17,6 +22,9 @@ export type MqttData = {
     message?: string; // byte array
     isDecodedProto: boolean;
     children: MqttData;
+    // EWMA rate score for "Busiest" sort, lazily initialised on first message.
+    // Optional so hand-built fixtures/stories stay valid without it.
+    rate?: DecayScore;
   };
 };
 
@@ -105,6 +113,21 @@ export const createMqttDataStore = (
     highlightedTopicStore.markTopicsForHighlight(highlightMarks);
   };
 
+  // Age the node's rate score to the batch timestamp and credit all `count`
+  // messages (lazily creating the score the first time a node sees traffic).
+  // Called on the leaf node AND every ancestor so each level carries its
+  // subtree-aggregate rate, mirroring the graph's per-level bump.
+  const bumpNodeRate = (
+    node: MqttData[string],
+    nowMs: number,
+    count: number
+  ) => {
+    if (node.rate === undefined) {
+      node.rate = { score: 0, lastMs: 0 };
+    }
+    bumpScore(node.rate, nowMs, LIST_RATE_TAU_MS, count);
+  };
+
   // Returns true when a new topic-level key was created in mqttData, so the
   // caller can maintain subtopicCount (the number of direct child keys) by
   // incrementing it, instead of rescanning every sibling on each insert —
@@ -125,6 +148,7 @@ export const createMqttDataStore = (
         mqttData[topicLevel].message = message;
         mqttData[topicLevel].isDecodedProto = isDecodedProto;
         mqttData[topicLevel].latestMessageTime = timestamp;
+        bumpNodeRate(mqttData[topicLevel], timestamp.getTime(), count);
 
         return false;
       }
@@ -143,6 +167,7 @@ export const createMqttDataStore = (
         mqttData[topicLevel].subtopicCount += 1;
       }
       mqttData[topicLevel].latestMessageTime = timestamp;
+      bumpNodeRate(mqttData[topicLevel], timestamp.getTime(), count);
       return false;
     }
 
@@ -157,6 +182,7 @@ export const createMqttDataStore = (
         children: {},
         latestMessageTime: timestamp,
       };
+      bumpNodeRate(mqttData[topicLevel], timestamp.getTime(), count);
       return true;
     }
 
@@ -181,6 +207,7 @@ export const createMqttDataStore = (
       children,
       latestMessageTime: timestamp,
     };
+    bumpNodeRate(mqttData[topicLevel], timestamp.getTime(), count);
     return true;
   };
 

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/sort.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/sort.ts
@@ -3,7 +3,7 @@ import { writable } from "svelte/store";
 
 export const DEFAULT_SORT_PERSIST_KEY = "mqtt-data-sort";
 
-export type MqttDataSortKey = "time" | "topic" | "rate" | "count";
+export type MqttDataSortKey = "time" | "topic" | "rate" | "msgs";
 export type MqttDataSortDirection = "asc" | "desc";
 
 export interface MqtttDataSort {
@@ -17,7 +17,7 @@ const VALID_SORT_KEYS: readonly MqttDataSortKey[] = [
   "time",
   "topic",
   "rate",
-  "count",
+  "msgs",
 ];
 const VALID_SORT_DIRS: readonly MqttDataSortDirection[] = ["asc", "desc"];
 

--- a/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/sort.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttDataPanel/stores/sort.ts
@@ -3,7 +3,7 @@ import { writable } from "svelte/store";
 
 export const DEFAULT_SORT_PERSIST_KEY = "mqtt-data-sort";
 
-export type MqttDataSortKey = "time" | "topic";
+export type MqttDataSortKey = "time" | "topic" | "rate" | "count";
 export type MqttDataSortDirection = "asc" | "desc";
 
 export interface MqtttDataSort {
@@ -11,14 +11,33 @@ export interface MqtttDataSort {
   dir: MqttDataSortDirection;
 }
 
+const DEFAULT_SORT: MqtttDataSort = { key: "topic", dir: "desc" };
+
+const VALID_SORT_KEYS: readonly MqttDataSortKey[] = [
+  "time",
+  "topic",
+  "rate",
+  "count",
+];
+const VALID_SORT_DIRS: readonly MqttDataSortDirection[] = ["asc", "desc"];
+
+// A persisted sort row can come from a newer build with keys/dirs this build
+// doesn't know. Coerce anything unrecognised back to the default so unknown
+// values never reach the comparators. Each field defaults independently.
+export const validateSort = (key: unknown, dir: unknown): MqtttDataSort => ({
+  key: VALID_SORT_KEYS.includes(key as MqttDataSortKey)
+    ? (key as MqttDataSortKey)
+    : DEFAULT_SORT.key,
+  dir: VALID_SORT_DIRS.includes(dir as MqttDataSortDirection)
+    ? (dir as MqttDataSortDirection)
+    : DEFAULT_SORT.dir,
+});
+
 export type MqttDataSortStore = ReturnType<typeof createSortStore>;
 
 export const createSortStore = (defaultSortState?: MqtttDataSort) => {
   const { subscribe, update, set } = writable<MqtttDataSort>(
-    defaultSortState ?? {
-      key: "topic",
-      dir: "desc",
-    }
+    defaultSortState ?? DEFAULT_SORT
   );
 
   const setSort = (key: MqttDataSortKey, dir: MqttDataSortDirection) => {

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.spec.json
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.spec.json
@@ -37,6 +37,11 @@
       "name": "messageSource",
       "type": "object",
       "required": false
+    },
+    {
+      "name": "searchStore",
+      "type": "object",
+      "required": false
     }
   ],
   "tokens": [

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
@@ -365,6 +365,10 @@
   let stats: StatsInfo | null = null;
   let statsTimer: number | null = null;
   let ingestCounter = 0;
+  // Monotonic arrival count for the live-tick re-sort gate. Deliberately
+  // separate from ingestCounter, which the stats HUD zeroes every second and
+  // so cannot signal "anything arrived since the last eligible tick".
+  let totalIngested = 0;
 
   const startStatsTimer = () => {
     if (statsTimer !== null) return;
@@ -461,6 +465,7 @@
     unsubSource = (messageSource ?? wailsSource).subscribe(
       (msgs) => {
         ingestCounter += msgs.length;
+        totalIngested += msgs.length;
         for (const m of msgs) model.ingest(m.topic, m.timeMs || Date.now());
       },
       () => {
@@ -490,8 +495,8 @@
       // actually run: on throttled big trees (or while paused) arrivals must
       // stay pending until the next eligible tick, not be forgotten.
       if (!paused && dueThisTick) {
-        const ingestedSinceLastTick = ingestCounter !== lastTickIngest;
-        lastTickIngest = ingestCounter;
+        const ingestedSinceLastTick = totalIngested !== lastTickIngest;
+        lastTickIngest = totalIngested;
         const needsRelayout =
           sortKey === "rate" ||
           sortKey === "recency" ||

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
@@ -486,14 +486,19 @@
       // alpha/count don't drift at all: alpha never reorders existing nodes, and
       // topic-count changes bump structureGen -> visibleDirty -> notifyData
       // relayouts on their own.
-      const ingestedSinceLastTick = ingestCounter !== lastTickIngest;
-      lastTickIngest = ingestCounter;
-      const needsRelayout =
-        sortKey === "rate" ||
-        sortKey === "recency" ||
-        ((sortKey === "stale" || sortKey === "msgs") && ingestedSinceLastTick);
-      if (!paused && dueThisTick && needsRelayout) {
-        renderer.relayout();
+      // Only consume the arrival signal on ticks where a relayout could
+      // actually run: on throttled big trees (or while paused) arrivals must
+      // stay pending until the next eligible tick, not be forgotten.
+      if (!paused && dueThisTick) {
+        const ingestedSinceLastTick = ingestCounter !== lastTickIngest;
+        lastTickIngest = ingestCounter;
+        const needsRelayout =
+          sortKey === "rate" ||
+          sortKey === "recency" ||
+          ((sortKey === "stale" || sortKey === "msgs") && ingestedSinceLastTick);
+        if (needsRelayout) {
+          renderer.relayout();
+        }
       }
       // keep the hover inspector's numbers live while the pointer rests
       if (hover) hover = buildHover(hover.topic, hover.x, hover.y);

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
@@ -12,11 +12,13 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { Events } from "@wailsio/runtime";
+  import { get } from "svelte/store";
   import _ from "lodash";
   import type * as mqtt from "bindings/mqtt-viewer/backend/mqtt/models";
   import type { Connection } from "@/stores/connections";
   import type { SelectedTopicStore } from "../../stores/selected-topic-store";
   import type { MqttData } from "../MqttDataPanel/stores/mqtt-data";
+  import type { SearchStore } from "../MqttDataPanel/stores/search";
   import theme from "@/stores/theme";
   import PanelHeader from "@/components/PanelHeader/PanelHeader.svelte";
   import BaseInput from "@/components/InputFields/BaseInput.svelte";
@@ -35,7 +37,7 @@
     rampCssGradient,
     rateFromScore,
   } from "./cooldown";
-  import type { SortKey } from "./tidy-layout";
+  import { coerceSortKey, type SortKey } from "./tidy-layout";
 
   export let connection: Connection;
   export let selectedTopicStore: SelectedTopicStore;
@@ -44,6 +46,9 @@
   export let width = 0;
   /** override the live message feed (storybook / dev harnesses) */
   export let messageSource: GraphMessageSource | undefined = undefined;
+  /** shared filter text store from the List view, so filter survives the
+   *  List<->Graph toggle. Absent in storybook/dev: falls back to local state. */
+  export let searchStore: SearchStore | undefined = undefined;
 
   let canvasEl: HTMLCanvasElement;
   let containerEl: HTMLDivElement;
@@ -52,11 +57,14 @@
   const model = new TopicModel();
   let renderer: TopicGraphRenderer | null = null;
   let unsubSource: (() => void) | null = null;
+  let unsubSearch: (() => void) | null = null;
   let ro: ResizeObserver | null = null;
   let liveTimer: number | null = null;
   let everSized = false;
 
-  let filterText = "";
+  // Seed from the shared store (when present) BEFORE the reactive push below
+  // runs, so switching in from the List doesn't clobber existing filter text.
+  let filterText = searchStore ? get(searchStore).text : "";
   let sortKey: SortKey = "rate";
   let paused = false;
   let allExpanded = false;
@@ -70,9 +78,10 @@
 
   const SORT_LABELS: Record<SortKey, string> = {
     rate: "Busiest first",
-    recency: "Recent first",
+    msgs: "Most messages",
+    recency: "Newest first",
     stale: "Silent first",
-    alpha: "Name",
+    alpha: "Topic A → Z",
     count: "Topic count",
   };
 
@@ -129,6 +138,10 @@
       if (typeof s.cooldownMs === "number") cooldownMs = s.cooldownMs;
       if (typeof s.tauMs === "number") tauMs = s.tauMs;
       if (typeof s.maxNodeR === "number") maxNodeR = s.maxNodeR;
+      // validate against the full key union; unknown/missing coerces to the
+      // "rate" default so an older blob (no sortKey) or garbage never reaches
+      // the sort comparators
+      sortKey = coerceSortKey(s.sortKey);
     } catch (e) {
       console.error("topic-graph settings load failed", e);
     }
@@ -146,6 +159,7 @@
           cooldownMs,
           tauMs,
           maxNodeR,
+          sortKey,
         })
       );
     } catch (e) {
@@ -159,25 +173,35 @@
     renderer.setCvdSafe(cvdSafe);
     renderer.setCooldownMs(cooldownMs);
     renderer.setMaxNodeSize(maxNodeR);
+    renderer.setSort(sortKey); // reflect the persisted sort into the renderer
     model.tauMs = tauMs;
   };
 
   const seed = (data: MqttData) => {
+    // Recurse into children FIRST (post-order) so that when seedTopic runs for
+    // a topic that both publishes and has subtopics, its child nodes already
+    // exist and it is correctly treated as a non-leaf (its own rate isn't
+    // over-seeded from the subtree aggregate).
     const walk = (d: MqttData) => {
       for (const key of Object.keys(d)) {
         const n = d[key];
-        // Only nodes that actually published get ingested (same structural
-        // check as the list view). Parents carry latestMessageTime propagated
-        // from children, so ingesting them too would record a phantom own
-        // message on every ancestor. ingest() still creates the ancestor
-        // nodes from the leaf's path.
+        walk(n.children);
+        // Only nodes that actually published get their own count/rate; parents
+        // carry a propagated latestMessageTime but no own message. seedTopic
+        // still creates the ancestor path and folds this topic's own count into
+        // every ancestor's aggCount, so each level ends equal to the List's
+        // subtree-cumulative messageCount.
         if (n.message !== undefined) {
-          const t = n.latestMessageTime
+          let childMsgs = 0;
+          for (const ck of Object.keys(n.children)) {
+            childMsgs += n.children[ck].messageCount;
+          }
+          const ownMsgs = n.messageCount - childMsgs;
+          const lastMs = n.latestMessageTime
             ? new Date(n.latestMessageTime).getTime()
             : Date.now();
-          model.ingest(n.topic, t);
+          model.seedTopic(n.topic, ownMsgs, lastMs, n.rate);
         }
-        walk(n.children);
       }
     };
     walk(data);
@@ -356,6 +380,18 @@
     },
   };
 
+  // Mirror the shared List search store into filterText (external edits, e.g.
+  // typing in the List then toggling here). Guarded so the store->local sync
+  // and the local->store push below don't loop.
+  onMount(() => {
+    if (!searchStore) return;
+    unsubSearch = searchStore.subscribe((s) => {
+      if (s.text !== filterText) filterText = s.text;
+    });
+  });
+  // Push local edits back out so the List picks them up on the return toggle.
+  $: if (searchStore) searchStore.setSearchText(filterText);
+
   onMount(async () => {
     loadSettings();
     const w = containerEl.clientWidth || width || 800;
@@ -408,7 +444,19 @@
       // visual reconciliation) is too expensive to run every 1.2s tick, so it
       // only runs every 4th tick (~5s) once the tree crosses 2000 topics.
       const dueThisTick = model.topicCount <= 2000 || liveTick % 4 === 0;
-      if (!paused && dueThisTick && (sortKey === "rate" || sortKey === "recency")) {
+      // rate/recency/stale/msgs all drift with incoming data WITHOUT any
+      // structural change, so their sibling order goes stale between arrivals
+      // and needs the periodic relayout to track the List. alpha/count don't:
+      // alpha never reorders existing nodes, and topic-count changes bump
+      // structureGen -> visibleDirty -> notifyData relayouts on their own.
+      if (
+        !paused &&
+        dueThisTick &&
+        (sortKey === "rate" ||
+          sortKey === "recency" ||
+          sortKey === "stale" ||
+          sortKey === "msgs")
+      ) {
         renderer.relayout();
       }
       // keep the hover inspector's numbers live while the pointer rests
@@ -442,6 +490,7 @@
 
   onDestroy(() => {
     unsubSource?.();
+    unsubSearch?.();
     ro?.disconnect();
     document.removeEventListener("fullscreenchange", onFullscreenChange);
     if (liveTimer) clearInterval(liveTimer);
@@ -465,6 +514,7 @@
   const setSort = (key: SortKey) => {
     sortKey = key;
     renderer?.setSort(key);
+    saveSettings();
   };
   const setDepth = (d: number) => {
     renderer?.expandToDepth(d);

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/MqttGraphView.svelte
@@ -28,6 +28,7 @@
   import DropdownMenu from "@/components/DropdownMenu/DropdownMenu.svelte";
   import DropdownMenuItem from "@/components/DropdownMenu/DropdownMenuItem.svelte";
   import { untypedColors } from "@/util/resolvedTailwindConfig";
+  import { LIST_RATE_TAU_MS, type DecayScore } from "@/util/decay-score";
   import { TopicModel, type TopicNode } from "./topic-model";
   import { TopicGraphRenderer } from "./pixi-graph";
   import {
@@ -178,10 +179,20 @@
   };
 
   const seed = (data: MqttData) => {
-    // Recurse into children FIRST (post-order) so that when seedTopic runs for
-    // a topic that both publishes and has subtopics, its child nodes already
-    // exist and it is correctly treated as a non-leaf (its own rate isn't
-    // over-seeded from the subtree aggregate).
+    // The List accumulated its rate scores at LIST_RATE_TAU_MS, but the graph's
+    // tau is user-configurable. At steady state score = rate x tau, so a score
+    // transplanted across taus misreports rate magnitude by tauGraph/tauList;
+    // scale every seeded score by this factor so both views agree on busyness.
+    const tauScale = tauMs / LIST_RATE_TAU_MS;
+    const scaleRate = (r: DecayScore): DecayScore => ({
+      score: r.score * tauScale,
+      lastMs: r.lastMs,
+    });
+
+    // Pass 1 (post-order): recurse into children FIRST so that when seedTopic
+    // runs for a topic that both publishes and has subtopics, its child nodes
+    // already exist and it is correctly treated as a non-leaf (its own rate
+    // isn't over-seeded from the subtree aggregate).
     const walk = (d: MqttData) => {
       for (const key of Object.keys(d)) {
         const n = d[key];
@@ -200,11 +211,30 @@
           const lastMs = n.latestMessageTime
             ? new Date(n.latestMessageTime).getTime()
             : Date.now();
-          model.seedTopic(n.topic, ownMsgs, lastMs, n.rate);
+          model.seedTopic(
+            n.topic,
+            ownMsgs,
+            lastMs,
+            n.rate ? scaleRate(n.rate) : undefined
+          );
         }
       }
     };
     walk(data);
+
+    // Pass 2: seed EVERY node's subtree-aggregate rate onto model.agg, not just
+    // publisher leaves. The List bumps ancestors too, so each node's rate field
+    // is already its subtree aggregate; without this, interior non-publisher
+    // nodes keep agg score 0 and the default "Busiest first" sort ranks
+    // collapsed namespaces last for ~1 tau after a List -> Graph toggle.
+    const walkAgg = (d: MqttData) => {
+      for (const key of Object.keys(d)) {
+        const n = d[key];
+        if (n.rate) model.seedAggRate(n.topic, scaleRate(n.rate));
+        walkAgg(n.children);
+      }
+    };
+    walkAgg(data);
   };
 
   const applyTheme = (t: "dark" | "light") => {
@@ -390,7 +420,11 @@
     });
   });
   // Push local edits back out so the List picks them up on the return toggle.
-  $: if (searchStore) searchStore.setSearchText(filterText);
+  // Guarded symmetrically with the subscribe above: only push when the value
+  // genuinely originated here, else a store-driven filterText change would
+  // bounce straight back into the store.
+  $: if (searchStore && get(searchStore).text !== filterText)
+    searchStore.setSearchText(filterText);
 
   onMount(async () => {
     loadSettings();
@@ -436,6 +470,7 @@
     );
 
     let liveTick = 0;
+    let lastTickIngest = 0;
     liveTimer = window.setInterval(() => {
       if (!renderer) return;
       renderer.notifyData();
@@ -444,19 +479,20 @@
       // visual reconciliation) is too expensive to run every 1.2s tick, so it
       // only runs every 4th tick (~5s) once the tree crosses 2000 topics.
       const dueThisTick = model.topicCount <= 2000 || liveTick % 4 === 0;
-      // rate/recency/stale/msgs all drift with incoming data WITHOUT any
-      // structural change, so their sibling order goes stale between arrivals
-      // and needs the periodic relayout to track the List. alpha/count don't:
-      // alpha never reorders existing nodes, and topic-count changes bump
-      // structureGen -> visibleDirty -> notifyData relayouts on their own.
-      if (
-        !paused &&
-        dueThisTick &&
-        (sortKey === "rate" ||
-          sortKey === "recency" ||
-          sortKey === "stale" ||
-          sortKey === "msgs")
-      ) {
+      // rate/recency drift continuously between arrivals via decay-driven node
+      // sizing, so their sibling order always needs the periodic relayout to
+      // track the List. stale/msgs only change when a message actually arrives,
+      // so skip their relayout on idle ticks (no batch since the last tick).
+      // alpha/count don't drift at all: alpha never reorders existing nodes, and
+      // topic-count changes bump structureGen -> visibleDirty -> notifyData
+      // relayouts on their own.
+      const ingestedSinceLastTick = ingestCounter !== lastTickIngest;
+      lastTickIngest = ingestCounter;
+      const needsRelayout =
+        sortKey === "rate" ||
+        sortKey === "recency" ||
+        ((sortKey === "stale" || sortKey === "msgs") && ingestedSinceLastTick);
+      if (!paused && dueThisTick && needsRelayout) {
         renderer.relayout();
       }
       // keep the hover inspector's numbers live while the pointer rests

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/cooldown.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/cooldown.ts
@@ -90,36 +90,17 @@ export function tintForAge(
 }
 
 // ---- EWMA decaying-score rate estimator ----
-// score ~= exponentially-weighted recent event count. decayScore() ages it to
-// `now`; bump it by 1 on each message. rate magnitude is read off the score.
+// The pure engine now lives in `@/util/decay-score` so the topic List can share
+// it without a list->graph import. Re-exported here so this module's existing
+// consumers (topic-model, pixi-graph, MqttGraphView) keep importing unchanged.
 
-export type DecayScore = { score: number; lastMs: number };
-
-export function decayScore(s: DecayScore, nowMs: number, tauMs: number): number {
-  if (s.lastMs === 0) {
-    s.lastMs = nowMs;
-    return s.score;
-  }
-  const dt = nowMs - s.lastMs;
-  if (dt > 0) {
-    s.score *= Math.exp(-dt / tauMs);
-    s.lastMs = nowMs;
-  }
-  return s.score;
-}
-
-export function bumpScore(s: DecayScore, nowMs: number, tauMs: number): void {
-  decayScore(s, nowMs, tauMs);
-  s.score += 1;
-}
-
-// Convert a decayed score to an approximate message rate in msg/s. At steady
-// state the accumulator converges to rate x tau, so score / tau recovers the
-// real unit — comparable across smoothing (tau) settings, unlike the raw score.
-export function rateFromScore(score: number, tauMs: number): number {
-  if (tauMs <= 0) return 0;
-  return score / (tauMs / 1000);
-}
+export {
+  decayScore,
+  peekScore,
+  bumpScore,
+  rateFromScore,
+} from "@/util/decay-score";
+export type { DecayScore } from "@/util/decay-score";
 
 // Human-friendly msg/s label for tooltips/legends.
 export function formatRate(msgPerSec: number): string {

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "vitest";
-import { layoutTopicTree } from "./tidy-layout";
+import { coerceSortKey, layoutTopicTree } from "./tidy-layout";
 import { TopicModel } from "./topic-model";
 
 const baseOpts = { rowH: 34, colW: 240, nowMs: 10000 };
+const T = 1_700_000_000_000; // realistic epoch-ms base for test timestamps
 
 test("rate-sorted layout does not mutate node.agg decay state", () => {
   const model = new TopicModel(14000);
@@ -38,13 +39,77 @@ test("rate sort still orders busier topics first, matching decayed score order",
 
 test("repeated layout calls at the same nowMs are idempotent for rate sort", () => {
   const model = new TopicModel(14000);
-  model.ingest("a", 0);
-  model.ingest("b", 0);
-  model.ingest("b", 0);
+  model.ingest("a", T);
+  model.ingest("b", T);
+  model.ingest("b", T);
 
-  const first = layoutTopicTree(model, { ...baseOpts, sortKey: "rate" });
-  const second = layoutTopicTree(model, { ...baseOpts, sortKey: "rate" });
+  const first = layoutTopicTree(model, { ...baseOpts, nowMs: T, sortKey: "rate" });
+  const second = layoutTopicTree(model, { ...baseOpts, nowMs: T, sortKey: "rate" });
   expect(second.nodes.map((n) => n.node.topic)).toEqual(
     first.nodes.map((n) => n.node.topic)
   );
+});
+
+test("msgs sort orders topics by descending subtree message count", () => {
+  const model = new TopicModel(14000);
+  model.ingest("a", T); // aggCount 1
+  model.ingest("b", T);
+  model.ingest("b", T);
+  model.ingest("b", T); // aggCount 3
+  model.ingest("c", T);
+  model.ingest("c", T); // aggCount 2
+
+  const res = layoutTopicTree(model, { ...baseOpts, nowMs: T, sortKey: "msgs" });
+  const order = res.nodes
+    .filter((pn) => pn.node.depth === 0)
+    .sort((x, y) => x.y - y.y)
+    .map((pn) => pn.node.name);
+  expect(order).toEqual(["b", "c", "a"]);
+});
+
+test("wildcard filter keeps the matching branch and prunes non-matching siblings", () => {
+  const model = new TopicModel(14000);
+  model.ingest("factory/line1/temp", T);
+  model.ingest("factory/line1/humidity", T);
+  model.ingest("factory/line2/temp", T);
+  model.ingest("warehouse/line1/temp", T);
+
+  const res = layoutTopicTree(model, {
+    ...baseOpts,
+    nowMs: T,
+    sortKey: "alpha",
+    filter: "factory/+/temp",
+  });
+  const topics = new Set(res.nodes.map((pn) => pn.node.topic));
+
+  // matching leaves kept
+  expect(topics.has("factory/line1/temp")).toBe(true);
+  expect(topics.has("factory/line2/temp")).toBe(true);
+  // interior nodes kept via a matching descendant, even though the interior
+  // path itself does NOT wildcard-match "factory/+/temp" (A5: intermediate
+  // node retained by the keep-set, not by matching the pattern directly)
+  expect(topics.has("factory")).toBe(true);
+  expect(topics.has("factory/line1")).toBe(true);
+  expect(topics.has("factory/line2")).toBe(true);
+  // sibling leaf that doesn't match the pattern is pruned
+  expect(topics.has("factory/line1/humidity")).toBe(false);
+  // unrelated top-level branch pruned entirely
+  expect(topics.has("warehouse")).toBe(false);
+  expect(topics.has("warehouse/line1/temp")).toBe(false);
+});
+
+test("coerceSortKey falls back to rate for legacy-missing and garbage values", () => {
+  // legacy settings blob predates sortKey persistence -> s.sortKey undefined
+  expect(coerceSortKey(undefined)).toBe("rate");
+  // corrupt / unknown strings and non-strings never reach the comparators
+  expect(coerceSortKey("bogus")).toBe("rate");
+  expect(coerceSortKey(42)).toBe("rate");
+  expect(coerceSortKey(null)).toBe("rate");
+  // every valid key passes through unchanged
+  expect(coerceSortKey("rate")).toBe("rate");
+  expect(coerceSortKey("msgs")).toBe("msgs");
+  expect(coerceSortKey("recency")).toBe("recency");
+  expect(coerceSortKey("stale")).toBe("stale");
+  expect(coerceSortKey("alpha")).toBe("alpha");
+  expect(coerceSortKey("count")).toBe("count");
 });

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.test.ts
@@ -67,6 +67,22 @@ test("msgs sort orders topics by descending subtree message count", () => {
   expect(order).toEqual(["b", "c", "a"]);
 });
 
+test("equal-rate siblings are ordered alphabetically (deterministic tie-break)", () => {
+  const model = new TopicModel(14000);
+  // three siblings that all published exactly once at the same instant: equal
+  // decayed rate, so the tie-break by name (A -> Z) must decide the order
+  model.ingest("charlie", T);
+  model.ingest("alpha", T);
+  model.ingest("bravo", T);
+
+  const res = layoutTopicTree(model, { ...baseOpts, nowMs: T, sortKey: "rate" });
+  const order = res.nodes
+    .filter((pn) => pn.node.depth === 0)
+    .sort((x, y) => x.y - y.y)
+    .map((pn) => pn.node.name);
+  expect(order).toEqual(["alpha", "bravo", "charlie"]);
+});
+
 test("wildcard filter keeps the matching branch and prunes non-matching siblings", () => {
   const model = new TopicModel(14000);
   model.ingest("factory/line1/temp", T);

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.ts
@@ -3,9 +3,35 @@
 // See docs/topic-graph-view-spec.md §3.
 
 import { hierarchy, tree, type HierarchyPointNode } from "d3-hierarchy";
+import { topicMatchesQuery } from "@/util/topic-filter";
 import { TopicModel, TopicNode } from "./topic-model";
 
-export type SortKey = "rate" | "recency" | "stale" | "alpha" | "count";
+export type SortKey =
+  | "rate"
+  | "msgs"
+  | "recency"
+  | "stale"
+  | "alpha"
+  | "count";
+
+export const SORT_KEYS: readonly SortKey[] = [
+  "rate",
+  "msgs",
+  "recency",
+  "stale",
+  "alpha",
+  "count",
+];
+
+// Coerce a persisted/untrusted value to a valid SortKey, falling back to the
+// default "rate". Guards the localStorage settings blob: an older build wrote
+// no sortKey (undefined), and a corrupt or newer blob could carry a string
+// this build doesn't know — neither may reach the sort comparators.
+export function coerceSortKey(v: unknown): SortKey {
+  return typeof v === "string" && (SORT_KEYS as readonly string[]).includes(v)
+    ? (v as SortKey)
+    : "rate";
+}
 
 export interface LayoutOptions {
   rowH: number;
@@ -37,8 +63,11 @@ export interface LayoutResult {
   height: number;
 }
 
+// Filter match, shared with the List view: case-insensitive substring on the
+// full topic path OR (when the query is a valid MQTT filter) an MQTT wildcard
+// match. No payload haystack — the graph model stores no payloads.
 function matches(node: TopicNode, q: string): boolean {
-  return node.topic.toLowerCase().includes(q);
+  return topicMatchesQuery(node.topic, q);
 }
 
 // returns true if node or any descendant matches the query
@@ -68,6 +97,9 @@ export function layoutTopicTree(model: TopicModel, opts: LayoutOptions): LayoutR
         // real elapsed-time decay). peekAggScore computes the same decayed
         // value without writing it back.
         return -model.peekAggScore(n, nowMs);
+      case "msgs":
+        // most-messages-first: subtree-cumulative message count
+        return -n.aggCount;
       case "recency":
         return -n.aggLastMsg;
       case "stale":

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/tidy-layout.ts
@@ -127,7 +127,10 @@ export function layoutTopicTree(model: TopicModel, opts: LayoutOptions): LayoutR
       if (typeof a.key === "string" || typeof b.key === "string") {
         return String(a.key).localeCompare(String(b.key));
       }
-      return (a.key as number) - (b.key as number);
+      // Equal numeric keys tie-break by name (A -> Z) so sibling order is
+      // deterministic instead of dependent on Map insertion order.
+      const d = (a.key as number) - (b.key as number);
+      return d !== 0 ? d : a.node.name.localeCompare(b.node.name);
     });
     return decorated.map((d) => d.node);
   };

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.test.ts
@@ -176,6 +176,62 @@ test("seedTopic copies the List rate into agg and own for a leaf, by value", () 
   expect(leaf.own.score).toBe(4.2);
 });
 
+test("seedAggRate seeds an interior non-publisher node's subtree agg score from the List aggregate", () => {
+  const model = new TopicModel(14000);
+  // Only the leaves publish; factory/line1 is structural. After seedTopic its
+  // agg RATE score is still 0 (seedTopic only sets the exact publisher's score).
+  model.seedTopic("factory/line1/temp", 3, SEED_T);
+  model.seedTopic("factory/line1/hum", 2, SEED_T);
+  const line1 = model.root.children.get("factory")!.children.get("line1")!;
+  expect(line1.agg.score).toBe(0);
+
+  // The List carries a per-level aggregate rate for factory/line1 (its subtree
+  // total). seedAggRate transplants it so the collapsed namespace ranks by
+  // "Busiest" from the instant of the toggle.
+  model.seedAggRate("factory/line1", { score: 7.5, lastMs: SEED_T });
+  expect(line1.agg.score).toBe(7.5);
+  expect(line1.agg.lastMs).toBe(SEED_T);
+  // the root-side interior node too
+  const factory = model.root.children.get("factory")!;
+  model.seedAggRate("factory", { score: 9.25, lastMs: SEED_T });
+  expect(factory.agg.score).toBe(9.25);
+});
+
+test("seedAggRate copies by value and is a no-op on a missing path", () => {
+  const model = new TopicModel(14000);
+  model.seedTopic("a/b", 1, SEED_T);
+  const b = model.root.children.get("a")!.children.get("b")!;
+
+  const rate = { score: 4, lastMs: SEED_T };
+  model.seedAggRate("a/b", rate);
+  rate.score = 999; // the List keeps mutating its own object
+  expect(b.agg.score).toBe(4);
+
+  // a path segment that was never created: silent no-op, no node materialised
+  expect(() =>
+    model.seedAggRate("a/x/y", { score: 5, lastMs: SEED_T })
+  ).not.toThrow();
+  expect(model.root.children.get("a")!.children.has("x")).toBe(false);
+});
+
+test("tau scaling: the caller doubles the seeded score when graph tau is 2x list tau", () => {
+  // The scaling lives at the seed() call site in MqttGraphView (score = rate x
+  // tau, so a score accumulated at LIST tau must be scaled by tauGraph/tauList
+  // before it is transplanted). This asserts the model stores exactly the
+  // scaled value the caller hands it.
+  const listTau = 14000;
+  const graphTau = 28000;
+  const model = new TopicModel(graphTau);
+  model.seedTopic("a/b", 1, SEED_T);
+  const listRate = { score: 3, lastMs: SEED_T };
+  model.seedAggRate("a", {
+    score: listRate.score * (graphTau / listTau),
+    lastMs: listRate.lastMs,
+  });
+  const a = model.root.children.get("a")!;
+  expect(a.agg.score).toBe(6); // 3 x (28000 / 14000)
+});
+
 test("seedTopic does not copy the subtree rate into own for a non-leaf publisher", () => {
   const model = new TopicModel(14000);
   // seed the child first so the parent is a non-leaf when it is seeded

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.test.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.test.ts
@@ -111,3 +111,83 @@ test("clear resets nodeCount and marks visibleDirty", () => {
   expect(model.topicCount).toBe(0);
   expect(model.visibleDirty).toBe(true);
 });
+
+const SEED_T = 1_700_000_000_000; // realistic epoch-ms base for seed timestamps
+
+test("seedTopic makes aggCount equal the List's cumulative messageCount at every level", () => {
+  const model = new TopicModel(14000);
+  // Mirrors a MqttData snapshot (subtree-cumulative messageCount):
+  //   factory                 messageCount 6 (structural)
+  //     factory/line1         messageCount 5 (structural)
+  //       factory/line1/temp  messageCount 3  own 3
+  //       factory/line1/hum   messageCount 2  own 2
+  //     factory/line2/temp    messageCount 1  own 1
+  model.seedTopic("factory/line1/temp", 3, SEED_T);
+  model.seedTopic("factory/line1/hum", 2, SEED_T);
+  model.seedTopic("factory/line2/temp", 1, SEED_T);
+
+  const factory = model.root.children.get("factory")!;
+  const line1 = factory.children.get("line1")!;
+  const temp1 = line1.children.get("temp")!;
+  const hum = line1.children.get("hum")!;
+  const line2 = factory.children.get("line2")!;
+  const temp2 = line2.children.get("temp")!;
+
+  // aggCount at every level equals that node's cumulative messageCount
+  expect(temp1.aggCount).toBe(3);
+  expect(hum.aggCount).toBe(2);
+  expect(line1.aggCount).toBe(5);
+  expect(temp2.aggCount).toBe(1);
+  expect(line2.aggCount).toBe(1);
+  expect(factory.aggCount).toBe(6);
+  // own count lands only on the exact publisher leaves
+  expect(temp1.ownCount).toBe(3);
+  expect(line1.ownCount).toBe(0);
+  expect(factory.ownCount).toBe(0);
+  // recency propagates to interior ancestors for stale/newest sorts
+  expect(factory.aggLastMsg).toBe(SEED_T);
+  expect(line1.aggLastMsg).toBe(SEED_T);
+});
+
+test("seedTopic without a rate seeds score 0 (no phantom bump) with the real lastMs", () => {
+  const model = new TopicModel(14000);
+  model.seedTopic("idle/topic", 1, SEED_T); // no rate supplied
+  const leaf = model.root.children.get("idle")!.children.get("topic")!;
+  // ingest() would leave score 1 here; seedTopic must add NO phantom bump so an
+  // hour-idle topic doesn't seed hot
+  expect(leaf.agg.score).toBe(0);
+  expect(leaf.own.score).toBe(0);
+  // ...but the real last-message time is preserved, not the uninitialised 0
+  expect(leaf.agg.lastMs).toBe(SEED_T);
+  expect(leaf.own.lastMs).toBe(SEED_T);
+  expect(leaf.aggLastMsg).toBe(SEED_T);
+});
+
+test("seedTopic copies the List rate into agg and own for a leaf, by value", () => {
+  const model = new TopicModel(14000);
+  const rate = { score: 4.2, lastMs: SEED_T };
+  model.seedTopic("sensor/temp", 5, SEED_T, rate);
+  const leaf = model.root.children.get("sensor")!.children.get("temp")!;
+  expect(leaf.agg.score).toBe(4.2);
+  expect(leaf.own.score).toBe(4.2);
+  // copied by value: the List keeps mutating its own DecayScore object
+  rate.score = 999;
+  expect(leaf.agg.score).toBe(4.2);
+  expect(leaf.own.score).toBe(4.2);
+});
+
+test("seedTopic does not copy the subtree rate into own for a non-leaf publisher", () => {
+  const model = new TopicModel(14000);
+  // seed the child first so the parent is a non-leaf when it is seeded
+  model.seedTopic("parent/child", 2, SEED_T, { score: 1, lastMs: SEED_T });
+  model.seedTopic("parent", 3, SEED_T, { score: 9, lastMs: SEED_T });
+  const parent = model.root.children.get("parent")!;
+  expect(parent.isLeaf).toBe(false);
+  // agg (the subtree aggregate) takes the copied rate; own is left at 0 for
+  // live traffic to fill, since the List rate is a subtree figure not own
+  expect(parent.agg.score).toBe(9);
+  expect(parent.own.score).toBe(0);
+  // counts stay exact regardless
+  expect(parent.ownCount).toBe(3);
+  expect(parent.aggCount).toBe(5); // 3 own + 2 from child
+});

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.ts
@@ -146,11 +146,13 @@ export class TopicModel {
   // aggLastMsg (subtree max) at every level for recency/stale sorts.
   //
   // `rate`, when the List supplied one, is that topic's decay score (already a
-  // subtree aggregate on the List side) copied verbatim into `agg` (and, for a
-  // leaf, `own`) so "Busiest" ordering survives the toggle. When absent the
-  // score seeds at 0 with the real lastMs — an hour-idle topic must not seed
-  // hot. Structural interior nodes get exact counts + recency here; their agg
-  // rate score reconverges within ~1 tau of live traffic.
+  // subtree aggregate on the List side, tau-scaled by the caller to the graph's
+  // tau) copied verbatim into `agg` (and, for a leaf, `own`) so "Busiest"
+  // ordering survives the toggle. When absent the score seeds at 0 with the real
+  // lastMs — an hour-idle topic must not seed hot. Structural interior nodes get
+  // exact counts + recency here; their agg rate score is seeded on every level
+  // by seedAggRate() from the List's per-level aggregates, so collapsed
+  // namespaces rank correctly from the instant of the toggle.
   seedTopic(
     topic: string,
     ownMsgs: number,
@@ -191,6 +193,23 @@ export class TopicModel {
       node.agg = { score: 0, lastMs };
       if (node.isLeaf) node.own = { score: 0, lastMs };
     }
+  }
+
+  // Seed the subtree-aggregate rate score on an already-existing node path from
+  // the List's per-level aggregate (taken on a List -> Graph toggle). The List
+  // bumps every ancestor, so each node's rate is already its subtree total; this
+  // transplants it onto `agg` at every level so collapsed namespaces rank by
+  // "Busiest" from the instant of the toggle, not ~1 tau later. Walks the path
+  // and bails silently if any segment is missing (the node must already exist,
+  // created by seedTopic). Copies by value — the List keeps mutating its own
+  // DecayScore object. The caller tau-scales `rate` to the graph's tau.
+  seedAggRate(topic: string, rate: DecayScore): void {
+    let node: TopicNode | undefined = this.root;
+    for (const seg of topic.split("/")) {
+      node = node.children.get(seg);
+      if (!node) return; // missing path: no-op
+    }
+    node.agg = { score: rate.score, lastMs: rate.lastMs };
   }
 
   // current subtree rate-score, decayed to now

--- a/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.ts
+++ b/frontend/src/views/Connection/DataView/components/MqttGraphView/topic-model.ts
@@ -134,6 +134,65 @@ export class TopicModel {
     node.ownCount++;
   }
 
+  // Seed one already-observed publisher topic from a List snapshot (taken on a
+  // List -> Graph view toggle) WITHOUT replaying phantom traffic. Unlike
+  // ingest(), this adds no EWMA bump: it transplants the state the List already
+  // computed so the two views agree the instant you switch.
+  //
+  // `ownMsgs` is this exact topic's own message count (List messageCount minus
+  // the direct children's). It is added to aggCount on every node along the
+  // path, so each level's aggCount ends equal to the List's subtree-cumulative
+  // messageCount. `lastMs` is the topic's latest-message time, folded into
+  // aggLastMsg (subtree max) at every level for recency/stale sorts.
+  //
+  // `rate`, when the List supplied one, is that topic's decay score (already a
+  // subtree aggregate on the List side) copied verbatim into `agg` (and, for a
+  // leaf, `own`) so "Busiest" ordering survives the toggle. When absent the
+  // score seeds at 0 with the real lastMs — an hour-idle topic must not seed
+  // hot. Structural interior nodes get exact counts + recency here; their agg
+  // rate score reconverges within ~1 tau of live traffic.
+  seedTopic(
+    topic: string,
+    ownMsgs: number,
+    lastMs: number,
+    rate?: DecayScore
+  ): void {
+    const levels = topic.split("/");
+    let node = this.root;
+    for (let i = 0; i < levels.length; i++) {
+      const seg = levels[i];
+      let child = node.children.get(seg);
+      if (!child) {
+        const full = levels.slice(0, i + 1).join("/");
+        child = new TopicNode(seg, full, i, node);
+        child.expanded = i < this.autoExpandDepth;
+        node.children.set(seg, child);
+        this.nodeCount++;
+        for (let p = node; p && p !== this.root; p = p.parent!) p.descendantCount++;
+        if (this.isVisibleInTree(child)) {
+          this.visibleDirty = true;
+          this.structureGen++;
+        }
+      }
+      node = child;
+      // subtree aggregate COUNT + recency accumulate on every level so the
+      // final aggCount matches the List's cumulative messageCount exactly
+      node.aggCount += ownMsgs;
+      if (lastMs > node.aggLastMsg) node.aggLastMsg = lastMs;
+    }
+    // `node` is now the exact topic: seed its own counters and rate score.
+    node.ownCount += ownMsgs;
+    if (lastMs > node.ownLastMsg) node.ownLastMsg = lastMs;
+    if (rate) {
+      // copy by value — the List keeps mutating its own DecayScore object
+      node.agg = { score: rate.score, lastMs: rate.lastMs };
+      if (node.isLeaf) node.own = { score: rate.score, lastMs: rate.lastMs };
+    } else {
+      node.agg = { score: 0, lastMs };
+      if (node.isLeaf) node.own = { score: 0, lastMs };
+    }
+  }
+
   // current subtree rate-score, decayed to now
   aggScore(node: TopicNode, nowMs: number): number {
     return decayScore(node.agg, nowMs, this.tauMs);


### PR DESCRIPTION
Stacked on #76 (topic graph view). Unifies how the List and Graph views order and filter topics, so e.g. **busiest-first is now available in the list too** — without flattening the two views into sameness where their semantics genuinely differ.

## Ordering

Both views now offer the same core sort vocabulary, with matching labels:

| Label | List | Graph | Key |
| --- | --- | --- | --- |
| Busiest first | new | existing (default) | EWMA rate, subtree aggregate |
| Most messages | new | new | cumulative message count |
| Newest first | existing | renamed from "Recent first" | latest activity |
| Silent first | renamed from "Oldest first" | existing | least recent activity |
| Topic A → Z | existing | renamed from "Name" | per-level segment sort |
| Topic Z → A | list-only | — | direction pair |
| Topic count | — | graph-only | structural sort |

- The list's "Busiest" uses the **same EWMA engine** as the graph: the pure decay-score module moved out of the graph into `util/decay-score.ts` (graph re-exports unchanged); `MqttData` nodes carry an optional `rate` score bumped per batch on the node and every ancestor, tau fixed at the graph's 14s default.
- No re-sort ticker in the list: uniform exponential decay preserves sibling rank between arrivals, so re-sorting on data change (which already happens) is provably sufficient.
- Equal values tie-break alphabetically in both views.
- Graph sort choice is now **persisted per connection** (localStorage settings blob, validated on load); list sort persistence is unchanged (global `SortState` row — deliberately not rescoped, see below).

## Filtering

- Shared matcher in `util/topic-filter.ts`: case-insensitive substring OR MQTT wildcard (`+`/`#`) when the query validates as a topic filter. The list re-uses it (behaviour unchanged); **the graph gains wildcard support** it lacked.
- **Filter text survives the List ⇄ Graph toggle** both ways: the graph binds the list's search store (with debounce flush on toggle so half-typed queries aren't lost).
- Payload-content search stays list-only on purpose: the graph model stores no payloads (memory budget at 2×2000 msg/s), and the two placeholders signpost the difference.

## Cross-view consistency on toggle

`seed()` previously replayed one phantom message per topic, so after a List → Graph toggle the graph's message counts were ~topic counts and "Busiest" ranked collapsed namespaces last for ~14s. Seeding now transplants the list's exact counts, recency, and tau-scaled rate aggregates at every level (`TopicModel.seedTopic` + `seedAggRate`), so both views agree the moment you switch.

## Deliberate divergences (not blind matching)

- List persists sort globally (existing behaviour), graph per connection — rescoping either changes existing UX beyond this PR's ask; flagged for a future product call.
- No pause control in the list: "Newest first" already reorders live and the virtual list keeps it usable; the graph keeps its pause because nodes move spatially.
- "Topic count" stays graph-only (structural view), "Topic Z → A" stays list-only.

## Review + verification

- Design was adversarially reviewed before implementation; the implementation then went through a multi-angle review pass which produced the two fix commits (ancestor rate seeding, msgs key rename, tie-breaks, sync guards, arrival-gated relayouts, debounce flush) and two follow-up gate corrections.
- `pnpm check` 0 errors, 268 unit tests, `pnpm build`, `ds:validate`, 134 storybook tests, `go build`/`vet`/`go test ./...` all green.
- Graph perf harness (`perf:graph`, ~2400 nodes): 0.74ms avg frame vs 0.75ms on the base branch — no regression (both read above the committed 0.6ms baseline equally; environmental).
- List sort cost at flood scale (2610 nodes fully expanded, benchmarked): rate sort 0.68ms per full rebuild vs 0.37ms for the existing time sort — negligible against the ~300ms batch cadence.
- Not verified live: a full two-broker 2000 msg/s native-app session. This branch predates #123's served-over-HTTP mode, so the running app couldn't be driven from the harness browser; the flood setup is scripted and ready if you want to eyeball it before merge.

Changelog section included. Note #76 itself still has no changelog section for the graph view — worth adding there before either merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
