### PR TITLE
fix: space disk budget label clear of the record-to-disk toggle

### DIFF
--- a/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
+++ b/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
@@ -123,7 +123,7 @@
         />
       </div>
 
-      <div class="flex flex-col gap-1">
+      <div class="flex flex-col gap-1 mt-3">
         <BaseNumberInput
           name="prompt-disk-budget"
           label="Disk budget (GB)"


### PR DESCRIPTION
## Problem

In the message history retention prompt, the "Disk budget (GB)" label was crammed right under the "Record history to disk" toggle, while the memory-budget spacing above the toggle looked fine.

## Cause

`BaseNumberInput`'s label is absolutely positioned as a floating label ~14px above its input box. The disk block sat `gap-4` (16px) below the Switch, so the floating label consumed nearly all of that gap, leaving ~2px of visual breathing room. The memory→toggle gap looked right because the Switch has no floating label above it.

## Fix

Add `mt-3` to the disk-budget block so its floating label clears the toggle. Measured in Storybook: toggle→disk-label gap is now 14px, matching the 16px memory-input→toggle gap.

Before: label ~2px under the toggle. After: balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)