### PR TITLE
fix(mqtt): stop the buffer handler without racing its ticker

### DIFF
--- a/backend/mqtt/buffer.go
+++ b/backend/mqtt/buffer.go
@@ -6,8 +6,12 @@ import (
 )
 
 type MessageBuffer struct {
-	mu           *sync.Mutex
-	buffer       []MqttMessage
+	mu     *sync.Mutex
+	buffer []MqttMessage
+
+	// handleMu guards the two lifecycle fields below. The handler goroutine
+	// never reads them; it works off locals captured at start.
+	handleMu     sync.Mutex
 	handleTicker *time.Ticker
 	handleChan   chan bool
 }
@@ -20,15 +24,25 @@ func newMessageBuffer() *MessageBuffer {
 }
 
 func (mb *MessageBuffer) StartHandlingBuffer(handleInterval time.Duration, cb func(messages []MqttMessage)) {
-	mb.handleTicker = time.NewTicker(handleInterval)
-	mb.handleChan = make(chan bool)
+	mb.handleMu.Lock()
+	defer mb.handleMu.Unlock()
+
+	if mb.handleChan != nil {
+		// Already running; callers stop before restarting.
+		return
+	}
+
+	ticker := time.NewTicker(handleInterval)
+	done := make(chan bool)
+	mb.handleTicker = ticker
+	mb.handleChan = done
 
 	go func() {
 		for {
 			select {
-			case <-mb.handleChan:
+			case <-done:
 				return
-			case <-mb.handleTicker.C:
+			case <-ticker.C:
 				mb.useBufferContents(cb)
 			}
 		}
@@ -36,14 +50,19 @@ func (mb *MessageBuffer) StartHandlingBuffer(handleInterval time.Duration, cb fu
 }
 
 func (mb *MessageBuffer) StopHandlingBuffer() {
-	if mb.handleTicker != nil {
-		mb.handleTicker.Stop()
-		mb.handleTicker = nil
+	mb.handleMu.Lock()
+	defer mb.handleMu.Unlock()
+
+	if mb.handleChan == nil {
+		return
 	}
-	if mb.handleChan != nil {
-		mb.handleChan <- true
-		mb.handleChan = nil
-	}
+
+	// The unbuffered send blocks until the handler goroutine takes it, so the
+	// goroutine is guaranteed out of its select before the fields are cleared.
+	mb.handleChan <- true
+	mb.handleTicker.Stop()
+	mb.handleTicker = nil
+	mb.handleChan = nil
 }
 
 func (mb *MessageBuffer) useBufferContents(useContentsFunc func(messages []MqttMessage)) {

--- a/backend/mqtt/buffer_test.go
+++ b/backend/mqtt/buffer_test.go
@@ -1,0 +1,65 @@
+package mqtt
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression test for a crash on disconnect under load: StopHandlingBuffer
+// used to nil handleTicker while the handler goroutine re-read the field in
+// its select, dereferencing a nil ticker. Run with -race to catch the field
+// race even on runs where the nil dereference itself doesn't fire.
+func TestStopHandlingBufferWhileHandlerBusy(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		mb := newMessageBuffer()
+		mb.StartHandlingBuffer(time.Microsecond, func(messages []MqttMessage) {})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				mb.addMessageToBuffer(MqttMessage{})
+			}
+		}()
+
+		mb.StopHandlingBuffer()
+		wg.Wait()
+	}
+}
+
+func TestStopHandlingBufferIsIdempotent(t *testing.T) {
+	mb := newMessageBuffer()
+	mb.StartHandlingBuffer(time.Millisecond, func(messages []MqttMessage) {})
+	mb.StopHandlingBuffer()
+	mb.StopHandlingBuffer()
+}
+
+func TestNoHandleAfterStop(t *testing.T) {
+	mb := newMessageBuffer()
+	var mu sync.Mutex
+	calls := 0
+	mb.StartHandlingBuffer(100*time.Microsecond, func(messages []MqttMessage) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	})
+	mb.addMessageToBuffer(MqttMessage{})
+	time.Sleep(2 * time.Millisecond)
+	mb.StopHandlingBuffer()
+
+	mu.Lock()
+	after := calls
+	mu.Unlock()
+
+	mb.addMessageToBuffer(MqttMessage{})
+	time.Sleep(2 * time.Millisecond)
+
+	mu.Lock()
+	final := calls
+	mu.Unlock()
+	if final != after {
+		t.Fatalf("handler ran after StopHandlingBuffer: %d calls before, %d after", after, final)
+	}
+}

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -153,6 +153,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Updates that match your install",
         body: "The updater now detects how the app was installed: in-app updates on macOS, Windows and portable Linux, and the right instructions for Flatpak, AppImage, deb and rpm.",
       },
+      {
+        title: "Fixed a crash when disconnecting from a busy broker",
+        body: "Disconnecting while messages were still flooding in could take the whole app down. The message buffer's shutdown raced its own drain timer; it now stops cleanly no matter how busy the connection is.",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Disconnecting a connection while a broker floods ~2000 msg/s crashed the app with a SIGSEGV in the message buffer's handler goroutine (`StartHandlingBuffer.func1`, buffer.go:31).

Root cause: the handler goroutine re-read `mb.handleTicker.C` on every select iteration, while `StopHandlingBuffer` nilled that field before the goroutine had exited, so it dereferenced a nil ticker.

## Changes

- The handler goroutine now works entirely off locals (`ticker`, `done`) captured at start and never reads the struct fields.
- `StopHandlingBuffer` signals the goroutine first and only stops/clears the ticker after the unbuffered send returns, guaranteeing the goroutine is out of its select.
- Both lifecycle methods are guarded by a dedicated `handleMu` mutex (start/stop are driven from connect/disconnect event handlers and can race each other); stop is idempotent.
- Regression tests in `backend/mqtt/buffer_test.go`; changelog section added to the unreleased entry.

## Verification

- The new test run against the old code under `-race` reproduces the exact production panic (nil deref at buffer.go:31) plus a race-detector report.
- With the fix: `go test ./backend/mqtt/ -race -count=3` passes, full `go test ./...` green, `go build`/`go vet` clean, `pnpm check` 0 errors.
- Repro context: `scripts/mqtt-flood.py --rate 2000`, then disconnect from the UI.

The `SQLITE_BUSY` persist errors seen in the same log are a separate issue and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)