### PR TITLE
fix(connections): name the connection dropped by GetAllConnections

### DIFF
--- a/backend/app/connections.go
+++ b/backend/app/connections.go
@@ -29,7 +29,7 @@ func (a *App) GetAllConnections() Connections {
 	for id, appConn := range a.AppConnections {
 		connectionDetails := models.Connection{}
 		if res := a.Db.First(&connectionDetails, id); res.Error != nil {
-			slog.Error("Failed to get connection details", "error", res.Error)
+			slog.Error("failed to load connection details, skipping connection", "conn_id", id, "error", res.Error)
 			continue
 		}
 		result[id] = Connection{

--- a/backend/app/connections_test.go
+++ b/backend/app/connections_test.go
@@ -64,3 +64,74 @@ func TestNewConnectionHasCorrectSubs(t *testing.T) {
 		t.Errorf("Expected second subscription to be $SYS/#, got %v", newConnection.ConnectionDetails.Subscriptions[1].Topic)
 	}
 }
+
+// Locks in that a connection row with NULL optional columns is tolerated on
+// startup rather than being silently dropped from the connection list.
+func TestConnectionsWithNullColumnsLoadOnStartup(t *testing.T) {
+	app := getTestApp(t)
+	res := app.Db.Exec("INSERT INTO connections (name, mqtt_version, protocol, host, port, websocket_path) VALUES ('Raw insert', '5', 'mqtt', 'localhost', 1883, '')")
+	if res.Error != nil {
+		t.Fatalf("Expected no error inserting raw connection, got %v", res.Error)
+	}
+
+	app2 := reopenTestApp(t, app)
+	conns := app2.GetAllConnections()
+	if len(conns.Connections) != 1 {
+		t.Fatalf("Expected 1 connection, got %v", len(conns.Connections))
+	}
+	for _, conn := range conns.Connections {
+		if conn.ConnectionDetails.Name != "Raw insert" {
+			t.Errorf("Expected connection name to be Raw insert, got %v", conn.ConnectionDetails.Name)
+		}
+		if conn.ConnectionDetails.LastConnectedAt != nil {
+			t.Errorf("Expected LastConnectedAt to be nil, got %v", conn.ConnectionDetails.LastConnectedAt)
+		}
+		if conn.ConnectionDetails.CustomIconSeed != nil {
+			t.Errorf("Expected CustomIconSeed to be nil, got %v", *conn.ConnectionDetails.CustomIconSeed)
+		}
+	}
+}
+
+// Same as above but with every non-id column left NULL.
+func TestConnectionsWithAllNullColumnsLoadOnStartup(t *testing.T) {
+	app := getTestApp(t)
+	res := app.Db.Exec("INSERT INTO connections (id) VALUES (99)")
+	if res.Error != nil {
+		t.Fatalf("Expected no error inserting raw connection, got %v", res.Error)
+	}
+
+	app2 := reopenTestApp(t, app)
+	conns := app2.GetAllConnections()
+	if len(conns.Connections) != 1 {
+		t.Fatalf("Expected 1 connection, got %v", len(conns.Connections))
+	}
+	conn, ok := conns.Connections[99]
+	if !ok {
+		t.Fatalf("Expected connection with id 99, got %v", conns.Connections)
+	}
+	if conn.ConnectionDetails.ID != 99 {
+		t.Errorf("Expected connection id 99, got %v", conn.ConnectionDetails.ID)
+	}
+	if conn.ConnectionDetails.LastConnectedAt != nil {
+		t.Errorf("Expected LastConnectedAt to be nil, got %v", conn.ConnectionDetails.LastConnectedAt)
+	}
+	if conn.ConnectionDetails.CustomIconSeed != nil {
+		t.Errorf("Expected CustomIconSeed to be nil, got %v", *conn.ConnectionDetails.CustomIconSeed)
+	}
+}
+
+// Documents the intended behaviour: GetAllConnections is driven by the
+// in-memory AppConnections map built at startup, so rows written straight to
+// the database are not picked up until the app restarts.
+func TestGetAllConnectionsIgnoresRowsInsertedWithoutRestart(t *testing.T) {
+	app := getTestApp(t)
+	res := app.Db.Exec("INSERT INTO connections (name, mqtt_version, protocol, host, port, websocket_path) VALUES ('Raw insert', '5', 'mqtt', 'localhost', 1883, '')")
+	if res.Error != nil {
+		t.Fatalf("Expected no error inserting raw connection, got %v", res.Error)
+	}
+
+	conns := app.GetAllConnections()
+	if len(conns.Connections) != 0 {
+		t.Errorf("Expected 0 connections without a restart, got %v", len(conns.Connections))
+	}
+}


### PR DESCRIPTION
## What

A report from PR #125 testing claimed `GetAllConnections` silently skips connection rows with NULL `last_connected_at`/`custom_icon_seed`, via a swallowed GORM scan error. I could not reproduce that, and the diagnosis turned out to be wrong.

## What is actually going on

**NULL scanning is already tolerant.** `LastConnectedAt` is `*time.Time` and `CustomIconSeed` is `*string`, so NULLs scan cleanly. I went further and inserted a row with *every* non-id column NULL: it still loads, including NULL `created_at`/`updated_at` into the non-pointer `time.Time` fields, which glebarez/sqlite scans as the zero value. There is no scan error to swallow.

**The real reason a directly inserted row is invisible:** `GetAllConnections` iterates the in-memory `a.AppConnections` map, not the database. That map is built once by `buildAppConnections()` during `Startup`. A row inserted into SQLite while the app is running is not picked up until restart. The agent testing #125 inserted a row into a live dev DB, so it saw no effect. Restart and the row appears.

## What this changes

There is one genuine skip-and-log path: if the DB row backing an `AppConnection` cannot be read, the loop logs and continues, dropping that connection from the response. It did log, but without saying which connection, so the drop was undiagnosable. The log line now carries `conn_id` and states the connection is being skipped.

Plus three regression tests using the existing `getTestApp`/`reopenTestApp` helpers:

- `TestConnectionsWithNullColumnsLoadOnStartup` - raw insert with the named columns NULL, asserts the row loads with nil pointers
- `TestConnectionsWithAllNullColumnsLoadOnStartup` - every non-id column NULL, asserts it still loads
- `TestGetAllConnectionsIgnoresRowsInsertedWithoutRestart` - documents that direct DB writes stay invisible until restart

No changelog entry: neither change is user-facing.

## Known gap, not fixed here

The map-versus-DB divergence is one-directional and undetectable at runtime. If a connection row is deleted straight from the DB, its `AppConnection` and its MQTT manager stay alive in memory while vanishing from the UI. Same root asymmetry, but out of scope for this fix.

## Testing

`go build ./...`, `go vet ./...` clean. Full `go test ./backend/app/` passes, including the three new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)