### PR TITLE
chore(build): stub frontend/dist for Go-only commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,22 +36,25 @@ Backend (repo root):
 ```sh
 just dev                 # wails3 dev: run the app with hot reload
 just test                # go test ./... via tparse
+just stub-dist           # create the embedded frontend/dist stub
 just new-migration NAME  # atlas migrate diff --env gorm NAME
 go build ./... && go vet ./...
 ```
 
-On a fresh checkout or new worktree, `go build ./...` fails with
-`pattern all:frontend/dist: no matching files found`: main.go embeds the
-frontend build, which does not exist yet (`frontend/dist` is gitignored
-and vite empties it on every build, so a committed placeholder would not
-survive). Stub it once before building Go code:
+`just test` runs `stub-dist` first, so it works on a fresh tree. For a
+bare `go build ./...` or `go vet ./...`, run the stub once yourself:
 
 ```sh
-mkdir -p frontend/dist && [ -f frontend/dist/index.html ] || echo "<html></html>" > frontend/dist/index.html
+just stub-dist
 ```
 
-(the same stub `build/Taskfile.yml`'s `generate:bindings` task creates),
-or run a real `pnpm build` from `frontend/`.
+Without it those commands fail with `pattern all:frontend/dist: no
+matching files found`. main.go embeds the frontend build, which does not
+exist yet on a fresh checkout or new worktree (`frontend/dist` is
+gitignored and vite empties it on every build, so a committed
+placeholder would not survive). The recipe mirrors the stub
+`build/Taskfile.yml`'s `generate:bindings` task creates. A real
+`pnpm build` from `frontend/` satisfies the embed too.
 
 Dev-server ports are derived per checkout so parallel agent worktrees
 never collide. Once per checkout, run `scripts/dev-ports.sh write-launch`

--- a/justfile
+++ b/justfile
@@ -1,5 +1,13 @@
-test PATH='./...':
+test PATH='./...': stub-dist
   set -o pipefail && go test {{PATH}} fmt -json | tparse -all
+
+# main.go embeds frontend/dist, which is gitignored and so missing on a fresh
+# checkout - without it the root package fails to load and any ./... command
+# fails. Stub it so Go-only workflows work without a full frontend build.
+# Mirrors the stub in build/Taskfile.yml's generate:bindings task.
+stub-dist:
+  mkdir -p frontend/dist
+  [ -f frontend/dist/index.html ] || echo "<html></html>" > frontend/dist/index.html
 
 new-migration NAME:
   atlas migrate diff --env gorm {{NAME}}


### PR DESCRIPTION
## What

`just test` fails on a fresh checkout or new worktree, even though every package passes.

`main.go` embeds `all:frontend/dist`. That directory is gitignored, so it does not exist until something builds the frontend. Without it the root `mqtt-viewer` package fails to load:

```
main.go:15:12: pattern all:frontend/dist: no matching files found
FAIL	mqtt-viewer [setup failed]
```

`just test` defaults its PATH to `./...`, so it picks up the root package and exits 1. The tparse summary above the error is all green, which makes this easy to misread as a real test failure. It also hits bare `go build ./...` and `go vet ./...`.

CLAUDE.md documented a manual `mkdir -p frontend/dist && ...` workaround, and `build/Taskfile.yml`'s `generate:bindings` already does the same stub inline. This just makes the stub a recipe and wires it in.

## Changes

- New `stub-dist` recipe in the justfile, mirroring the existing stub in `build/Taskfile.yml`
- `test` now depends on `stub-dist`, so `just test` works on a fresh tree with no manual step
- CLAUDE.md points at `just stub-dist` instead of the manual command, keeping the explanation of why a committed placeholder would not survive (vite empties `dist` on every build)

`test` stays the first recipe in the file, so bare `just` still runs the tests.

## Why not commit a placeholder

`frontend/dist` is gitignored and vite empties it on every build, so a checked-in placeholder would be deleted by the first real `pnpm build`. A real `pnpm build` from `frontend/` also satisfies the embed, but requiring it for a Go-only change is heavy.

## Testing

From a fresh worktree of `develop` with `frontend/dist` removed:

- `rm -rf frontend/dist && just test` now exits 0, all packages pass, root package reports "no test files" instead of failing to load
- `rm -rf frontend/dist && just stub-dist && go build ./... && go vet ./...` both exit 0
- `just --list` parses, bare `just` still resolves to `test`

Not user-facing, so no changelog entry.

Note for reviewers: tparse prints a blank-name row with `FAIL 1` in its summary. There are zero `Action: "fail"` events in the raw `go test -json` stream. That row is tparse mis-attributing two `build-output` events carrying macOS `ld:` linker warnings, which have no `Package` field. Pre-existing noise, unrelated to this change, and `just test` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)