### PR TITLE
fix(mqtt): reconnect when a v5 broker goes silent

### DIFF
--- a/backend/mqtt/connect.go
+++ b/backend/mqtt/connect.go
@@ -198,6 +198,12 @@ func (mm *MqttManager) connectV5(ctx context.Context, connectionDetails MqttConn
 		cm.Disconnect(ctx)
 		return nil, nil
 	case <-time.After(CONNECTION_TIMEOUT):
+		// Shut the connection manager down. Left running it keeps retrying in
+		// the background forever, and can later report itself connected on a
+		// connection the caller has already given up on.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), CONNECTION_TIMEOUT)
+		defer cancel()
+		cm.Disconnect(shutdownCtx)
 		return nil, fmt.Errorf("timeout while connecting to broker")
 	}
 
@@ -268,6 +274,9 @@ func (mm *MqttManager) connectV3(ctx context.Context, connectionDetails MqttConn
 		client.Disconnect(500)
 		return nil, nil
 	case <-time.After(CONNECTION_TIMEOUT):
+		// Same as v5: auto-reconnect is on, so a client we walk away from
+		// keeps trying to connect in the background.
+		client.Disconnect(500)
 		return nil, fmt.Errorf("timeout while connecting to broker")
 	case err := <-subErrChan:
 		if err != nil {
@@ -276,6 +285,7 @@ func (mm *MqttManager) connectV3(ctx context.Context, connectionDetails MqttConn
 		}
 	}
 	if token.Error() != nil {
+		client.Disconnect(500)
 		return nil, token.Error()
 	}
 	return &client, nil

--- a/backend/mqtt/ping.go
+++ b/backend/mqtt/ping.go
@@ -31,13 +31,30 @@ type Pinger interface {
 	SetDebug(log.Logger)
 }
 
+var (
+	// How often to send a PINGREQ. The MQTT keepalive is a ceiling, not a
+	// target: pinging more often than that is legal and keeps the latency
+	// readout in the UI live. A PINGREQ is two bytes, so the cost is noise
+	// even against a broker flooding us.
+	PING_INTERVAL = 2 * time.Second
+	// How long to wait for the PINGRESP before treating the connection as
+	// dead. Without this the client sits in "connected" forever whenever a
+	// broker goes silent without closing the socket, and never reconnects.
+	// Matches the v3 client's PingTimeout.
+	PING_TIMEOUT = 10 * time.Second
+)
+
 type PingerV5 struct {
 	logCtx            context.Context
 	lastPacketSent    time.Time
 	lastPingSent      time.Time
 	lastPingResponse  time.Time
 	lastPingLatencyMs int32
+	pingOutstanding   bool
 	onNewLatencyMs    func(int32)
+
+	interval time.Duration
+	timeout  time.Duration
 
 	debug log.Logger
 
@@ -51,6 +68,8 @@ func newPingerV5(ctx context.Context, onNewLatencyMs func(int32)) *PingerV5 {
 		logCtx:         ctx,
 		debug:          log.NOOPLogger{},
 		onNewLatencyMs: onNewLatencyMs,
+		interval:       PING_INTERVAL,
+		timeout:        PING_TIMEOUT,
 	}
 }
 
@@ -69,15 +88,27 @@ func (p *PingerV5) Run(ctx context.Context, conn net.Conn, keepAlive uint16) err
 		return fmt.Errorf("Run() already in progress")
 	}
 	p.running = true
+	// The pinger instance outlives a single connection (autopaho builds a new
+	// paho client per reconnect but reuses this handler), so clear anything
+	// left over from the previous connection.
+	p.lastPingSent = time.Time{}
+	p.lastPingResponse = time.Time{}
+	p.pingOutstanding = false
 	p.mu.Unlock()
+
 	defer func() {
 		p.mu.Lock()
 		p.running = false
+		p.pingOutstanding = false
 		p.mu.Unlock()
 	}()
 
-	// interval := time.Duration(keepAlive) * time.Second
-	interval := time.Second * 2
+	interval := p.interval
+	// The keepalive the server agreed to is an upper bound on the gap between
+	// packets, so never ping less often than that.
+	if keepAliveInterval := time.Duration(keepAlive) * time.Second; keepAliveInterval < interval {
+		interval = keepAliveInterval
+	}
 	timer := time.NewTimer(0) // Immediately send first pingreq
 	for {
 		select {
@@ -86,22 +117,29 @@ func (p *PingerV5) Run(ctx context.Context, conn net.Conn, keepAlive uint16) err
 			return nil
 		case <-timer.C:
 			p.mu.Lock()
-			// Only send a ping if a ping has recently arrived, or it's been more than 5 seconds
-			// (it may have been missed)
-			since := time.Since(p.lastPingResponse)
-			if since < interval || since > time.Second*5 {
-				if since > time.Second*5 {
-					slog.WarnContext(p.logCtx, fmt.Sprintf("ping response handler waited longer than 5000ms, assuming no response"))
-				}
-				p.lastPingSent = time.Now() // set before sending because WriteTo may return after PINGRESP is handled
+			outstanding := p.pingOutstanding
+			if outstanding && time.Since(p.lastPingSent) > p.timeout {
+				p.mu.Unlock()
+				slog.WarnContext(p.logCtx, fmt.Sprintf("no PINGRESP after %s, treating connection as lost", p.timeout))
+				return fmt.Errorf("no PINGRESP received within %s", p.timeout)
+			}
+			if !outstanding {
+				// Set before sending: WriteTo may return after the PINGRESP
+				// has already been handled.
+				p.lastPingSent = time.Now()
+				p.pingOutstanding = true
+			}
+			p.mu.Unlock()
+
+			if !outstanding {
+				// Write outside the lock so a blocked socket cannot stall
+				// PacketSent and PingResp, which paho calls from its own loops.
 				if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(conn); err != nil {
-					slog.Error(fmt.Sprintf("ping packet write error: %v", err))
-					p.mu.Unlock()
+					slog.ErrorContext(p.logCtx, fmt.Sprintf("ping packet write error: %v", err))
 					return fmt.Errorf("failed to send PINGREQ: %w", err)
 				}
 			}
 			timer.Reset(interval)
-			p.mu.Unlock()
 		}
 	}
 }
@@ -114,11 +152,21 @@ func (p *PingerV5) PacketSent() {
 
 func (p *PingerV5) PingResp() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.lastPingResponse = time.Now()
-	p.lastPingLatencyMs = int32(p.lastPingResponse.UnixMilli()) - int32(p.lastPingSent.UnixMilli())
-	if p.onNewLatencyMs != nil {
-		p.onNewLatencyMs(p.lastPingLatencyMs)
+	p.pingOutstanding = false
+	if p.lastPingSent.IsZero() {
+		// A PINGRESP we did not ask for. Nothing to measure.
+		p.mu.Unlock()
+		return
+	}
+	p.lastPingLatencyMs = int32(p.lastPingResponse.Sub(p.lastPingSent).Milliseconds())
+	latency := p.lastPingLatencyMs
+	onNewLatencyMs := p.onNewLatencyMs
+	p.mu.Unlock()
+
+	// Called outside the lock: this runs into app code that emits events.
+	if onNewLatencyMs != nil {
+		onNewLatencyMs(latency)
 	}
 }
 

--- a/backend/mqtt/ping_test.go
+++ b/backend/mqtt/ping_test.go
@@ -1,0 +1,181 @@
+package mqtt
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// newTestPinger returns a pinger with short timings and a connection whose
+// server side is drained. Every PINGREQ read from the wire is signalled on the
+// returned channel.
+func newTestPinger(t *testing.T, onNewLatencyMs func(int32)) (*PingerV5, net.Conn, <-chan struct{}) {
+	t.Helper()
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		client.Close()
+		server.Close()
+	})
+
+	pings := make(chan struct{}, 32)
+	go func() {
+		buf := make([]byte, 16)
+		for {
+			n, err := server.Read(buf)
+			if err != nil {
+				return
+			}
+			for i := 0; i < n; i += 2 { // PINGREQ is two bytes
+				select {
+				case pings <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	p := newPingerV5(context.Background(), onNewLatencyMs)
+	p.interval = 20 * time.Millisecond
+	p.timeout = 200 * time.Millisecond
+	return p, client, pings
+}
+
+// A broker that goes silent without closing the socket must be reported as
+// dead, otherwise the client sits in "connected" forever and never reconnects.
+func TestPingerFailsWhenNoPingResp(t *testing.T) {
+	p, conn, pings := newTestPinger(t, nil)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- p.Run(context.Background(), conn, 30) }()
+
+	select {
+	case <-pings:
+	case <-time.After(time.Second):
+		t.Fatal("expected a PINGREQ to be sent")
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected Run to return an error when no PINGRESP arrives")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not report the connection as lost")
+	}
+}
+
+// While the broker answers, the pinger must keep running and only stop when
+// its context is cancelled.
+func TestPingerKeepsRunningWhilePingRespArrives(t *testing.T) {
+	var latencies []int32
+	latencyCh := make(chan int32, 32)
+	p, conn, pings := newTestPinger(t, func(ms int32) {
+		select {
+		case latencyCh <- ms:
+		default:
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- p.Run(ctx, conn, 30) }()
+
+	go func() {
+		for range pings {
+			p.PingResp()
+		}
+	}()
+
+	// Well past the timeout: with responses arriving the pinger must survive.
+	deadline := time.After(p.timeout * 5)
+	for {
+		select {
+		case err := <-errCh:
+			t.Fatalf("pinger stopped while the broker was answering: %v", err)
+		case ms := <-latencyCh:
+			latencies = append(latencies, ms)
+		case <-deadline:
+			if len(latencies) == 0 {
+				t.Fatal("expected at least one latency reading")
+			}
+			for _, ms := range latencies {
+				if ms < 0 || ms > 5000 {
+					t.Fatalf("implausible latency reading: %dms", ms)
+				}
+			}
+			cancel()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("expected nil error on context cancel, got %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Run did not return after context cancel")
+			}
+			return
+		}
+	}
+}
+
+// autopaho reuses one pinger across reconnects, so a run must not inherit the
+// previous connection's timestamps.
+func TestPingerResetsStateBetweenRuns(t *testing.T) {
+	p, conn, pings := newTestPinger(t, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- p.Run(ctx, conn, 30) }()
+	<-pings
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("expected nil error on context cancel, got %v", err)
+	}
+
+	// The first run left an unanswered ping behind. The second run must start
+	// clean and send a fresh PINGREQ rather than immediately timing out.
+	p2, conn2, pings2 := newTestPinger(t, nil)
+	p2.lastPingSent = p.lastPingSent
+	p2.pingOutstanding = true
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	errCh2 := make(chan error, 1)
+	go func() { errCh2 <- p2.Run(ctx2, conn2, 30) }()
+
+	select {
+	case <-pings2:
+	case err := <-errCh2:
+		t.Fatalf("second run failed instead of pinging: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("second run did not send a PINGREQ")
+	}
+}
+
+// A keepalive shorter than the ping interval is the ceiling on how long we may
+// stay quiet, so it must win.
+func TestPingerRespectsShortKeepAlive(t *testing.T) {
+	p, conn, pings := newTestPinger(t, nil)
+	p.interval = time.Hour
+	p.timeout = 5 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = p.Run(ctx, conn, 1) }()
+
+	answered := make(chan struct{}, 8)
+	go func() {
+		for range pings {
+			p.PingResp()
+			answered <- struct{}{}
+		}
+	}()
+
+	<-answered // first ping is immediate
+	select {
+	case <-answered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected the 1s keepalive to override the longer ping interval")
+	}
+}

--- a/backend/mqtt/reconnect_integration_test.go
+++ b/backend/mqtt/reconnect_integration_test.go
@@ -1,0 +1,151 @@
+package mqtt
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Reconnect tests against a broker this test starts and kills itself. Slow
+// (minutes) and needs docker, so gated behind an env var rather than run in
+// `just test`:
+//
+//	MQTT_RECONNECT_TEST=1 go test ./backend/mqtt -run TestReconnect -v -timeout 600s
+//
+// It uses its own container on its own port on purpose. scripts/test-broker.sh
+// binds 1883, and a mosquitto installed on the host binds the same port, so a
+// test that stops the container there can end up talking to the host broker
+// and silently prove nothing.
+const (
+	reconnectBrokerName = "mqtt-viewer-reconnect-test-broker"
+	reconnectBrokerPort = 18831
+)
+
+// The broker is killed in two ways because they fail differently:
+//
+//   - stop: the socket closes, so the client sees an immediate EOF.
+//   - pause: the container freezes with the socket still open. Nothing is
+//     returned and nothing is refused, so only the keepalive can notice. This
+//     is what a network blackhole, a sleeping laptop or a dropped VPN look
+//     like, and it is the case that used to leave the v5 client wedged in
+//     "connected" forever.
+func TestReconnectAfterBrokerStop(t *testing.T) {
+	testReconnect(t, "3", "stop", "start")
+	testReconnect(t, "5", "stop", "start")
+}
+
+func TestReconnectAfterBrokerGoesSilent(t *testing.T) {
+	testReconnect(t, "3", "pause", "unpause")
+	testReconnect(t, "5", "pause", "unpause")
+}
+
+func testReconnect(t *testing.T, mqttVersion, down, up string) {
+	t.Run(fmt.Sprintf("v%s/%s", mqttVersion, down), func(t *testing.T) {
+		requireReconnectTest(t)
+		startReconnectBroker(t)
+
+		start := time.Now()
+		logf := func(format string, args ...any) {
+			t.Logf("[%5.1fs] %s", time.Since(start).Seconds(), fmt.Sprintf(format, args...))
+		}
+
+		m := getTestMqttManager(t)
+		m.SetConnectionCallbacks(MqttConnectionCallbacks{
+			OnConnecting:     func() { logf("connecting") },
+			OnConnectionUp:   func() { logf("connected") },
+			OnConnectionDown: func(e *error) { logf("disconnected: %s", errText(e)) },
+			OnReconnecting:   func(e *error) { logf("reconnecting: %s", errText(e)) },
+		})
+
+		err := m.Connect(MqttConnectionDetails{
+			Host:        "localhost",
+			Port:        reconnectBrokerPort,
+			Protocol:    "mqtt",
+			MqttVersion: mqttVersion,
+		}, []SubscribeParams{{Topic: t.Name(), QoS: 0}})
+		if err != nil {
+			t.Fatalf("initial connect failed: %v", err)
+		}
+		defer m.Disconnect(nil)
+		logf("connected")
+
+		docker(t, down, reconnectBrokerName)
+
+		// The client must notice the broker is gone. With the socket left open
+		// this can only come from the keepalive, so allow for the ping timeout.
+		if !waitForState(t, m, ConnectionStates.Reconnecting, 45*time.Second) {
+			t.Fatalf("client never noticed the broker was gone (state=%s)", m.ConnectionState)
+		}
+		logf("noticed the broker was gone")
+
+		// Stay down long enough that any give-up-after-N-attempts behaviour
+		// would have taken effect.
+		time.Sleep(60 * time.Second)
+		if m.ConnectionState != ConnectionStates.Reconnecting {
+			t.Fatalf("expected to still be retrying after 60s down, got %s", m.ConnectionState)
+		}
+
+		docker(t, up, reconnectBrokerName)
+		if !waitForState(t, m, ConnectionStates.Connected, 45*time.Second) {
+			t.Fatalf("did not reconnect after the broker came back (state=%s)", m.ConnectionState)
+		}
+		logf("reconnected")
+	})
+}
+
+func requireReconnectTest(t *testing.T) {
+	t.Helper()
+	if os.Getenv("MQTT_RECONNECT_TEST") == "" {
+		t.Skip("set MQTT_RECONNECT_TEST=1 to run (slow, needs docker)")
+	}
+}
+
+// startReconnectBroker gives the test a mosquitto it fully owns, and makes sure
+// it is running and unpaused whatever the previous test left behind.
+func startReconnectBroker(t *testing.T) {
+	t.Helper()
+	_ = exec.Command("docker", "rm", "-f", reconnectBrokerName).Run()
+	out, err := exec.Command("docker", "run", "-d",
+		"--name", reconnectBrokerName,
+		"-p", fmt.Sprintf("%d:1883", reconnectBrokerPort),
+		"eclipse-mosquitto", "sh", "-c",
+		"printf 'listener 1883\\nallow_anonymous true\\n' > /mosquitto/config/mosquitto.conf && exec /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not start test broker: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rm", "-f", reconnectBrokerName).Run()
+	})
+	time.Sleep(2 * time.Second) // let mosquitto bind
+}
+
+func docker(t *testing.T, args ...string) {
+	t.Helper()
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker %s failed: %v: %s", strings.Join(args, " "), err, out)
+	}
+}
+
+func waitForState(t *testing.T, m *MqttManager, want ConnectionState, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if m.ConnectionState == want {
+			return true
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return false
+}
+
+func errText(e *error) string {
+	if e == nil {
+		return "no reason given"
+	}
+	return (*e).Error()
+}

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -153,6 +153,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Updates that match your install",
         body: "The updater now detects how the app was installed: in-app updates on macOS, Windows and portable Linux, and the right instructions for Flatpak, AppImage, deb and rpm.",
       },
+      {
+        title: "Reconnecting when the network drops out",
+        body: "If a broker went away without closing the connection properly, which is what a dropped VPN, a flaky network or a laptop waking from sleep look like, MQTT Viewer could sit showing \"connected\" with nothing arriving and never reconnect. On MQTT 5 connections it now notices within about ten seconds and reconnects, and keeps retrying for as long as the broker is away.",
+      },
     ],
   },
   {


### PR DESCRIPTION
Follow-up to reconnect behaviour seen during #125 testing.

## The retry policy is not the bug

Reproduced broker outages against a container I fully controlled. Both stacks retry indefinitely:

- **v5 (autopaho)**: fixed 3s retry, forever. Recovered ~3s after a 90s outage.
- **v3 (paho.mqtt.golang)**: exponential 1s doubling, capped at `MaxReconnectInterval` (30s), forever. Recovered ~1s after a 90s outage.

Neither is bounded and neither has unbounded backoff growth. autopaho v0.21.0 exposes no backoff hook, only `ConnectRetryDelay`, so fixed 3s is what's available short of reimplementing its dialers.

The "only two attempts then silence" observation is partly a logging artefact: the paho v3 client logs nothing per reconnect attempt, so a healthy retry loop looks identical to one that gave up.

## The real bug

`PingerV5` is a fork of paho's `DefaultPinger` that dropped the PINGRESP timeout check. It sent a PINGREQ every 2s, warned `ping response handler waited longer than 5000ms` when nothing came back, and carried on regardless. Nothing ever failed the connection, so a drop was only detected when a socket write happened to fail.

A broker that goes away without closing the socket (network blackhole, dropped VPN, laptop waking from sleep) therefore left the v5 client wedged in "connected" indefinitely: no messages, no reconnect, no error.

Reproduced with `docker pause`, which freezes the container with the socket still open:

| | before | after |
| --- | --- | --- |
| v3 | detects at 30s, reconnects | unchanged |
| v5 | never detects, stuck "connected" indefinitely | detects at 12s, reconnects |

## Changes

- `backend/mqtt/ping.go`: track an outstanding ping and fail the connection after `PING_TIMEOUT` (10s, matching the v3 client's `PingTimeout`). Clamp the ping interval to the negotiated keepalive, reset state at the start of each `Run` (autopaho reuses one pinger across reconnects), write the PINGREQ outside the mutex so a blocked socket cannot stall `PacketSent`/`PingResp`, drop the spurious warning, and fix the latency calc to use `Sub().Milliseconds()`.
- `backend/mqtt/connect.go`: the connect-timeout paths returned without tearing the client down, leaving an orphaned background retry loop the manager no longer had a handle on, one that could later flip state back to `connected`. Both versions now disconnect first.
- `backend/mqtt/ping_test.go`: four fast deterministic tests over `net.Pipe`.
- `backend/mqtt/reconnect_integration_test.go`: env-gated (`MQTT_RECONNECT_TEST=1`), v3 and v5 against both `stop` and `pause`, each asserting it is still retrying after 60s down and reconnects when the broker returns.
- Changelog entry.

## Testing

All four integration cases pass. Green on `go build ./...`, `go vet ./...`, `just test`, `pnpm check` (0 errors), `pnpm test:run` (166 passed), and the pinger tests under `-race`.

Worth knowing for future outage testing: a host-installed mosquitto is bound to 1883 alongside `mqtt-test-broker`, so stopping the container leaves the port answering and clients stay connected. Two early repro runs proved nothing because of it. The new integration test starts its own container on 18831 for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
