### PR TITLE
build(nix): package the app as a flake for x86_64 and aarch64 Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ scripts/.venv/
 
 # Per-checkout dev-server ports; generate with scripts/dev-ports.sh write-launch
 .claude/launch.json
+
+# nix build symlinks
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Update through Nix, not through the app:
 nix profile upgrade --all
 ```
 
-The Nix store is read only, so MQTT Viewer cannot replace its own binary and will not try to. Be aware that the in-app update prompt currently tells you to download a .deb or .rpm, which is wrong for a Nix install. Ignore it.
+The app recognises a Nix install and points you at Nix. Store paths are immutable, so it will not try to replace its own binary. The in-app text assumes a profile install; if you pinned MQTT Viewer in a NixOS or home-manager configuration, update the flake input and rebuild instead.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,55 @@ But wait, there's more:
 
 Don't see a feature that would make your life easier? [I really, really want to know.](https://github.com/mqtt-viewer/mqtt-viewer/issues/new?template=feature_idea.yml)
 
+## Installing with Nix
+
+This repository is a flake, so on Linux you can build and run MQTT Viewer straight from source. It covers `x86_64-linux` and `aarch64-linux`.
+
+Run it without adding it to your profile:
+
+```sh
+nix run github:mqtt-viewer/mqtt-viewer
+```
+
+Install it properly, with the desktop entry and icon:
+
+```sh
+nix profile add github:mqtt-viewer/mqtt-viewer
+```
+
+Or pin it in a NixOS or home-manager configuration:
+
+```nix
+{
+  inputs.mqtt-viewer.url = "github:mqtt-viewer/mqtt-viewer";
+
+  # then, in your package list
+  environment.systemPackages = [ inputs.mqtt-viewer.packages.${pkgs.system}.default ];
+}
+```
+
+### Installation size
+
+MQTT Viewer is not in nixpkgs yet, so nothing is prebuilt. The first build compiles the Go binary and the frontend on your machine.
+
+The package itself is 23 MiB. The catch is everything under it: the app needs GTK 3 and WebKit2GTK, and Nix uses its own copies rather than the ones your distribution already ships. The full closure is about 920 MiB across 186 store paths, and WebKitGTK with its GStreamer stack is nearly all of that. Check for yourself before committing to it:
+
+```sh
+nix path-info -Sh github:mqtt-viewer/mqtt-viewer#default
+```
+
+Most of it comes prebuilt from cache.nixos.org instead of being compiled locally, and it is shared with every other GTK app in your store, so the marginal cost is smaller if you already run one.
+
+### Updating
+
+Update through Nix, not through the app:
+
+```sh
+nix profile upgrade --all
+```
+
+The Nix store is read only, so MQTT Viewer cannot replace its own binary and will not try to. Be aware that the in-app update prompt currently tells you to download a .deb or .rpm, which is wrong for a Nix install. Ignore it.
+
 ## Contributing
 
 If MQTT Viewer has been helpful, right now the best ways to contribute are:
@@ -57,6 +106,8 @@ MQTT Viewer is built using [Wails](https://wails.io/), a Go-based application fr
 - [pnpm](https://pnpm.io/installation) (install via `npm install -g pnpm`)
 - [Just](https://github.com/casey/just?tab=readme-ov-file#cross-platform) - optional, but recommended for running commands in the project
 - [Atlas](https://github.com/ariga/atlas) - optional, only necessary if you need to create database migrations
+
+If you use Nix, `nix develop` gives you all of the above, including the pinned `wails3` CLI and the GTK/WebKit libraries the Linux build needs.
 
 ### Setup
 

--- a/backend/update/canupdate_nix_test.go
+++ b/backend/update/canupdate_nix_test.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package update
+
+import "testing"
+
+// Lives in a !windows file because canSelfUpdate is only build-tagged in for
+// unix; the Windows implementation returns true unconditionally.
+func TestCanSelfUpdate_FalseForNixInstall(t *testing.T) {
+	t.Setenv("FLATPAK_ID", "")
+	t.Setenv("APPIMAGE", "")
+	defer func(orig func() (string, error)) { osExecutable = orig }(osExecutable)
+	osExecutable = func() (string, error) {
+		return "/nix/store/abcd-mqtt-viewer-1.0.0/bin/mqtt-viewer", nil
+	}
+	if canSelfUpdate() {
+		t.Fatal("a Nix store install must never self-update")
+	}
+}

--- a/backend/update/canupdate_unix.go
+++ b/backend/update/canupdate_unix.go
@@ -21,6 +21,13 @@ func canSelfUpdate() bool {
 		// Flatpak's /app is read-only; updates come through `flatpak update`.
 		return false
 	}
+	if isNixInstall() {
+		// Nix store paths are immutable. On a single-user install the store can
+		// be user-writable, so the writability check below is not sufficient on
+		// its own: refuse explicitly rather than let the updater try to
+		// overwrite a store path.
+		return false
+	}
 	exe, err := os.Executable()
 	if err != nil {
 		return false

--- a/backend/update/updater.go
+++ b/backend/update/updater.go
@@ -7,6 +7,7 @@ import (
 	"mqtt-viewer/backend/env"
 	"mqtt-viewer/backend/logging"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -17,6 +18,8 @@ import (
 const (
 	releasesPageURL = "https://github.com/mqtt-viewer/mqtt-viewer/releases"
 	flatpakAppID    = "app.mqttviewer.MQTTViewer"
+	// Default Nix store root. NIX_STORE_DIR overrides it, see isNixStorePath.
+	nixStoreDir = "/nix/store"
 )
 
 // Install type identifiers reported to the frontend so it can show the right
@@ -24,11 +27,15 @@ const (
 const (
 	installFlatpak       = "flatpak"
 	installAppImage      = "appimage"
+	installNix           = "nix"
 	installLinuxPackage  = "linux-package" // deb or rpm
 	installLinuxPortable = "linux-portable"
 	installMacOS         = "macos"
 	installWindows       = "windows"
 )
+
+// Indirection so tests can pretend the binary lives somewhere else.
+var osExecutable = os.Executable
 
 // UpdateResponse is what the frontend receives when an update is available.
 // There is no licensing, so an update is always offered when a newer version
@@ -120,16 +127,50 @@ func isFlatpak() bool {
 	return os.Getenv("FLATPAK_ID") != ""
 }
 
+// isNixStorePath reports whether p sits inside the Nix store. Store paths are
+// immutable, so a binary living under one can never replace itself in place.
+// NIX_STORE_DIR is honoured for the rare non-default store root; it is normally
+// unset at runtime, in which case the default applies.
+func isNixStorePath(p string) bool {
+	root := os.Getenv("NIX_STORE_DIR")
+	if root == "" {
+		root = nixStoreDir
+	}
+	root = strings.TrimSuffix(filepath.Clean(root), string(os.PathSeparator))
+	return strings.HasPrefix(filepath.Clean(p), root+string(os.PathSeparator))
+}
+
+// isNixInstall reports whether Nix installed this binary. `nix profile add`
+// leaves a symlink in ~/.nix-profile/bin, so resolve it first: the real path is
+// what decides. A failed resolve is not fatal, the unresolved path is still
+// worth checking.
+func isNixInstall() bool {
+	exe, err := osExecutable()
+	if err != nil {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return isNixStorePath(exe)
+}
+
 // resolveInstallType classifies how MQTT Viewer was installed so the frontend
-// can show the correct update instructions. Flatpak and AppImage set their own
-// environment variables; everything else is classified by OS, with Linux split
-// into a self-updatable portable binary and a system package (deb/rpm).
+// can show the correct update instructions. Flatpak, AppImage and Nix each
+// identify themselves (the first two through environment variables, Nix through
+// its immutable store path); everything else is classified by OS, with Linux
+// split into a self-updatable portable binary and a system package (deb/rpm).
 func resolveInstallType() string {
 	if isFlatpak() {
 		return installFlatpak
 	}
 	if os.Getenv("APPIMAGE") != "" {
 		return installAppImage
+	}
+	// Ahead of the OS switch: a Nix install looks identical on Linux and macOS,
+	// and the store path is immutable either way.
+	if isNixInstall() {
+		return installNix
 	}
 	switch runtime.GOOS {
 	case "darwin":
@@ -162,6 +203,10 @@ func updateGuidance(installType string) (command, instructions, releasesURL stri
 		return "",
 			"Download the .deb or .rpm for your distribution from the releases page and install it over your current version.",
 			releasesPageURL
+	case installNix:
+		return "nix profile upgrade --all",
+			"Update MQTT Viewer through Nix. If you installed it into your profile, run:",
+			""
 	default:
 		return "", "", releasesPageURL
 	}

--- a/backend/update/updater_test.go
+++ b/backend/update/updater_test.go
@@ -56,6 +56,60 @@ func TestUpdateGuidance_SelfUpdateTypesHaveNoInstructions(t *testing.T) {
 	}
 }
 
+func TestIsNixStorePath(t *testing.T) {
+	if !isNixStorePath("/nix/store/abcd-mqtt-viewer-1.0.0/bin/mqtt-viewer") {
+		t.Fatal("a path under /nix/store should be a store path")
+	}
+	if isNixStorePath("/usr/local/bin/mqtt-viewer") {
+		t.Fatal("/usr/local/bin should not be a store path")
+	}
+	if isNixStorePath("/home/u/.nix-profile/bin/mqtt-viewer") {
+		t.Fatal("a profile symlink path is not itself a store path")
+	}
+	// The prefix trap: without the separator, HasPrefix would match this.
+	if isNixStorePath("/nix/storeage/bin/x") {
+		t.Fatal("/nix/storeage should not be treated as being inside /nix/store")
+	}
+	if isNixStorePath("/nix/store") {
+		t.Fatal("the store root itself is not a store path")
+	}
+}
+
+func TestIsNixStorePath_HonoursNixStoreDir(t *testing.T) {
+	t.Setenv("NIX_STORE_DIR", "/custom/store")
+	if !isNixStorePath("/custom/store/x/bin/y") {
+		t.Fatal("should honour NIX_STORE_DIR")
+	}
+	if isNixStorePath("/nix/store/x/bin/y") {
+		t.Fatal("the default root should not apply when NIX_STORE_DIR is set")
+	}
+}
+
+func TestResolveInstallType_Nix(t *testing.T) {
+	t.Setenv("FLATPAK_ID", "")
+	t.Setenv("APPIMAGE", "")
+	defer func(orig func() (string, error)) { osExecutable = orig }(osExecutable)
+	osExecutable = func() (string, error) {
+		return "/nix/store/abcd-mqtt-viewer-1.0.0/bin/mqtt-viewer", nil
+	}
+	if got := resolveInstallType(); got != installNix {
+		t.Fatalf("expected nix, got %q", got)
+	}
+}
+
+func TestUpdateGuidance_Nix(t *testing.T) {
+	cmd, instructions, url := updateGuidance(installNix)
+	if !strings.Contains(cmd, "nix profile upgrade") {
+		t.Fatalf("nix command should run `nix profile upgrade`, got %q", cmd)
+	}
+	if instructions == "" {
+		t.Fatal("nix should have instructions")
+	}
+	if url != "" {
+		t.Fatalf("nix should have no releases URL, got %q", url)
+	}
+}
+
 func TestIsFlatpak(t *testing.T) {
 	t.Setenv("FLATPAK_ID", "")
 	if isFlatpak() {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,259 @@
+{
+  description = "MQTT Viewer: a fast and feature-rich MQTT visualisation and debugging tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+
+      # Latest release tag is v1.0.0. The ldflag value keeps the leading "v"
+      # (backend/env flips IsDev when Version contains "-dev", so a plain
+      # release tag gives us a production build).
+      version = "1.0.0";
+
+      # Wails on Linux needs the GTK/WebKit stack, so only Linux gets packages.
+      # The dev shell is offered everywhere so a mac checkout can still get Go,
+      # pnpm and the task runners from the flake.
+      linuxSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      # aarch64-darwin only, no x86_64-darwin: nixpkgs 26.11 (which
+      # nixos-unstable now is) dropped that platform outright, and merely
+      # naming it here makes `nix eval` on the dev shell throw
+      #   error: Nixpkgs 26.11 has dropped support for x86_64-darwin.
+      # An Intel mac would need the input switched to nixpkgs-26.05-darwin.
+      allSystems = linuxSystems ++ [ "aarch64-darwin" ];
+
+      # Tiny stand-in for flake-utils.eachSystem: no extra flake input needed.
+      forSystems = systems: f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # Two independently filtered sources. The Go build and the frontend build
+      # are separate derivations (see nix/package.nix), so keeping their inputs
+      # disjoint means editing a .go file does not invalidate the pnpm/vite
+      # build and editing a .svelte file does not invalidate the Go build.
+      goSrc = lib.fileset.toSource {
+        root = ./.;
+        fileset = lib.fileset.unions [
+          ./go.mod
+          ./go.sum
+          ./main.go
+          ./tools.go
+          ./backend
+          ./events
+          ./loader
+          # Consumed by the package's postInstall to install the app icon.
+          ./build/appicon.png
+        ];
+      };
+
+      # fileset.toSource copies whatever is on disk, and on a dev machine
+      # frontend/node_modules and frontend/dist very much exist. Subtract every
+      # generated tree explicitly; maybeMissing keeps this working on a clean
+      # checkout where none of them are present.
+      frontendSrc =
+        (lib.fileset.toSource {
+          root = ./.;
+          fileset = lib.fileset.difference ./frontend (
+            lib.fileset.unions (
+              map lib.fileset.maybeMissing [
+                ./frontend/node_modules
+                ./frontend/dist
+                ./frontend/storybook-static
+                ./frontend/coverage
+                ./frontend/.svelte-kit
+                ./frontend/.task
+              ]
+            )
+          );
+        })
+        # pnpmConfigHook defaults pnpmRoot to the source root, so hand the
+        # frontend directory itself to the derivation rather than the repo root.
+        + "/frontend";
+    in
+    {
+      packages = forSystems linuxSystems (pkgs: rec {
+        default = mqtt-viewer;
+
+        mqtt-viewer = pkgs.callPackage ./nix/package.nix {
+          inherit version mqtt-viewer-frontend;
+          src = goSrc;
+        };
+
+        mqtt-viewer-frontend = pkgs.callPackage ./nix/frontend.nix {
+          inherit version;
+          src = frontendSrc;
+        };
+
+        # Dev-shell tool only. packages.default never invokes the wails3 CLI:
+        # frontend/bindings/ is committed and a CLI from a different tag
+        # rewrites every file in it.
+        wails3 = pkgs.callPackage ./nix/wails3.nix { };
+      });
+
+      devShells = forSystems allSystems (
+        pkgs:
+        let
+          inherit (pkgs) stdenv;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.go
+              pkgs.pnpm_10
+              pkgs.nodejs
+              pkgs.just
+              pkgs.tparse
+              pkgs.atlas
+              pkgs.git
+            ]
+            ++ lib.optional stdenv.isLinux self.packages.${stdenv.hostPlatform.system}.wails3;
+
+            # pkg-config discovery for cgo needs these as real build inputs, not
+            # as `packages` (which land in PATH but not in the pkg-config path).
+            nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.pkg-config ];
+            buildInputs = lib.optionals stdenv.isLinux [
+              pkgs.gtk3
+              pkgs.webkitgtk_4_1
+              pkgs.libsoup_3
+              pkgs.glib
+              pkgs.glib-networking
+              pkgs.gsettings-desktop-schemas
+            ];
+
+            # Untagged, wails v3 selects its GTK4/WebKitGTK 6.0 backend, so a
+            # bare `go build ./...` asks pkg-config for gtk4 + webkitgtk-6.0 and
+            # fails against the gtk3 stack above. Default the whole shell to the
+            # tag the project actually ships (build/linux/Taskfile.yml pins
+            # gtk3 for Ubuntu 22.04-era compatibility) so the commands in
+            # CLAUDE.md work verbatim. GOFLAGS is only a default: an explicit
+            # `-tags production,gtk3` on a command line still wins, so
+            # `wails3 dev` and the Taskfile builds are unaffected.
+            env.GOFLAGS = lib.optionalString stdenv.isLinux "-tags=gtk3";
+
+            # On darwin the GTK stack does not apply and wails3 itself wants the
+            # Xcode frameworks, so getting the CLI there is left to
+            #   go install -tags gtk3 github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.98-tui
+            shellHook = ''
+              # main.go has //go:embed all:frontend/dist, so `go build ./...`
+              # fails outright on a fresh checkout. Stub it once, and never
+              # touch a real build (vite empties dist on every build, so the
+              # stub cannot be committed). Same workaround as CLAUDE.md and
+              # build/Taskfile.yml's generate:bindings task.
+              if [ ! -d frontend/dist ]; then
+                mkdir -p frontend/dist
+                echo "<html></html>" > frontend/dist/index.html
+                echo "nix: stubbed frontend/dist/index.html so go build works; run 'pnpm build' in frontend/ for the real thing"
+              fi
+              echo "nix: dev shell ready${lib.optionalString stdenv.isLinux " (GOFLAGS=-tags=gtk3)"}; 'just dev' to run the app"
+            '';
+          };
+        }
+      );
+
+      checks = forSystems linuxSystems (
+        pkgs:
+        let
+          system = pkgs.stdenv.hostPlatform.system;
+          inherit (self.packages.${system}) mqtt-viewer mqtt-viewer-frontend wails3;
+        in
+        {
+          package = mqtt-viewer;
+          frontend = mqtt-viewer-frontend;
+          inherit wails3;
+
+          # There is deliberately no `go-tests` check. `go test ./...` is not
+          # hermetic in a Nix sandbox, for two independent reasons:
+          #
+          #  1. backend/env's init() panics when /etc/machine-id is absent,
+          #     which it is in the sandbox (and /etc there is read-only, so it
+          #     cannot be faked). Every package that transitively imports
+          #     backend/env therefore dies at init: backend/app, backend/cloud,
+          #     backend/db, backend/env, backend/models, backend/update.
+          #  2. backend/mqtt's TestConnectV3/V5, TestV3ConnectWs and
+          #     TestV3PubSub/V5PubSub dial a live broker on localhost:1883.
+          #
+          # backend/util's TestDownloadFile also fetches over HTTPS, so it only
+          # passes where the sandbox leaks network. Run the suite with
+          # `just test` (or `nix develop -c just test`) against a real broker
+          # instead. go-vet below covers compile-time correctness.
+          #
+          # go-vet reuses the package's goModules, buildInputs and preBuild
+          # (frontend/dist has to exist before anything can typecheck the
+          # //go:embed) and only swaps the build phase. nativeBuildInputs is
+          # deliberately left alone: overriding it drops the Go toolchain that
+          # buildGoModule injects. The GTK install hooks are disabled instead,
+          # since this derivation produces a stamp file, not an app.
+          go-vet = mqtt-viewer.overrideAttrs (_: {
+            pname = "mqtt-viewer-go-vet";
+            # Renaming pname would otherwise rename the goModules fixed-output
+            # derivation too, refetching the whole module cache under a new
+            # store path for identical content. Pin it to the package's own.
+            goModules = mqtt-viewer.goModules;
+            desktopItems = [ ];
+            dontWrapGApps = true;
+            buildPhase = ''
+              runHook preBuild
+              go vet -tags production,gtk3 ./...
+              runHook postBuild
+            '';
+            doCheck = false;
+            installPhase = ''
+              runHook preInstall
+              touch $out
+              runHook postInstall
+            '';
+            postInstall = "";
+            # $out here is a stamp file, not a directory, so the package's
+            # libexec/ relocation (see nix/package.nix postFixup) would fail
+            # with "mkdir: cannot create directory: Not a directory".
+            postFixup = "";
+          });
+
+          # Both frontend checks pin pnpmDeps for the same reason go-vet pins
+          # goModules: pnpmDeps is derived from finalAttrs.pname, so renaming
+          # the derivation would refetch the entire pnpm store under a new name.
+          svelte-check = mqtt-viewer-frontend.overrideAttrs (_: {
+            pname = "mqtt-viewer-svelte-check";
+            pnpmDeps = mqtt-viewer-frontend.pnpmDeps;
+            buildPhase = ''
+              runHook preBuild
+              pnpm run check
+              runHook postBuild
+            '';
+            installPhase = ''
+              runHook preInstall
+              touch $out
+              runHook postInstall
+            '';
+          });
+
+          # vitest's "unit" project only. The "storybook" project is
+          # deliberately excluded: it drives a real Chromium through
+          # Playwright, which is not hermetic here.
+          frontend-tests = mqtt-viewer-frontend.overrideAttrs (_: {
+            pname = "mqtt-viewer-frontend-tests";
+            pnpmDeps = mqtt-viewer-frontend.pnpmDeps;
+            buildPhase = ''
+              runHook preBuild
+              pnpm run test:run
+              runHook postBuild
+            '';
+            installPhase = ''
+              runHook preInstall
+              touch $out
+              runHook postInstall
+            '';
+          });
+        }
+      );
+
+      # pkgs.nixfmt is the RFC-style formatter now; nixfmt-rfc-style still
+      # resolves but warns that it is the same derivation.
+      formatter = forSystems allSystems (pkgs: pkgs.nixfmt);
+    };
+}

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -153,6 +153,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Updates that match your install",
         body: "The updater now detects how the app was installed: in-app updates on macOS, Windows and portable Linux, and the right instructions for Flatpak, AppImage, deb and rpm.",
       },
+      {
+        title: "Install it with Nix",
+        body: "MQTT Viewer is now packaged as a Nix flake for x86_64 and aarch64 Linux, and the updater points Nix installs at Nix instead of the .deb download.",
+      },
     ],
   },
   {

--- a/nix/frontend.nix
+++ b/nix/frontend.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenvNoCC,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+  src,
+  version,
+}:
+
+# The pnpm store hash below is deliberately NOT keyed per system.
+#
+# A pnpm store would ordinarily be platform specific, because pnpm resolves the
+# optional dependencies of esbuild/rollup (@esbuild/linux-arm64 vs
+# @esbuild/linux-x64, @rollup/rollup-linux-*-gnu) for the machine it runs on.
+# nixpkgs' fetchPnpmDeps sidesteps that: its installPhase runs
+#   pnpm install --force --ignore-scripts --frozen-lockfile
+# and `--force` exists precisely so the fetch pulls in every platform's
+# optional packages rather than just the host's. The resulting tarball is
+# therefore identical across Linux architectures.
+#
+# Verified, not assumed: building .#packages.<sys>.mqtt-viewer-frontend.pnpmDeps
+# on aarch64-linux and again on x86_64-linux reported the same hash
+# (sha256-hIQFX+RPOA9ETSWuJM3QcG+dwxZM1tEl0lNxU1kCESw=). Should a future
+# fetcherVersion drop --force, this becomes a per-system attrset again.
+
+# frontend/package.json pins packageManager to pnpm@10.28.0 while nixpkgs
+# pnpm_10 is currently 10.34.5. Both speak lockfileVersion 9.0, so the
+# committed pnpm-lock.yaml installs cleanly; the drift is noted rather than
+# worked around (COREPACK_ENABLE_STRICT would need network access).
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mqtt-viewer-frontend";
+  inherit version src;
+
+  # Top-level pnpmConfigHook, not the deprecated pnpm_10.configHook. The hook
+  # does not bring its own pnpm, so pnpm_10 goes in alongside it. It links
+  # pnpmDeps into a store and runs an offline `pnpm install` rooted at
+  # pnpmRoot, which defaults to the source root: hence src being the frontend
+  # directory rather than the repo root.
+  nativeBuildInputs = [
+    nodejs
+    pnpm_10
+    pnpmConfigHook
+  ];
+
+  # Top-level fetchPnpmDeps rather than pnpm_10.fetchDeps: the latter is
+  # deprecated. fetcherVersion 1 and 2 were both removed in nixpkgs 26.11, so
+  # this is on 4 (the newest the fetcher supports).
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-hIQFX+RPOA9ETSWuJM3QcG+dwxZM1tEl0lNxU1kCESw=";
+  };
+
+  # build/Taskfile.yml sets PRODUCTION=true for the frontend build. Nothing in
+  # the frontend currently reads it (no import.meta.env.PRODUCTION, no
+  # process.env.PRODUCTION), so this is fidelity with the upstream task rather
+  # than a functional requirement.
+  env.PRODUCTION = "true";
+
+  buildPhase = ''
+    runHook preBuild
+
+    # `pnpm run build` is `vite build`; outDir is vite's default, ./dist.
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # main.go embeds this tree with //go:embed all:frontend/dist, and an empty
+    # or stub dist compiles perfectly happily into a blank app window. Fail
+    # here instead, loudly.
+    if [ ! -s dist/index.html ]; then
+      echo "error: vite build produced no dist/index.html" >&2
+      exit 1
+    fi
+    if [ -z "$(ls -A dist/assets 2>/dev/null)" ]; then
+      echo "error: vite build produced no dist/assets/* bundles" >&2
+      exit 1
+    fi
+
+    cp -r dist $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Built Svelte frontend assets for MQTT Viewer";
+    homepage = "https://mqttviewer.app";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+  };
+})

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,168 @@
+{
+  lib,
+  buildGoModule,
+  pkg-config,
+  wrapGAppsHook3,
+  copyDesktopItems,
+  makeDesktopItem,
+  gtk3,
+  webkitgtk_4_1,
+  libsoup_3,
+  glib,
+  glib-networking,
+  gsettings-desktop-schemas,
+  mqtt-viewer-frontend,
+  src,
+  version,
+}:
+
+# Notes for upstreaming this to nixpkgs, where a flake-local filtered source is
+# not available:
+#   * `src` becomes `fetchFromGitHub { owner = "mqtt-viewer"; repo =
+#     "mqtt-viewer"; tag = "v${version}"; hash = ...; }`.
+#   * The two filesets in flake.nix collapse into that single src. The frontend
+#     derivation then takes the same src with `sourceRoot = "${src.name}/frontend"`
+#     instead of being handed a pre-filtered subdirectory.
+#   * `version` and the frontend derivation stop being callPackage arguments:
+#     version is set inline and the frontend is a `passthru`/`let`-bound
+#     derivation in the same file (the usual nixpkgs shape for a two-stage
+#     build).
+buildGoModule (finalAttrs: {
+  pname = "mqtt-viewer";
+  inherit version src;
+
+  # buildGoModule's default `go mod vendor` cannot work on this dependency
+  # graph. Vendoring resolves //go:embed patterns for every platform, and
+  # github.com/wailsapp/wails/webview2/webviewloader embeds
+  # arm64/WebView2Loader.dll, a prebuilt Windows binary that is absent from the
+  # published module zip:
+  #   go: resolving embeds in github.com/wailsapp/wails/webview2/webviewloader:
+  #       pattern arm64/WebView2Loader.dll: no matching files found
+  # proxyVendor keeps the module download cache instead, so embeds are only
+  # resolved for the packages this build actually compiles.
+  proxyVendor = true;
+  vendorHash = "sha256-zunXLYg9pTeBZ58PR0siy9wgFhXgGTEQFsRGeZrFIHs=";
+
+  # Mirrors build/linux/Taskfile.yml's production build:
+  #   -tags production,gtk3, CGO_ENABLED=1, -ldflags "-w -s -X ...env.Version"
+  # gtk3 keeps the app on the WebKit2GTK 4.1 stack, matching upstream's
+  # Ubuntu 22.04-era compatibility choice.
+  tags = [
+    "production"
+    "gtk3"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "mqtt-viewer/backend/env.Version=v${finalAttrs.version}"
+  ];
+
+  # loader/ is an Atlas schema-dump helper and tools.go is build-tagged; only
+  # the root package is the shipped app.
+  subPackages = [ "." ];
+
+  # doCheck is left at buildGoModule's default (true), but because subPackages
+  # narrows the build to ".", checkPhase only ever reports
+  #   ? mqtt-viewer [no test files]
+  # The suite proper is not runnable in a sandbox; see the comment on `checks`
+  # in flake.nix for why, and use `just test` against a live broker.
+
+  nativeBuildInputs = [
+    pkg-config
+    # Wraps bin/mqtt-viewer so GTK finds its runtime data: the observed wrapper
+    # prefixes GIO_EXTRA_MODULES (dconf + glib-networking) and XDG_DATA_DIRS
+    # (gsettings-desktop-schemas, gtk+3 schemas, and this package's own share/).
+    wrapGAppsHook3
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    # cgo pkg-config set for -tags gtk3: gtk+-3.0, gdk-3.0, webkit2gtk-4.1,
+    # gio-unix-2.0, libsoup-3.0.
+    gtk3
+    webkitgtk_4_1
+    libsoup_3
+    glib
+    # libsoup has no TLS of its own; glib-networking supplies the GIO TLS
+    # backend, without which every wss:// / mqtts:// fetch inside the webview
+    # fails. Picked up via GIO_EXTRA_MODULES by wrapGAppsHook3.
+    glib-networking
+    # The stock GSettings schemas (org.gnome.desktop.interface and friends)
+    # that GTK reads on startup; wrapGAppsHook3 puts them on
+    # GSETTINGS_SCHEMA_DIR.
+    gsettings-desktop-schemas
+  ];
+
+  # main.go has //go:embed all:frontend/dist, so the built frontend has to be
+  # in place before the Go compiler runs. This is the whole reason the build is
+  # split in two.
+  preBuild = ''
+    mkdir -p frontend
+    # Store paths are read-only; the Go toolchain does not need to write here
+    # but keeping the tree writable avoids surprises in later phases.
+    cp -r --no-preserve=mode,ownership ${mqtt-viewer-frontend} frontend/dist
+  '';
+
+  postInstall = ''
+    install -Dm444 build/appicon.png \
+      $out/share/icons/hicolor/512x512/apps/mqtt-viewer.png
+  '';
+
+  # GTK takes WM_CLASS from argv[0], because main.go never sets
+  # Linux.ProgramName. wrapGAppsHook3's in-place wrapping renames the real ELF
+  # to .mqtt-viewer-wrapped, so the window came up as
+  #   0x200002 "MQTT Viewer": (".mqtt-viewer-wrapped" ".mqtt-viewer-wrapped")
+  # and never matched the StartupWMClass below, leaving the running app detached
+  # from its own launcher icon (verified under Xvfb with xwininfo).
+  #
+  # A wrapper --argv0 does not fix it: main.go runs under panicwrap, which
+  # re-execs the binary through os.Executable(), and it is that child process
+  # which owns the window. So the real ELF's own basename has to be
+  # "mqtt-viewer". Keep it under libexec/ and put the wrapper in bin/ instead of
+  # wrapping in place.
+  dontWrapGApps = true;
+  postFixup = ''
+    mkdir -p $out/libexec/mqtt-viewer
+    mv $out/bin/mqtt-viewer $out/libexec/mqtt-viewer/mqtt-viewer
+    makeWrapper $out/libexec/mqtt-viewer/mqtt-viewer $out/bin/mqtt-viewer \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  # Mirrors build/linux/flatpak/app.mqttviewer.MQTTViewer.desktop, except the
+  # icon/name use the plain binary name rather than the Flatpak app ID.
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mqtt-viewer";
+      desktopName = "MQTT Viewer";
+      comment = "A fast and feature-rich MQTT visualization and debugging tool";
+      exec = "mqtt-viewer";
+      icon = "mqtt-viewer";
+      terminal = false;
+      categories = [
+        "Development"
+        "Utility"
+        "Network"
+      ];
+      keywords = [
+        "MQTT"
+        "IoT"
+        "broker"
+        "messaging"
+        "Sparkplug"
+      ];
+      startupWMClass = "mqtt-viewer";
+    })
+  ];
+
+  meta = {
+    description = "Fast and feature-rich MQTT visualisation and debugging tool";
+    homepage = "https://mqttviewer.app";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "mqtt-viewer";
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+})

--- a/nix/wails3.nix
+++ b/nix/wails3.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildGoModule,
+  fetchzip,
+  pkg-config,
+  gtk3,
+  webkitgtk_4_1,
+  libsoup_3,
+  glib,
+}:
+
+let
+  # go.mod pins the fork tag v3.0.0-alpha.98-tui, and that tag has since been
+  # DELETED from github.com/wailsapp/wails, so fetchFromGitHub cannot resolve
+  # it. proxy.golang.org keeps module zips permanently once published, so fetch
+  # the module zip from there instead. (This is also why `go install ...@tag`
+  # still works while `git checkout tag` does not.)
+  goModPath = "github.com/wailsapp/wails/v3@v3.0.0-alpha.98-tui";
+
+  src = fetchzip {
+    url = "https://proxy.golang.org/github.com/wailsapp/wails/v3/@v/v3.0.0-alpha.98-tui.zip";
+    hash = "sha256-1/pt6p1pUp1HgWlEKym+5Ix9f2M0uwPZn7Uh/Ta2cAo=";
+    # The zip already contains the full module path as directory levels.
+    stripRoot = false;
+    extension = "zip";
+  };
+in
+
+buildGoModule {
+  pname = "wails3";
+  # `wails3 version` reports v3.0.0-alpha.98 because the fork tag never bumped
+  # internal/version/version.txt. The real module version is the -tui tag.
+  version = "3.0.0-alpha.98-tui";
+
+  # Caveat on CLAUDE.md's alignment check. Because this builds from an
+  # extracted module zip rather than `go install module@version`, Go cannot
+  # stamp a module version, so
+  #   go version -m "$(which wails3)" | grep -E '^\s+mod\s'
+  # reports `github.com/wailsapp/wails/v3 (devel)`, not the -tui tag. The
+  # source is still exactly the pinned tag, guaranteed by the fixed-output
+  # hash on `src` below rather than by the binary's own metadata.
+
+  inherit src;
+  sourceRoot = "${src.name}/${goModPath}";
+
+  # `go mod vendor` walks every module in the graph and resolves //go:embed
+  # patterns for all platforms, which trips over
+  # github.com/wailsapp/wails/webview2/webviewloader: its module zip does not
+  # ship the prebuilt arm64/WebView2Loader.dll the package embeds. proxyVendor
+  # keeps the module download cache instead of vendoring, so embeds are only
+  # resolved for the packages actually built here.
+  proxyVendor = true;
+  vendorHash = "sha256-Moerz6qIC9NMjl09FT1nzcuDjoeVHLeJLPL44H5ECro=";
+
+  subPackages = [ "cmd/wails3" ];
+
+  # Without -tags gtk3 the CLI's cgo pulls in the GTK4 headers; the repo's CI
+  # and build tasks pass gtk3 for the same reason.
+  tags = [ "gtk3" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    gtk3
+    webkitgtk_4_1
+    libsoup_3
+    glib
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Wails v3 CLI, pinned to the -tui fork tag used by MQTT Viewer's go.mod";
+    homepage = "https://wails.io";
+    license = lib.licenses.mit;
+    mainProgram = "wails3";
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Packages MQTT Viewer for Nix as a flake, for `x86_64-linux` and `aarch64-linux`.

## Approach

`main.go` embeds `frontend/dist` with `//go:embed`, so the frontend must exist before the Go compiler runs. That forces a two-stage build, and I made the two stages separate derivations with **disjoint** `lib.fileset` sources rather than one derivation doing both:

- `nix/frontend.nix` builds `frontend/dist` with pnpm and vite.
- `nix/package.nix` is a `buildGoModule` that copies that output into place in `preBuild`.

The payoff is caching, and I measured it rather than assuming: appending a comment to `backend/env/env.go` changed the app derivation but left the frontend derivation byte-identical, so no pnpm fetch and no vite run. Editing a `.svelte` file did the reverse and reused the Go module cache.

For pnpm I used `fetchPnpmDeps` plus `pnpmConfigHook` (one fixed-output derivation for the pnpm store, then an offline install) rather than a hand-rolled `node_modules` FOD, which is both the nixpkgs-idiomatic shape and the more reproducible one.

`nix/package.nix` is written to be upstreamable with minimal change, and carries a comment saying exactly what would move: `src` becomes `fetchFromGitHub` at the release tag, and the two filesets collapse into one src plus `sourceRoot`. I have **not** submitted anything to nixpkgs, and nothing here invokes the wails3 binding generator.

## System dependencies, and how I determined them

Not guessed. I grepped the pinned `v3.0.0-alpha.98-tui` module for its cgo directives, which under `-tags gtk3` (the tag `build/linux/Taskfile.yml` actually ships) are:

```
#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.1 gdk-3.0
#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.1 gio-unix-2.0
#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.1 libsoup-3.0
```

That gives `gtk3`, `webkitgtk_4_1`, `glib`, `libsoup_3`. It corroborates `build/linux/nfpm/nfpm.yaml` (`libgtk-3-0`, `libwebkit2gtk-4.1-0`) and the `libgtk-3-dev libwebkit2gtk-4.1-dev` line in `release-linux.yaml`, and confirms the gtk4 / webkitgtk-6.0 alternative in the same source is not the path this build takes. I added `glib-networking` (GIO TLS backend for libsoup) and `gsettings-desktop-schemas`, both wired through `wrapGAppsHook3`.

## A bug found by actually launching it

`wrapGAppsHook3` wraps in place, renaming the real ELF to `.mqtt-viewer-wrapped`. GTK derives `WM_CLASS` from `argv[0]`, so the window came up as:

```
0x200002 "MQTT Viewer": (".mqtt-viewer-wrapped" ".mqtt-viewer-wrapped")  900x700+250+100
```

which never matches `StartupWMClass=mqtt-viewer`, leaving the running app detached from its own launcher icon. A wrapper `--argv0` does not fix it, because `main.go` re-execs itself through `panicwrap` and the **child** owns the window. So the real binary now lives in `libexec/mqtt-viewer/mqtt-viewer` with the wrapper in `bin/`, giving:

```
0x200002 "MQTT Viewer": ("mqtt-viewer" "Mqtt-viewer")  900x700+250+100
```

## Verification

Nix is not installed on my machine and this package is Linux-only, so a local darwin Nix install could not build it without a separate Linux builder. I used a `nixos/nix` container (nix 2.35.1) running **natively** on arm64, plus a second container for x86_64.

`nix build .#default -L`:

```
mqtt-viewer> Running phase: installPhase
mqtt-viewer> Copying '/nix/store/...-mqtt-viewer.desktop/share/applications/mqtt-viewer.desktop' into '...'
mqtt-viewer> Running phase: gappsWrapperArgsHook
mqtt-viewer> stripping (with command strip and flags -S -p) in .../bin
(exit 0)
```

`nix flake check -L`:

```
mqtt-viewer-svelte-check> svelte-check found 0 errors and 34 warnings in 23 files
mqtt-viewer-go-vet> buildPhase completed in 43 seconds
all checks passed!
warning: The check omitted these incompatible systems: aarch64-darwin, x86_64-linux
```

x86_64-linux got a full native build and a full `nix flake check` in its own container, not just an eval.

Output layout and identity:

```
result/bin/mqtt-viewer                       71056 bytes (wrapper)
result/libexec/mqtt-viewer/mqtt-viewer    23601696 bytes (real ELF, aarch64)
result/share/applications/mqtt-viewer.desktop
result/share/icons/hicolor/512x512/apps/mqtt-viewer.png
```

The installed icon's sha256 is `180b014c127b1482fce2d71a6a63653fe0fdf9c1e3768aa616a05d4fa5d87f67`, identical to `build/appicon.png`. `desktop-file-validate` passes.

`ldd` on the real ELF resolves all 157 entries to `/nix/store`, zero non-store libraries:

```
libwebkit2gtk-4.1.so.0 => /nix/store/...-webkitgtk-2.52.5+abi=4.1/lib/libwebkit2gtk-4.1.so.0
libgtk-3.so.0          => /nix/store/...-gtk+3-3.24.52/lib/libgtk-3.so.0
libsoup-3.0.so.0       => /nix/store/...-libsoup-3.6.6/lib/libsoup-3.0.so.0
libgio-2.0.so.0        => /nix/store/...-glib-2.88.1/lib/libgio-2.0.so.0
```

**Assets are genuinely embedded, not the stub.** Rather than grep filenames, every dist file's full byte sequence was located in the binary:

```
binary size:      23601696 bytes
dist total size:  3280006 bytes across 5 files

asset                                   bytes  name-in-bin  bytes-in-bin
index.html                                812  yes          yes
assets/index-Bc479oww.js              3194471  yes          yes
assets/index-BkObFrnD.css               57161  yes          yes
assets/protobuf-logo-Dcvz-1RT.png       22928  yes          yes
assets/sparkplug-CGzs3Jhl.svg            4634  yes          yes

stub '<html></html>' present as full index.html content: no
```

The frontend derivation also refuses to install a stub, and both guards were proven to fire by forcing an empty dist (`error: vite build produced no dist/index.html`) and a stub `index.html` with an empty `assets/` (`error: vite build produced no dist/assets/* bundles`).

**It launches, and the UI renders.** Under Xvfb with software GL, the app opened a real 900x700 GTK window matching `main.go`, stayed alive, and painted the actual Svelte UI: the "Message history retention" first-run dialog, the connections bar, and `v1.0.0` in the status bar, which confirms the `-X env.Version` ldflag reached the frontend. No EGL, panic or fatal errors in the log.

Two container-only obstacles had to be cleared first, neither a packaging fault: there was no `/etc/machine-id` (`backend/env`'s `init()` panics without it, and every real desktop has one), and no `/run/opengl-driver`, so libglvnd had no EGL vendor and WebKit's renderer aborted until `__EGL_VENDOR_LIBRARY_FILENAMES` was pointed at mesa.

Install, not just build:

```
$ nix profile add .#default
/root/.nix-profile/bin/mqtt-viewer -> /nix/store/...-mqtt-viewer-1.0.0/bin/mqtt-viewer
/root/.nix-profile/share/applications/mqtt-viewer.desktop
/root/.nix-profile/share/icons/hicolor/512x512/apps/mqtt-viewer.png
```

Dev shell:

```
$ nix develop -c sh -c 'go build ./... && go vet ./... && echo DEVSHELL_OK'
nix: dev shell ready (GOFLAGS=-tags=gtk3); 'just dev' to run the app
DEVSHELL_OK

$ nix develop -c wails3 version
v3.0.0-alpha.98
```

The shell defaults `GOFLAGS=-tags=gtk3`, because untagged, wails selects its GTK4 backend and a bare `go build ./...` asks pkg-config for gtk4. That makes CLAUDE.md's commands work verbatim.

Finally, building from a clean `git clone` of this branch produced the **identical** store path to the non-git build (`p2nhic6dxcsf2njzq731s4rd1ygyjs84-mqtt-viewer-1.0.0`), confirming nothing is missing from git and that the filesets are complete. `nixfmt --check` is clean.

## The updater now knows about Nix

Fixed in this PR rather than left as a question.

`resolveInstallType()` previously fell through to `installLinuxPackage` for a Nix install, so the app told Nix users to *"Download the .deb or .rpm for your distribution"*. It now detects the store path and returns a new `nix` type, whose guidance is `nix profile upgrade --all`.

`canSelfUpdate()` also refuses explicitly for a store install now. The existing writability check happened to cover the multi-user case, but on a **single-user** install `/nix/store` can be user-writable, which would have let the updater try to overwrite an immutable store path. That is the part I would not want left to chance.

Detection resolves symlinks first, because `nix profile add` installs a symlink into `~/.nix-profile/bin`. No frontend change was needed: `UpdateResponse` keeps its shape and the dialog already renders `instructions` and `update_command` generically, so no bindings were regenerated.

Verified against a real Nix install. The profile symlink resolves into the store, and both the panicwrap parent and the child that owns the window report a store path as their executable, which is exactly the string `os.Executable()` feeds to the new check:

```
$ readlink -f /root/.nix-profile/bin/mqtt-viewer
/nix/store/p2nhic...-mqtt-viewer-1.0.0/bin/mqtt-viewer

pid 21613 -> /nix/store/p2nhic...-mqtt-viewer-1.0.0/libexec/mqtt-viewer/mqtt-viewer
pid 21622 -> /nix/store/p2nhic...-mqtt-viewer-1.0.0/libexec/mqtt-viewer/mqtt-viewer
```

New tests cover the store-path predicate (including the `/nix/storeage` prefix trap, which a naive `HasPrefix` would get wrong, and the `NIX_STORE_DIR` override), the resolved install type, the self-update refusal, and the guidance strings:

```
$ go test ./backend/update/...
ok  	mqtt-viewer/backend/update	0.246s
```

`nix flake check` is still green with the Go change in, and `svelte-check` still reports 0 errors and the same 34 pre-existing warnings.

I could not exercise the update **dialog** itself, because that needs a successful portal call and this build has no cloud credentials.

## What I could not verify

- **The app on a real Linux desktop.** Everything above is Xvfb with llvmpipe in a container. In particular, on **non-NixOS** the GL/EGL story is the usual Nix GUI caveat: without `/run/opengl-driver` the host's drivers may not be found, and a user may need nixGL. I could not test that, and it is the thing most likely to bite a non-NixOS user.
- **`aarch64-darwin` dev shell is eval-only.** No mac Nix here. Installing Nix locally needs root, so it is yours to run if you want it checked.
- **The build sandbox in my container leaks network** (`backend/util`'s `TestDownloadFile` reached `raw.githubusercontent.com` inside a build), so "it passed here" is not proof of hermeticity for anything network-touching.
- **Binding generation with the nix-built wails3.** The definitive check means wiping `frontend/bindings` and regenerating, which is prohibited, so the packaged CLI is unproven for that specific job.
- No `go-tests` check. `go test ./...` is not hermetic: `backend/env`'s `init()` needs `/etc/machine-id` (absent, and `/etc` is read-only in the sandbox), and `backend/mqtt` dials a live broker on `localhost:1883`. Reasoning is recorded in a comment on `checks`. `go-vet` covers compile-time correctness, and I confirmed it genuinely fails by injecting a bad `fmt.Sprintf`.

## Open questions

1. **`version` is hardcoded to `1.0.0`** to match the newest tag, since a prod build needs a version without `-dev`. It will drift. Bump it in `flake.nix` at release time, or say the word and I will drive it from a file the release process already touches.
2. **`README.md` uses `github:mqtt-viewer/mqtt-viewer`**, which resolves to the default branch. The flake will only be there after the next release promotes `develop`. Until then it needs `github:mqtt-viewer/mqtt-viewer/develop`.
3. **No cloud credentials are baked in**, so this is a production build whose portal calls authenticate with the dev defaults. Fine for update checks failing closed, worth confirming that is what you want.
4. nixpkgs `pnpm_10` is 10.34.5 against the 10.28.0 pinned in `package.json`. Same lockfile version, installs cleanly, noted in a comment rather than worked around.

## Changelog

Now that the app's own behaviour changes, there is an entry in the `unreleased` section of `frontend/src/changelog.ts`, following the precedent set by the Flatpak and install-type detection entries. One sentence, no credit line, since this was maintainer-initiated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

