### PR TITLE
Explain memory use in the settings dialogs

### DIFF
--- a/backend/app/memory.go
+++ b/backend/app/memory.go
@@ -1,0 +1,24 @@
+package app
+
+import "mqtt-viewer/backend/mqtt"
+
+type MemoryStats struct {
+	HistoryBytes      int64 `json:"historyBytes"`
+	ActiveConnections int   `json:"activeConnections"`
+}
+
+// GetMemoryStats reports how much estimated memory in-RAM message history is
+// using across all connections. A disconnected connection still holds its
+// history against the budget, so it counts as active while it has any.
+func (a *App) GetMemoryStats() MemoryStats {
+	stats := MemoryStats{}
+	for _, c := range a.AppConnections {
+		historyBytes := c.MqttManager.HistoryBytes()
+		stats.HistoryBytes += historyBytes
+		if c.MqttManager.ConnectionState == mqtt.ConnectionStates.Connected ||
+			historyBytes > 0 {
+			stats.ActiveConnections++
+		}
+	}
+	return stats
+}

--- a/backend/mqtt/history.go
+++ b/backend/mqtt/history.go
@@ -50,6 +50,14 @@ func (m *MessageHistory) SetBudgetBytes(budget int64) {
 	m.evictLocked()
 }
 
+// TotalBytes returns the estimated bytes of message history currently held
+// in memory.
+func (m *MessageHistory) TotalBytes() int64 {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.totalBytes
+}
+
 // Clear empties the store but preserves the configured budget.
 func (m *MessageHistory) Clear() {
 	m.mutex.Lock()

--- a/backend/mqtt/history.go
+++ b/backend/mqtt/history.go
@@ -28,6 +28,10 @@ type MessageHistory struct {
 	latest      map[string]*MqttMessage
 	totalBytes  int64
 	budgetBytes int64
+	// latestExtraBytes tracks the bytes of newest-per-topic messages that have
+	// been evicted from the recent window but are still pinned by the latest
+	// map. Counted in TotalBytes only; never part of budget eviction.
+	latestExtraBytes int64
 }
 
 func newMessageHistory() *MessageHistory {
@@ -51,11 +55,13 @@ func (m *MessageHistory) SetBudgetBytes(budget int64) {
 }
 
 // TotalBytes returns the estimated bytes of message history currently held
-// in memory.
+// in memory. Budget eviction still uses recent-slice bytes only (totalBytes);
+// latestExtraBytes is the newest-per-topic messages retained after eviction,
+// added here so the readout reflects what is genuinely held.
 func (m *MessageHistory) TotalBytes() int64 {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	return m.totalBytes
+	return m.totalBytes + m.latestExtraBytes
 }
 
 // Clear empties the store but preserves the configured budget.
@@ -66,6 +72,7 @@ func (m *MessageHistory) Clear() {
 	m.head = 0
 	m.latest = make(map[string]*MqttMessage)
 	m.totalBytes = 0
+	m.latestExtraBytes = 0
 }
 
 func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
@@ -73,6 +80,11 @@ func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	p := &msg
+	if prev, ok := m.latest[p.Topic]; ok && prev.evictedFromRecent {
+		// The previous latest was pinned outside the recent window; it is now
+		// released, so stop counting it.
+		m.latestExtraBytes -= int64(prev.estimatedBytes())
+	}
 	m.latest[p.Topic] = p
 	m.recent = append(m.recent, p)
 	m.totalBytes += int64(p.estimatedBytes())
@@ -86,6 +98,12 @@ func (m *MessageHistory) evictLocked() {
 		m.recent[m.head] = nil // release for GC
 		m.head++
 		m.totalBytes -= int64(old.estimatedBytes())
+		if m.latest[old.Topic] == old {
+			// Still the newest message for its topic, so the latest map pins it
+			// in memory; count it towards the readout.
+			old.evictedFromRecent = true
+			m.latestExtraBytes += int64(old.estimatedBytes())
+		}
 	}
 	// Compact the backing array once head has consumed half of it, so the
 	// dead prefix is reclaimed rather than growing unbounded.

--- a/backend/mqtt/history.go
+++ b/backend/mqtt/history.go
@@ -13,14 +13,33 @@ import (
 // separately by opt-in disk recording.
 const DefaultMemoryBudgetBytes int64 = 512 * 1024 * 1024 // 512 MB
 
+// latestBudgetShare divides the budget to cap the newest-per-topic cache: it
+// may hold at most budget/latestBudgetShare. That cache keeps a topic's current
+// value after its messages age out of the recent window, so it grows with topic
+// cardinality rather than message volume, and before this cap it sat entirely
+// outside the budget (measured ~430 B of heap per distinct topic; at 200k
+// topics real heap reached 5x a 16 MB budget). A quarter leaves most of the
+// budget for the message timeline while still holding tens of thousands of
+// topic values at typical payload sizes.
+const latestBudgetShare = 4
+
+// latestBudgetFloorBytes stops the share from rounding down to less than one
+// message at very small budgets. Capped at half the budget so the total stays
+// within it. Never binding in production: the settings minimum is 64 MB, whose
+// quarter share is 16 MB.
+const latestBudgetFloorBytes int64 = 1024 * 1024
+
 // MessageHistory is a bounded, in-memory store of recently received messages.
+// Everything it retains is charged against the budget, so total bytes never
+// exceed it.
 //
 //   - recent: every retained message in global insertion order. The live slice
 //     is recent[head:]; head advances on eviction so we don't reslice on every
 //     drop. Oldest is at recent[head].
 //   - latest: the newest message per topic, kept even after it falls out of
-//     the recent window, so selecting a topic in the tree always shows at least
-//     its current value. Bounded by topic cardinality, not message volume.
+//     the recent window, so selecting a topic in the tree usually shows at
+//     least its current value. Capped at a share of the budget; past that the
+//     least recently updated topics lose their pinned value.
 type MessageHistory struct {
 	mutex       sync.Mutex
 	recent      []*MqttMessage
@@ -30,8 +49,16 @@ type MessageHistory struct {
 	budgetBytes int64
 	// latestExtraBytes tracks the bytes of newest-per-topic messages that have
 	// been evicted from the recent window but are still pinned by the latest
-	// map. Counted in TotalBytes only; never part of budget eviction.
+	// map. Bounded by latestBudgetLocked and included in TotalBytes.
 	latestExtraBytes int64
+	// pinned holds those same messages in the order they were pinned, which is
+	// arrival order, so the cache evicts least-recently-updated first. The live
+	// slice is pinned[pinnedHead:]. Entries go stale when their topic publishes
+	// again; they are skipped on pop and cleared by compaction, which is why
+	// pinnedLive (the number of non-stale entries) is tracked separately.
+	pinned     []*MqttMessage
+	pinnedHead int
+	pinnedLive int
 }
 
 func newMessageHistory() *MessageHistory {
@@ -54,10 +81,9 @@ func (m *MessageHistory) SetBudgetBytes(budget int64) {
 	m.evictLocked()
 }
 
-// TotalBytes returns the estimated bytes of message history currently held
-// in memory. Budget eviction still uses recent-slice bytes only (totalBytes);
-// latestExtraBytes is the newest-per-topic messages retained after eviction,
-// added here so the readout reflects what is genuinely held.
+// TotalBytes returns the estimated bytes of message history currently held in
+// memory: the recent window plus the newest-per-topic messages pinned after
+// eviction. Both are charged against the budget, so this never exceeds it.
 func (m *MessageHistory) TotalBytes() int64 {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -73,6 +99,9 @@ func (m *MessageHistory) Clear() {
 	m.latest = make(map[string]*MqttMessage)
 	m.totalBytes = 0
 	m.latestExtraBytes = 0
+	m.pinned = nil
+	m.pinnedHead = 0
+	m.pinnedLive = 0
 }
 
 func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
@@ -82,8 +111,10 @@ func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
 	p := &msg
 	if prev, ok := m.latest[p.Topic]; ok && prev.evictedFromRecent {
 		// The previous latest was pinned outside the recent window; it is now
-		// released, so stop counting it.
+		// released, so stop counting it. Its queue entry is left to be skipped
+		// on pop or dropped by compaction.
 		m.latestExtraBytes -= int64(prev.estimatedBytes())
+		m.pinnedLive--
 	}
 	m.latest[p.Topic] = p
 	m.recent = append(m.recent, p)
@@ -91,20 +122,32 @@ func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
 	m.evictLocked()
 }
 
-// evictLocked drops oldest messages until under budget. Caller holds mutex.
+// evictLocked drops oldest messages until the retained total (recent window
+// plus pinned newest-per-topic messages) is under budget. Caller holds mutex.
+//
+// Evicting from the recent window can pin a message instead of freeing it, when
+// it is still its topic's newest, so the pinned cache is trimmed on every
+// iteration: once that cache is at its share of the budget each new pin drops
+// an older one, which guarantees the loop makes progress.
 func (m *MessageHistory) evictLocked() {
-	for m.totalBytes > m.budgetBytes && m.head < len(m.recent) {
+	for m.totalBytes+m.latestExtraBytes > m.budgetBytes && m.head < len(m.recent) {
 		old := m.recent[m.head]
 		m.recent[m.head] = nil // release for GC
 		m.head++
 		m.totalBytes -= int64(old.estimatedBytes())
 		if m.latest[old.Topic] == old {
 			// Still the newest message for its topic, so the latest map pins it
-			// in memory; count it towards the readout.
+			// in memory; charge it to the pinned cache.
 			old.evictedFromRecent = true
 			m.latestExtraBytes += int64(old.estimatedBytes())
+			m.pinned = append(m.pinned, old)
+			m.pinnedLive++
 		}
+		m.trimPinnedLocked()
 	}
+	// A budget reduction can leave the pinned cache over its share even when no
+	// recent eviction was needed.
+	m.trimPinnedLocked()
 	// Compact the backing array once head has consumed half of it, so the
 	// dead prefix is reclaimed rather than growing unbounded.
 	if m.head > 0 && m.head*2 >= len(m.recent) {
@@ -115,11 +158,66 @@ func (m *MessageHistory) evictLocked() {
 		m.recent = m.recent[:n]
 		m.head = 0
 	}
+	m.compactPinnedLocked()
+}
+
+// latestBudgetLocked is the ceiling on pinned newest-per-topic bytes.
+// Caller holds mutex.
+func (m *MessageHistory) latestBudgetLocked() int64 {
+	return max(m.budgetBytes/latestBudgetShare, min(m.budgetBytes/2, latestBudgetFloorBytes))
+}
+
+// trimPinnedLocked drops pinned newest-per-topic messages, least recently
+// updated first, until the cache is within its share of the budget. A dropped
+// topic leaves the latest map entirely, so selecting it in the tree finds
+// nothing until it publishes again. Caller holds mutex.
+func (m *MessageHistory) trimPinnedLocked() {
+	limit := m.latestBudgetLocked()
+	for m.latestExtraBytes > limit && m.pinnedHead < len(m.pinned) {
+		oldest := m.pinned[m.pinnedHead]
+		m.pinned[m.pinnedHead] = nil // release for GC
+		m.pinnedHead++
+		if m.latest[oldest.Topic] != oldest || !oldest.evictedFromRecent {
+			continue // stale: the topic published again after this was pinned
+		}
+		delete(m.latest, oldest.Topic)
+		m.latestExtraBytes -= int64(oldest.estimatedBytes())
+		m.pinnedLive--
+	}
+}
+
+// compactPinnedLocked rebuilds the pinned queue, dropping both the dead prefix
+// the head has consumed and stale entries left behind when a pinned topic
+// published again. Without it the backing array grows with message volume
+// rather than topic count. Triggered on the same half-consumed rule as the
+// recent window, so it stays amortised O(1) per pin, or when stale entries
+// outnumber live ones (they can sit mid-queue indefinitely while the cache is
+// under its limit). Caller holds mutex.
+func (m *MessageHistory) compactPinnedLocked() {
+	live := m.pinned[m.pinnedHead:]
+	deadPrefix := m.pinnedHead > 0 && m.pinnedHead*2 >= len(m.pinned)
+	staleHeavy := len(live) >= 1024 && len(live) > 2*m.pinnedLive
+	if !deadPrefix && !staleHeavy {
+		return
+	}
+	n := 0
+	for _, p := range live {
+		if m.latest[p.Topic] == p && p.evictedFromRecent {
+			m.pinned[n] = p
+			n++
+		}
+	}
+	for i := n; i < len(m.pinned); i++ {
+		m.pinned[i] = nil
+	}
+	m.pinned = m.pinned[:n]
+	m.pinnedHead = 0
 }
 
 // GetTopicHistory returns the retained messages for a topic in arrival order.
 // If the topic's messages have all aged out of the recent window, its latest
-// value is still returned so a tree-click is never empty.
+// value is still returned, unless the pinned cache hit its cap and dropped that
+// topic too, in which case this errors and callers show an empty timeline.
 func (m *MessageHistory) GetTopicHistory(topic string) ([]MqttMessage, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/backend/mqtt/history_test.go
+++ b/backend/mqtt/history_test.go
@@ -183,8 +183,11 @@ func TestHistoryTotalBytesCountsPinnedLatest(t *testing.T) {
 		h.addMessageToHistory(msg(fmt.Sprintf("topic/%02d", i), 1024))
 	}
 
-	if h.TotalBytes() <= h.budgetBytes {
-		t.Errorf("expected TotalBytes %d to exceed budget %d (pinned latest messages counted)", h.TotalBytes(), h.budgetBytes)
+	if h.latestExtraBytes == 0 {
+		t.Error("expected some latest messages pinned outside the recent window")
+	}
+	if h.TotalBytes() > h.budgetBytes {
+		t.Errorf("TotalBytes %d exceeds budget %d (pinned latest messages are charged to it)", h.TotalBytes(), h.budgetBytes)
 	}
 
 	// Republishing to topics whose latest was evicted-and-pinned must not grow
@@ -203,6 +206,93 @@ func TestHistoryTotalBytesCountsPinnedLatest(t *testing.T) {
 	h.Clear()
 	if h.TotalBytes() != 0 {
 		t.Errorf("expected TotalBytes 0 after clear, got %d", h.TotalBytes())
+	}
+}
+
+// The newest-per-topic cache used to sit outside the budget entirely, so high
+// topic cardinality grew memory without limit. It is now capped at a share of
+// the budget, and the whole store stays within the budget.
+func TestHistoryLatestCacheBoundedByBudget(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := int64(estBytes(msg("topic/000000", 1024)))
+	budget := perMsg * 200
+	h.SetBudgetBytes(budget)
+
+	// One message on each of many more distinct topics than the budget can hold.
+	const topics = 20000
+	for i := 0; i < topics; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("topic/%06d", i), 1024))
+	}
+
+	if h.TotalBytes() > budget {
+		t.Errorf("TotalBytes %d exceeds budget %d at %d topics", h.TotalBytes(), budget, topics)
+	}
+	if limit := h.latestBudgetLocked(); h.latestExtraBytes > limit {
+		t.Errorf("pinned latest bytes %d exceed the cache limit %d", h.latestExtraBytes, limit)
+	}
+	if len(h.latest) >= topics {
+		t.Errorf("expected the latest map to drop topics, holding %d of %d", len(h.latest), topics)
+	}
+	if len(h.latest) == 0 {
+		t.Error("expected the latest map to keep the most recently updated topics")
+	}
+	// Least recently updated topics go first, so the newest ones survive.
+	if _, err := h.GetTopicHistory(fmt.Sprintf("topic/%06d", topics-1)); err != nil {
+		t.Errorf("expected the newest topic to be retained: %v", err)
+	}
+	if _, err := h.GetTopicHistory("topic/000000"); err == nil {
+		t.Error("expected the oldest topic to have been dropped from the latest cache")
+	}
+}
+
+// Lowering the budget must trim a cache that was legal under the old one.
+func TestHistoryLatestCacheTrimsOnBudgetReduction(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := int64(estBytes(msg("topic/0000", 1024)))
+	h.SetBudgetBytes(perMsg * 400)
+	for i := 0; i < 2000; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("topic/%04d", i), 1024))
+	}
+	before := h.latestExtraBytes
+
+	h.SetBudgetBytes(perMsg * 20)
+	if h.TotalBytes() > h.budgetBytes {
+		t.Errorf("TotalBytes %d exceeds reduced budget %d", h.TotalBytes(), h.budgetBytes)
+	}
+	if h.latestExtraBytes >= before {
+		t.Errorf("expected the pinned cache to shrink with the budget: %d -> %d", before, h.latestExtraBytes)
+	}
+}
+
+// Republishing to pinned topics leaves stale queue entries behind; they must be
+// compacted away rather than growing with message volume.
+func TestHistoryPinnedQueueDoesNotGrowWithVolume(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := int64(estBytes(msg("topic/000", 1024)))
+	h.SetBudgetBytes(perMsg * 100)
+
+	const topics = 200
+	for i := 0; i < 200000; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("topic/%03d", i%topics), 1024))
+	}
+
+	if len(h.pinned) > 8*topics {
+		t.Errorf("pinned queue grew with message volume: len=%d for %d topics", len(h.pinned), topics)
+	}
+	if h.pinnedLive < 0 {
+		t.Errorf("pinnedLive went negative: %d", h.pinnedLive)
+	}
+	live := 0
+	for _, p := range h.pinned[h.pinnedHead:] {
+		if h.latest[p.Topic] == p && p.evictedFromRecent {
+			live++
+		}
+	}
+	if live != h.pinnedLive {
+		t.Errorf("pinnedLive %d does not match %d live queue entries", h.pinnedLive, live)
+	}
+	if h.TotalBytes() > h.budgetBytes {
+		t.Errorf("TotalBytes %d exceeds budget %d", h.TotalBytes(), h.budgetBytes)
 	}
 }
 

--- a/backend/mqtt/history_test.go
+++ b/backend/mqtt/history_test.go
@@ -172,6 +172,40 @@ func TestHistoryClearPreservesBudget(t *testing.T) {
 	}
 }
 
+func TestHistoryTotalBytesCountsPinnedLatest(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := estBytes(msg("topic/00", 1024))
+	// Budget for ~3 messages, then one message on each of many distinct topics
+	// so most age out of the recent window but stay pinned in the latest map.
+	h.SetBudgetBytes(int64(perMsg * 3))
+	const topics = 20
+	for i := 0; i < topics; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("topic/%02d", i), 1024))
+	}
+
+	if h.TotalBytes() <= h.budgetBytes {
+		t.Errorf("expected TotalBytes %d to exceed budget %d (pinned latest messages counted)", h.TotalBytes(), h.budgetBytes)
+	}
+
+	// Republishing to topics whose latest was evicted-and-pinned must not grow
+	// latestExtraBytes unboundedly: each replacement decrements the old pin, so
+	// the extra term stays bounded by topic cardinality.
+	for i := 0; i < 100; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("topic/%02d", i%topics), 1024))
+	}
+	if max := int64(topics * perMsg); h.latestExtraBytes > max {
+		t.Errorf("latestExtraBytes %d exceeds topic-cardinality bound %d", h.latestExtraBytes, max)
+	}
+	if h.latestExtraBytes < 0 {
+		t.Errorf("latestExtraBytes went negative: %d", h.latestExtraBytes)
+	}
+
+	h.Clear()
+	if h.TotalBytes() != 0 {
+		t.Errorf("expected TotalBytes 0 after clear, got %d", h.TotalBytes())
+	}
+}
+
 func TestHistoryUnknownTopic(t *testing.T) {
 	h := newMessageHistory()
 	if _, err := h.GetTopicHistory("nope"); err == nil {

--- a/backend/mqtt/manager.go
+++ b/backend/mqtt/manager.go
@@ -60,6 +60,12 @@ func (m *MqttManager) ClearConnectionHistory() {
 	m.MessageHistory.Clear()
 }
 
+// HistoryBytes returns the estimated bytes of in-RAM message history this
+// connection currently holds.
+func (m *MqttManager) HistoryBytes() int64 {
+	return m.MessageHistory.TotalBytes()
+}
+
 // SetMessageMemoryBudget bounds the in-RAM message history for this connection.
 func (m *MqttManager) SetMessageMemoryBudget(budgetBytes int64) {
 	m.MessageHistory.SetBudgetBytes(budgetBytes)

--- a/backend/mqtt/message.go
+++ b/backend/mqtt/message.go
@@ -18,6 +18,11 @@ type MqttMessage struct {
 	TimeMs               int64              `json:"timeMs"`
 	MiddlewareProperties *map[string]any    `json:"middlewareProperties,omitempty"`
 	Time                 time.Time
+
+	// evictedFromRecent marks a message that has been evicted from the history's
+	// recent window but is still pinned by the latest-per-topic map. Unexported
+	// so it never serialises; only read/written under the history mutex.
+	evictedFromRecent bool
 }
 
 // estimatedBytes approximates the heap cost of retaining this message, used to
@@ -25,8 +30,7 @@ type MqttMessage struct {
 // just proportional and dominated by the variable parts (payload, topic,
 // properties) so eviction tracks real memory growth.
 func (m *MqttMessage) estimatedBytes() int {
-	// Fixed per-message overhead: struct fields, id/uuid, time.Time, and the
-	// always-allocated property/middleware map headers for v5 messages.
+	// Fixed per-message overhead: struct fields, id/uuid and time.Time.
 	const baseOverhead = 256
 	n := baseOverhead + len(m.Topic) + len(m.Payload) + len(m.Id)
 	if m.Properties != nil {

--- a/backend/mqtt/message.go
+++ b/backend/mqtt/message.go
@@ -30,6 +30,10 @@ func (m *MqttMessage) estimatedBytes() int {
 	const baseOverhead = 256
 	n := baseOverhead + len(m.Topic) + len(m.Payload) + len(m.Id)
 	if m.Properties != nil {
+		// v5 always allocates the properties struct plus the UserProperties and
+		// MiddlewareProperties maps, measured at ~450 B beyond the counted strings.
+		const v5Overhead = 448
+		n += v5Overhead
 		n += len(m.Properties.CorrelationData) +
 			len(m.Properties.ContentType) +
 			len(m.Properties.ResponseTopic)

--- a/docs/specs/bounded-message-memory.md
+++ b/docs/specs/bounded-message-memory.md
@@ -48,11 +48,20 @@ the memory budget:
 - **Latest-per-topic** map kept always (tiny, bounded by topic count) — feeds
   the live tree (already how the frontend works).
 
-  Correction (measured, 2026-08): this map is not counted against the budget
+  Correction (measured, 2026-08): this map was not counted against the budget
   and retains each topic's newest message in full, payload included, after it
-  ages out of the recent window, so very high topic cardinality grows memory
+  ages out of the recent window, so very high topic cardinality grew memory
   beyond the cap. The roughly 430 B of heap per distinct topic measured here
-  was with ~200 B payloads. A bound for this cache is future work.
+  was with ~200 B payloads; at 200k topics real heap reached 5x a 16 MB budget.
+
+  Bounded (2026-08): messages held only by this map are charged to the budget
+  and capped at a quarter of it (`latestBudgetShare`), with a 1 MB floor that
+  only matters for test-sized budgets. They are evicted least-recently-updated
+  first, tracked by a FIFO of pinned messages that is compacted on the same
+  half-consumed rule as the recent window. A topic whose pinned value is
+  dropped leaves the map, so `GetTopicHistory` errors for it until it publishes
+  again; the timeline treats that as empty. Total retained bytes are now
+  strictly within the budget.
 - **Recent ring** of full `MqttMessage`s, evicting **oldest globally** when the
   estimated retained bytes exceed the memory budget. Byte estimate =
   Σ(payload len + topic len + fixed per-message overhead). Maintain a running

--- a/docs/specs/bounded-message-memory.md
+++ b/docs/specs/bounded-message-memory.md
@@ -47,6 +47,11 @@ the memory budget:
 
 - **Latest-per-topic** map kept always (tiny, bounded by topic count) — feeds
   the live tree (already how the frontend works).
+
+  Correction (measured, 2026-08): this map is not counted against the budget
+  and costs roughly 430 B of heap per distinct topic, so very high topic
+  cardinality grows memory beyond the cap. A bound for this cache is future
+  work.
 - **Recent ring** of full `MqttMessage`s, evicting **oldest globally** when the
   estimated retained bytes exceed the memory budget. Byte estimate =
   Σ(payload len + topic len + fixed per-message overhead). Maintain a running

--- a/docs/specs/bounded-message-memory.md
+++ b/docs/specs/bounded-message-memory.md
@@ -49,9 +49,10 @@ the memory budget:
   the live tree (already how the frontend works).
 
   Correction (measured, 2026-08): this map is not counted against the budget
-  and costs roughly 430 B of heap per distinct topic, so very high topic
-  cardinality grows memory beyond the cap. A bound for this cache is future
-  work.
+  and retains each topic's newest message in full, payload included, after it
+  ages out of the recent window, so very high topic cardinality grows memory
+  beyond the cap. The roughly 430 B of heap per distinct topic measured here
+  was with ~200 B payloads. A bound for this cache is future work.
 - **Recent ring** of full `MqttMessage`s, evicting **oldest globally** when the
   estimated retained bytes exceed the memory budget. Byte estimate =
   Σ(payload len + topic len + fixed per-message overhead). Maintain a running

--- a/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/app.ts
+++ b/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/app.ts
@@ -425,6 +425,13 @@ export async function GetReceivedMessageCount(
   return mockMqttMessages.length;
 }
 
+export async function GetMemoryStats(): Promise<app.MemoryStats> {
+  return new app.MemoryStats({
+    historyBytes: 34 * 1024 * 1024,
+    activeConnections: 1,
+  });
+}
+
 export async function GetMqttStats(): Promise<app.MqttStats> {
   return new app.MqttStats({
     totalMessagesReceived: 128,

--- a/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/models.ts
+++ b/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/models.ts
@@ -47,6 +47,19 @@ export class EnvInfo {
   }
 }
 
+export class MemoryStats {
+  historyBytes = 0;
+  activeConnections = 0;
+
+  static createFrom(source: any = {}) {
+    return new MemoryStats(source);
+  }
+
+  constructor(source: any = {}) {
+    assign(this, source);
+  }
+}
+
 export class MqttStats {
   totalMessagesReceived = 128;
   totalMessagesSent = 42;

--- a/frontend/bindings/mqtt-viewer/backend/app/app.ts
+++ b/frontend/bindings/mqtt-viewer/backend/app/app.ts
@@ -204,27 +204,38 @@ export function GetMatchingSubscriptionForTopic(connId: number, topic: string): 
     });
 }
 
+/**
+ * GetMemoryStats reports how much estimated memory in-RAM message history is
+ * using across all connections. A disconnected connection still holds its
+ * history against the budget, so it counts as active while it has any.
+ */
+export function GetMemoryStats(): $CancellablePromise<$models.MemoryStats> {
+    return $Call.ByID(3870247942).then(($result: any) => {
+        return $$createType16($result);
+    });
+}
+
 export function GetMessageHistory(connId: number, topic: string): $CancellablePromise<mqtt$0.MqttMessage[]> {
     return $Call.ByID(3700437937, connId, topic).then(($result: any) => {
-        return $$createType17($result);
+        return $$createType18($result);
     });
 }
 
 export function GetMqttStats(): $CancellablePromise<$models.MqttStats> {
     return $Call.ByID(2888945465).then(($result: any) => {
-        return $$createType18($result);
+        return $$createType19($result);
     });
 }
 
 export function GetPanelSizes(): $CancellablePromise<models$0.PanelSize[]> {
     return $Call.ByID(3836927596).then(($result: any) => {
-        return $$createType20($result);
+        return $$createType21($result);
     });
 }
 
 export function GetPublishHistoriesForConnection(connectionID: number): $CancellablePromise<models$0.PublishHistory[]> {
     return $Call.ByID(3102818020, connectionID).then(($result: any) => {
-        return $$createType22($result);
+        return $$createType23($result);
     });
 }
 
@@ -249,13 +260,13 @@ export function GetReceivedMessageCount(connectionID: number, topic: string): $C
  */
 export function GetReceivedMessageWindow(connectionID: number, topic: string, beforeID: number, afterID: number, limit: number): $CancellablePromise<mqtt$0.MqttMessage[]> {
     return $Call.ByID(2230097254, connectionID, topic, beforeID, afterID, limit).then(($result: any) => {
-        return $$createType17($result);
+        return $$createType18($result);
     });
 }
 
 export function GetSortStates(): $CancellablePromise<models$0.SortState[]> {
     return $Call.ByID(2748919454).then(($result: any) => {
-        return $$createType24($result);
+        return $$createType25($result);
     });
 }
 
@@ -266,19 +277,19 @@ export function GetSortStates(): $CancellablePromise<models$0.SortState[]> {
  */
 export function GetSysMessageHistory(connId: number): $CancellablePromise<mqtt$0.MqttMessage[]> {
     return $Call.ByID(2117163184, connId).then(($result: any) => {
-        return $$createType17($result);
+        return $$createType18($result);
     });
 }
 
 export function GetSysMetricMappingsByConnectionId(connId: number): $CancellablePromise<models$0.SysMetricMapping[]> {
     return $Call.ByID(1443899974, connId).then(($result: any) => {
-        return $$createType25($result);
+        return $$createType26($result);
     });
 }
 
 export function LoadOpenTabs(): $CancellablePromise<models$0.Tab[]> {
     return $Call.ByID(2526018972).then(($result: any) => {
-        return $$createType27($result);
+        return $$createType28($result);
     });
 }
 
@@ -290,7 +301,7 @@ export function MoveCollectionMessage(id: number, targetCollectionID: number): $
 
 export function NewConnection(): $CancellablePromise<$models.Connection | null> {
     return $Call.ByID(3098702478).then(($result: any) => {
-        return $$createType29($result);
+        return $$createType30($result);
     });
 }
 
@@ -342,7 +353,7 @@ export function SaveFilterHistoryEntry(connectionId: number, text: string): $Can
 
 export function SavePublishHistoryEntry(params: $models.SavePublishHistoryEntryParams): $CancellablePromise<models$0.PublishHistory> {
     return $Call.ByID(3794014424, params).then(($result: any) => {
-        return $$createType21($result);
+        return $$createType22($result);
     });
 }
 
@@ -405,17 +416,18 @@ const $$createType12 = $Create.Array($$createType7);
 const $$createType13 = $models.EnvInfo.createFrom;
 const $$createType14 = models$0.FilterHistory.createFrom;
 const $$createType15 = $Create.Array($$createType14);
-const $$createType16 = mqtt$0.MqttMessage.createFrom;
-const $$createType17 = $Create.Array($$createType16);
-const $$createType18 = $models.MqttStats.createFrom;
-const $$createType19 = models$0.PanelSize.createFrom;
-const $$createType20 = $Create.Array($$createType19);
-const $$createType21 = models$0.PublishHistory.createFrom;
-const $$createType22 = $Create.Array($$createType21);
-const $$createType23 = models$0.SortState.createFrom;
-const $$createType24 = $Create.Array($$createType23);
-const $$createType25 = $Create.Array($$createType3);
-const $$createType26 = models$0.Tab.createFrom;
-const $$createType27 = $Create.Array($$createType26);
-const $$createType28 = $models.Connection.createFrom;
-const $$createType29 = $Create.Nullable($$createType28);
+const $$createType16 = $models.MemoryStats.createFrom;
+const $$createType17 = mqtt$0.MqttMessage.createFrom;
+const $$createType18 = $Create.Array($$createType17);
+const $$createType19 = $models.MqttStats.createFrom;
+const $$createType20 = models$0.PanelSize.createFrom;
+const $$createType21 = $Create.Array($$createType20);
+const $$createType22 = models$0.PublishHistory.createFrom;
+const $$createType23 = $Create.Array($$createType22);
+const $$createType24 = models$0.SortState.createFrom;
+const $$createType25 = $Create.Array($$createType24);
+const $$createType26 = $Create.Array($$createType3);
+const $$createType27 = models$0.Tab.createFrom;
+const $$createType28 = $Create.Array($$createType27);
+const $$createType29 = $models.Connection.createFrom;
+const $$createType30 = $Create.Nullable($$createType29);

--- a/frontend/bindings/mqtt-viewer/backend/app/index.ts
+++ b/frontend/bindings/mqtt-viewer/backend/app/index.ts
@@ -11,6 +11,7 @@ export {
     Connections,
     CreateCollectionParams,
     EnvInfo,
+    MemoryStats,
     MqttStats,
     OpenChartWindowParams,
     PublishParams,

--- a/frontend/bindings/mqtt-viewer/backend/app/models.ts
+++ b/frontend/bindings/mqtt-viewer/backend/app/models.ts
@@ -141,6 +141,31 @@ export class EnvInfo {
     }
 }
 
+export class MemoryStats {
+    "historyBytes": number;
+    "activeConnections": number;
+
+    /** Creates a new MemoryStats instance. */
+    constructor($$source: Partial<MemoryStats> = {}) {
+        if (!("historyBytes" in $$source)) {
+            this["historyBytes"] = 0;
+        }
+        if (!("activeConnections" in $$source)) {
+            this["activeConnections"] = 0;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new MemoryStats instance from a string or object.
+     */
+    static createFrom($$source: any = {}): MemoryStats {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new MemoryStats($$parsedSource as Partial<MemoryStats>);
+    }
+}
+
 export class MqttStats {
     "totalMessagesReceived": number;
     "totalMessagesSent": number;

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -171,7 +171,7 @@ export const CHANGELOG: ChangelogEntry[] = [
       },
       {
         title: "Clearer memory settings",
-        body: "The settings dialog now shows how much memory history is using and estimates the app's total use from your budget.",
+        body: "The settings dialog now shows how much memory message history is using and estimates the app's total use from your budget.",
       },
     ],
   },

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -173,6 +173,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Clearer memory settings",
         body: "The settings dialog now shows how much memory message history is using and estimates the app's total use from your budget.",
       },
+      {
+        title: "The memory budget now covers everything it keeps",
+        body: "The newest message on each topic used to sit outside the budget, so a broker with hundreds of thousands of topics could grow well past the number you set. Those messages are now counted against the budget too, and on brokers that big the quietest topics lose their kept value first.",
+      },
     ],
   },
   {

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -169,6 +169,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Deleting a connection works again",
         body: "Deleting a connection could fail and quietly roll back if you'd ever used publish or filter history on it. It now removes everything that belongs to the connection, and clearing out a large message history no longer freezes the app while it works.",
       },
+      {
+        title: "Clearer memory settings",
+        body: "The settings dialog now shows how much memory history is using and estimates the app's total use from your budget.",
+      },
     ],
   },
   {

--- a/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
+++ b/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
@@ -9,7 +9,6 @@
   import {
     GetAppSettings,
     UpdateAppSettings,
-    GetMemoryStats,
   } from "bindings/mqtt-viewer/backend/app/app";
   import { firstRunGateCleared } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
   import {
@@ -25,23 +24,14 @@
   let memoryBudgetMb = 512;
   let recordingEnabled = false;
   let diskBudgetGb = 1;
-  let activeConnections = 1;
   let isSaving = false;
 
   const recordingChecked = writable(false);
 
-  $: memoryBelowMin =
-    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
-  $: shownConnections = Math.max(1, activeConnections);
+  // A cleared Svelte number input binds null, which is also invalid.
+  $: memoryBelowMin = memoryBudgetMb == null || memoryBudgetMb < MIN_MEMORY_MB;
 
   onMount(async () => {
-    try {
-      const stats = await GetMemoryStats();
-      activeConnections = stats.activeConnections;
-    } catch (e) {
-      console.error("Failed to read memory stats", e);
-      activeConnections = 1;
-    }
     try {
       const settings = await GetAppSettings();
       if (!settings.hasSeenHistoryPrompt) {
@@ -125,23 +115,16 @@
           name="prompt-memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
-          class={memoryBelowMin ? "mb-[17px]" : ""}
+          class="mb-[17px]"
           hasError={memoryBelowMin}
           errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
         />
         <p class="text-sm text-secondary-text">
-          Caps the message history I keep in memory for each connection. The
-          newest message per topic is kept outside the cap so the topic tree
-          always has a value.
-        </p>
-        <p class="text-sm text-secondary-text">
-          Expect about {formatBytes(
-            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
-          )} in total with {shownConnections} connection{shownConnections === 1
-            ? ""
-            : "s"} active. That's this budget for each connection plus around
-          300 MB for the interface and runtime.
+          Expect up to about {formatBytes(
+            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, 1)
+          )} in total with one connection. That's this budget for each
+          connection plus around 300 MB for the interface and runtime.
         </p>
       </div>
 
@@ -170,7 +153,11 @@
       <Button variant="text" disabled={isSaving} on:click={onNotNow}
         >Not now</Button
       >
-      <Button variant="primary" disabled={isSaving} on:click={onSave}>
+      <Button
+        variant="primary"
+        disabled={isSaving || memoryBelowMin}
+        on:click={onSave}
+      >
         {isSaving ? "Saving…" : "Save"}
       </Button>
     </div>

--- a/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
+++ b/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
@@ -9,23 +9,39 @@
   import {
     GetAppSettings,
     UpdateAppSettings,
+    GetMemoryStats,
   } from "bindings/mqtt-viewer/backend/app/app";
   import { firstRunGateCleared } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
-
-  const MB = 1024 * 1024;
-  const GB = 1024 * 1024 * 1024;
-  const MIN_MEMORY_MB = 64;
+  import {
+    MB,
+    GB,
+    MIN_MEMORY_MB,
+    formatBytes,
+    estimateTotalBytes,
+  } from "@/util/memory-budget";
 
   const isOpen = writable(false);
 
   let memoryBudgetMb = 512;
   let recordingEnabled = false;
   let diskBudgetGb = 1;
+  let activeConnections = 1;
   let isSaving = false;
 
   const recordingChecked = writable(false);
 
+  $: memoryBelowMin =
+    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
+  $: shownConnections = Math.max(1, activeConnections);
+
   onMount(async () => {
+    try {
+      const stats = await GetMemoryStats();
+      activeConnections = stats.activeConnections;
+    } catch (e) {
+      console.error("Failed to read memory stats", e);
+      activeConnections = 1;
+    }
     try {
       const settings = await GetAppSettings();
       if (!settings.hasSeenHistoryPrompt) {
@@ -98,9 +114,9 @@
 <Dialog title="Message history retention" {isOpen} showCloseButton={false}>
   <div class="flex flex-col gap-5 mt-3 w-[440px]">
     <p class="text-secondary-text">
-      MQTT Viewer now bounds how much message history it keeps in memory so long
-      subscriptions don't grow RAM. You can also record history to disk so it
-      survives restarts.
+      I cap how much message history I keep in memory so long sessions don't
+      eat your RAM. You can also record history to disk so it survives
+      restarts.
     </p>
 
     <div class="flex flex-col gap-4">
@@ -109,8 +125,24 @@
           name="prompt-memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
+          class={memoryBelowMin ? "mb-[17px]" : ""}
+          hasError={memoryBelowMin}
+          errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
         />
+        <p class="text-sm text-secondary-text">
+          Caps the message history I keep in memory for each connection. The
+          newest message per topic is kept outside the cap so the topic tree
+          always has a value.
+        </p>
+        <p class="text-sm text-secondary-text">
+          Expect about {formatBytes(
+            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
+          )} in total with {shownConnections} connection{shownConnections === 1
+            ? ""
+            : "s"} active. That's this budget for each connection plus around
+          300 MB for the interface and runtime.
+        </p>
       </div>
 
       <div class="flex flex-col gap-2">

--- a/frontend/src/components/SettingsDialog/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog/SettingsDialog.svelte
@@ -4,45 +4,64 @@
   import BaseNumberInput from "@/components/InputFields/BaseNumberInput.svelte";
   import Switch from "@/components/InputFields/Switch.svelte";
   import { addToast } from "@/components/Toast/Toast.svelte";
+  import { onDestroy } from "svelte";
   import { writable } from "svelte/store";
   import {
     GetAppSettings,
     UpdateAppSettings,
     GetDatabaseSizeBytes,
     ClearReceivedMessages,
+    GetMemoryStats,
   } from "bindings/mqtt-viewer/backend/app/app";
   import env from "@/stores/env";
   import { whatsNewOpen } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
+  import {
+    MB,
+    GB,
+    MIN_MEMORY_MB,
+    formatBytes,
+    estimateTotalBytes,
+  } from "@/util/memory-budget";
 
   export let open = writable(false);
-
-  const MB = 1024 * 1024;
-  const GB = 1024 * 1024 * 1024;
-  const MIN_MEMORY_MB = 64;
 
   let memoryBudgetMb = 512;
   let recordingEnabled = false;
   let diskBudgetGb = 1;
   let dbSizeBytes: number | undefined = undefined;
+  let historyBytes: number | undefined = undefined;
+  let activeConnections = 1;
   let isSaving = false;
   let isClearing = false;
 
   const recordingChecked = writable(false);
 
-  // Human-readable byte formatting (e.g. "240 MB", "1.2 GB").
-  const formatBytes = (bytes: number | undefined): string => {
-    if (bytes === undefined) return "…";
-    if (bytes < 1024) return `${bytes} B`;
-    const units = ["KB", "MB", "GB", "TB"];
-    let value = bytes / 1024;
-    let unitIndex = 0;
-    while (value >= 1024 && unitIndex < units.length - 1) {
-      value /= 1024;
-      unitIndex += 1;
+  const refreshMemoryStats = async () => {
+    try {
+      const stats = await GetMemoryStats();
+      historyBytes = stats.historyBytes;
+      activeConnections = stats.activeConnections;
+    } catch (e) {
+      console.error("Failed to read memory stats", e);
+      historyBytes = undefined;
+      activeConnections = 1;
     }
-    const rounded = value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
-    return `${rounded} ${units[unitIndex]}`;
   };
+
+  // Poll memory stats while the dialog is open so the readout stays live.
+  let memoryPollInterval: ReturnType<typeof setInterval> | undefined;
+  const startMemoryPolling = () => {
+    if (memoryPollInterval !== undefined) return;
+    refreshMemoryStats();
+    memoryPollInterval = setInterval(refreshMemoryStats, 2000);
+  };
+  const stopMemoryPolling = () => {
+    if (memoryPollInterval !== undefined) {
+      clearInterval(memoryPollInterval);
+      memoryPollInterval = undefined;
+    }
+  };
+  onDestroy(stopMemoryPolling);
 
   const refreshDbSize = async () => {
     try {
@@ -76,11 +95,19 @@
     }
   };
 
-  // Load fresh settings + db size whenever the dialog opens.
+  // Load fresh settings + db size whenever the dialog opens, and poll memory
+  // stats only while it stays open.
   $: if ($open) {
     loadSettings();
     refreshDbSize();
+    startMemoryPolling();
+  } else {
+    stopMemoryPolling();
   }
+
+  $: memoryBelowMin =
+    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
+  $: shownConnections = Math.max(1, activeConnections);
 
   const onRecordingChange = (checked: boolean) => {
     recordingEnabled = checked;
@@ -154,11 +181,23 @@
           name="memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
+          class={memoryBelowMin ? "mb-[17px]" : ""}
+          hasError={memoryBelowMin}
+          errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
         />
         <p class="text-sm text-secondary-text">
-          Bounds in-memory message history so long subscriptions don't grow RAM
-          without limit. Always on.
+          Caps the message history I keep in memory for each connection. The
+          newest message per topic is kept outside the cap so the topic tree
+          always has a value.
+        </p>
+        <p class="text-sm text-secondary-text">
+          Expect about {formatBytes(
+            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
+          )} in total with {shownConnections} connection{shownConnections === 1
+            ? ""
+            : "s"} active. That's this budget for each connection plus around
+          300 MB for the interface and runtime.
         </p>
       </div>
 
@@ -188,6 +227,11 @@
     </section>
 
     <section class="flex flex-col gap-3 border-t border-outline pt-4">
+      <div class="flex items-center justify-between">
+        <span class="text-secondary-text"
+          >History in memory: {formatBytes(historyBytes)}</span
+        >
+      </div>
       <div class="flex items-center justify-between">
         <span class="text-secondary-text"
           >Database size: {formatBytes(dbSizeBytes)}</span

--- a/frontend/src/components/SettingsDialog/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog/SettingsDialog.svelte
@@ -187,9 +187,9 @@
           bind:value={memoryBudgetMb}
         />
         <p class="text-sm text-secondary-text">
-          Caps the message history I keep in memory for each connection. The
-          newest message per topic is kept outside the cap so the topic tree
-          always has a value.
+          Caps the message history I keep in memory for each connection,
+          including the newest message per topic. On brokers with very many
+          topics, quiet ones lose their kept value first.
         </p>
         <p class="text-sm text-secondary-text">
           Expect up to about {formatBytes(

--- a/frontend/src/components/SettingsDialog/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog/SettingsDialog.svelte
@@ -105,8 +105,8 @@
     stopMemoryPolling();
   }
 
-  $: memoryBelowMin =
-    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
+  // A cleared Svelte number input binds null, which is also invalid.
+  $: memoryBelowMin = memoryBudgetMb == null || memoryBudgetMb < MIN_MEMORY_MB;
   $: shownConnections = Math.max(1, activeConnections);
 
   const onRecordingChange = (checked: boolean) => {
@@ -181,7 +181,7 @@
           name="memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
-          class={memoryBelowMin ? "mb-[17px]" : ""}
+          class="mb-[17px]"
           hasError={memoryBelowMin}
           errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
@@ -192,12 +192,12 @@
           always has a value.
         </p>
         <p class="text-sm text-secondary-text">
-          Expect about {formatBytes(
+          Expect up to about {formatBytes(
             estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
-          )} in total with {shownConnections} connection{shownConnections === 1
+          )} in total across {shownConnections} connection{shownConnections === 1
             ? ""
-            : "s"} active. That's this budget for each connection plus around
-          300 MB for the interface and runtime.
+            : "s"}. That's this budget for each connection plus around 300 MB
+          for the interface and runtime.
         </p>
       </div>
 
@@ -258,7 +258,11 @@
 
     <div class="flex gap-3 justify-end items-center">
       <Button variant="text" on:click={() => open.set(false)}>Cancel</Button>
-      <Button variant="primary" disabled={isSaving} on:click={onSave}>
+      <Button
+        variant="primary"
+        disabled={isSaving || memoryBelowMin}
+        on:click={onSave}
+      >
         {isSaving ? "Saving…" : "Save"}
       </Button>
     </div>

--- a/frontend/src/util/memory-budget.ts
+++ b/frontend/src/util/memory-budget.ts
@@ -1,0 +1,32 @@
+// Shared constants and helpers for the memory-budget setting, used by the
+// settings dialog and the first-run history retention prompt.
+
+export const MB = 1024 * 1024;
+export const GB = 1024 * 1024 * 1024;
+export const MIN_MEMORY_MB = 64;
+
+// Measured ~320 MB baseline on macOS (Go process + webview helpers) with no
+// history; rounded to a cross-platform figure.
+export const BASE_APP_BYTES = 300 * MB;
+
+// Human-readable byte formatting (e.g. "240 MB", "1.2 GB").
+export const formatBytes = (bytes: number | undefined): string => {
+  if (bytes === undefined) return "…";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const rounded = value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[unitIndex]}`;
+};
+
+// Rough total app memory: baseline plus the per-connection history budget for
+// each active connection (at least one, so an idle app still shows a figure).
+export const estimateTotalBytes = (
+  budgetMb: number,
+  activeConnections: number
+): number => BASE_APP_BYTES + budgetMb * MB * Math.max(1, activeConnections);

--- a/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
+++ b/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
@@ -191,7 +191,10 @@ export const createSelectedTopicStore = (
     }
 
     // Memory mode: the in-RAM history is already bounded by the memory budget.
-    const history = await GetMessageHistory(connectionId, topic);
+    // It rejects with "topic not found in message history" when the topic's
+    // messages have aged out and its pinned latest value was dropped too (the
+    // newest-per-topic cache is capped); an empty timeline is the right answer.
+    const history = await GetMessageHistory(connectionId, topic).catch(() => []);
     const decoded = history.map(decode);
     update((store) => ({
       ...store,


### PR DESCRIPTION
## What

The "Memory budget (MB)" setting only capped part of what the app kept in RAM, so real memory sat well above the number the user typed. This PR makes the budget a genuine per-connection cap, and makes the dialogs honest about what it means in total.

- The newest-per-topic cache is now bounded. It used to retain each topic's newest message in full after the message aged out of the recent window, entirely outside the budget, so memory grew with topic cardinality (measured 5x a 16 MB budget at 200k topics). Those messages are now charged to the budget and capped at a quarter of it, evicted least-recently-updated first.
- Settings dialog and first-run retention prompt now state what the budget covers and estimate total app RAM live from the budget, the number of active connections, and a measured ~300 MB app baseline.
- New `GetMemoryStats` binding reports live history bytes and active connections; the settings dialog shows "History in memory" next to "Database size" and polls it while open.
- Values below the 64 MB minimum now show an inline error instead of being clamped silently on save.
- `estimatedBytes()` now charges ~448 B for the v5 properties struct and its maps, closing a measured ~26% undercount for v5 traffic.

## Diagnostics behind the numbers

- App baseline (release-style build, empty history, macOS): ~320 MB total (~110 MB Go process, ~210 MB WebKit helpers). Rounded to 300 MB in the estimate. Not yet verified on Windows or Linux.
- History accounting vs real heap: 0.76-0.99x for v3 across 100 B to 10 KB payloads; 1.26x for v5 with user properties (fixed by this PR).
- Latest-per-topic cache: was ~430 B of heap per distinct topic retained outside the budget. After the bound, the same 200k-topic workload (200 B payloads, 16 MB budget) measures 14.3 MB of real heap, 0.85x the budget, with the cache holding the 32k most recently updated topics.

## Behaviour change

A topic whose pinned value is dropped leaves the latest map, so `GetTopicHistory` errors for it until it publishes again. The timeline treats that as empty history rather than an error, and the settings copy says quiet topics lose their kept value first on brokers with very many topics.

## Checks

`go build ./...`, `go vet ./...`, `just test`, `pnpm check` (0 errors), `pnpm test:run` (166/166), `pnpm build`, `pnpm ds:validate`, `pnpm test-storybook` (132/132) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
