### PR TITLE
fix: close four data races in the MQTT backend

### DIFF
--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -10,20 +10,28 @@ import (
 	topicmatching "mqtt-viewer/backend/topic-matching"
 	"mqtt-viewer/backend/update"
 	"mqtt-viewer/events"
+	"sync"
 	"sync/atomic"
 )
 
 type App struct {
-	ctx            context.Context
-	Mode           AppMode
-	Paths          paths.Paths
-	Db             *db.DB
-	EventRuntime   *eventRuntime.EventRuntime
-	Events         *events.ConnectionEvents
-	Version        string
-	AppConnections map[uint]*AppConnection
-	Updater        *update.Updater
-	ProtoRegistry  *protobuf.ProtoRegistry
+	ctx          context.Context
+	Mode         AppMode
+	Paths        paths.Paths
+	Db           *db.DB
+	EventRuntime *eventRuntime.EventRuntime
+	Events       *events.ConnectionEvents
+	Version      string
+	Updater      *update.Updater
+	// Loaded in the background by Startup while binding calls are already
+	// being served, so reads have to be atomic. Use protoRegistry() /
+	// setProtoRegistry rather than touching it directly.
+	protoRegistryPtr atomic.Pointer[protobuf.ProtoRegistry]
+	// Guarded by appConnectionsMu; reach it only through the helpers in
+	// app_connections.go. Binding calls arrive on separate goroutines, so an
+	// unlocked add/delete against a concurrent poll is a fatal map race.
+	appConnections   map[uint]*AppConnection
+	appConnectionsMu sync.RWMutex
 	// Cached so the 300ms message-buffer drain doesn't hit the DB to decide
 	// whether to persist; kept in sync by loadRetentionSettings / UpdateAppSettings.
 	recordingEnabled atomic.Bool
@@ -60,6 +68,15 @@ type AppConnection struct {
 	// guaranteed to be serialised onto one goroutine, so counting is gated by
 	// a CompareAndSwap rather than trusting callback alternation.
 	connUp atomic.Bool
+}
+
+// protoRegistry returns the loaded registry, or nil while it is still loading.
+func (a *App) protoRegistry() *protobuf.ProtoRegistry {
+	return a.protoRegistryPtr.Load()
+}
+
+func (a *App) setProtoRegistry(registry *protobuf.ProtoRegistry) {
+	a.protoRegistryPtr.Store(registry)
 }
 
 func NewApp(appMode AppMode, version string) *App {

--- a/backend/app/app_connections.go
+++ b/backend/app/app_connections.go
@@ -1,0 +1,64 @@
+package app
+
+// Every Wails binding call runs on its own goroutine, so a connection being
+// added or deleted can land while a poller is walking the map. An unsynchronised
+// Go map fails that with a fatal "concurrent map read and map write" that no
+// recover can catch, taking the whole app down. These helpers are the only way
+// the map is touched; the field is unexported so the compiler keeps it that way.
+//
+// The lock covers the map, not the *AppConnection values it holds. Callers get a
+// live pointer and are expected to rely on MqttManager's own internal
+// synchronisation for anything they do with it.
+
+// appConnection returns the connection record for id, if it still exists.
+func (a *App) appConnection(id uint) (*AppConnection, bool) {
+	a.appConnectionsMu.RLock()
+	defer a.appConnectionsMu.RUnlock()
+	conn, ok := a.appConnections[id]
+	return conn, ok
+}
+
+// setAppConnection registers a newly created connection.
+func (a *App) setAppConnection(id uint, conn *AppConnection) {
+	a.appConnectionsMu.Lock()
+	defer a.appConnectionsMu.Unlock()
+	if a.appConnections == nil {
+		a.appConnections = make(map[uint]*AppConnection)
+	}
+	a.appConnections[id] = conn
+}
+
+// removeAppConnection drops a deleted connection.
+func (a *App) removeAppConnection(id uint) {
+	a.appConnectionsMu.Lock()
+	defer a.appConnectionsMu.Unlock()
+	delete(a.appConnections, id)
+}
+
+// replaceAppConnections swaps in the full set built at startup.
+func (a *App) replaceAppConnections(conns map[uint]*AppConnection) {
+	a.appConnectionsMu.Lock()
+	defer a.appConnectionsMu.Unlock()
+	a.appConnections = conns
+}
+
+// appConnectionsSnapshot copies the map so callers can iterate without holding
+// the lock across DB queries or MQTT calls. Values are shared pointers, so the
+// snapshot can name a connection that is deleted while the caller iterates;
+// that is the same window callers already had and is harmless here.
+func (a *App) appConnectionsSnapshot() map[uint]*AppConnection {
+	a.appConnectionsMu.RLock()
+	defer a.appConnectionsMu.RUnlock()
+	snapshot := make(map[uint]*AppConnection, len(a.appConnections))
+	for id, conn := range a.appConnections {
+		snapshot[id] = conn
+	}
+	return snapshot
+}
+
+// appConnectionCount reports how many connections are registered.
+func (a *App) appConnectionCount() int {
+	a.appConnectionsMu.RLock()
+	defer a.appConnectionsMu.RUnlock()
+	return len(a.appConnections)
+}

--- a/backend/app/app_connections_test.go
+++ b/backend/app/app_connections_test.go
@@ -1,0 +1,86 @@
+package app
+
+import (
+	"sync"
+	"testing"
+)
+
+// Wails runs each binding call on its own goroutine, so the 1s stats poll can
+// walk the map while a connection is being added or deleted. Without the lock
+// this is a fatal "concurrent map read and map write" that kills the app.
+func TestAppConnectionsSurviveConcurrentAccess(t *testing.T) {
+	a := &App{}
+	const ids = 50
+
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		for id := uint(1); id <= ids; id++ {
+			a.setAppConnection(id, &AppConnection{ConnectionId: id})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for id := uint(1); id <= ids; id++ {
+			a.removeAppConnection(id)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < ids; i++ {
+			for _, conn := range a.appConnectionsSnapshot() {
+				_ = conn.ConnectionId
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for id := uint(1); id <= ids; id++ {
+			a.appConnection(id)
+			a.appConnectionCount()
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestAppConnectionHelpersRoundTrip(t *testing.T) {
+	a := &App{}
+	if a.appConnectionCount() != 0 {
+		t.Fatalf("expected empty map, got %d", a.appConnectionCount())
+	}
+	if _, ok := a.appConnection(1); ok {
+		t.Error("expected no connection before one is set")
+	}
+
+	a.setAppConnection(1, &AppConnection{ConnectionId: 1})
+	conn, ok := a.appConnection(1)
+	if !ok || conn.ConnectionId != 1 {
+		t.Fatalf("expected connection 1, got %v (ok=%v)", conn, ok)
+	}
+	if a.appConnectionCount() != 1 {
+		t.Errorf("expected 1 connection, got %d", a.appConnectionCount())
+	}
+
+	// The snapshot must be a copy: mutating it cannot reach the live map.
+	snapshot := a.appConnectionsSnapshot()
+	delete(snapshot, 1)
+	if _, ok := a.appConnection(1); !ok {
+		t.Error("deleting from the snapshot changed the live map")
+	}
+
+	a.removeAppConnection(1)
+	if _, ok := a.appConnection(1); ok {
+		t.Error("expected connection removed")
+	}
+
+	a.replaceAppConnections(map[uint]*AppConnection{2: {ConnectionId: 2}})
+	if _, ok := a.appConnection(2); !ok {
+		t.Error("expected replaced set to contain connection 2")
+	}
+	if a.appConnectionCount() != 1 {
+		t.Errorf("expected 1 connection after replace, got %d", a.appConnectionCount())
+	}
+}

--- a/backend/app/connections.go
+++ b/backend/app/connections.go
@@ -26,7 +26,7 @@ type Connections struct {
 
 func (a *App) GetAllConnections() Connections {
 	result := make(map[uint]Connection)
-	for id, appConn := range a.AppConnections {
+	for id, appConn := range a.appConnectionsSnapshot() {
 		connectionDetails := models.Connection{}
 		if res := a.Db.First(&connectionDetails, id); res.Error != nil {
 			slog.Error("failed to load connection details, skipping connection", "conn_id", id, "error", res.Error)
@@ -34,7 +34,7 @@ func (a *App) GetAllConnections() Connections {
 		}
 		result[id] = Connection{
 			ConnectionDetails: connectionDetails,
-			IsConnected:       appConn.MqttManager.ConnectionState == mqtt.ConnectionStates.Connected,
+			IsConnected:       appConn.MqttManager.GetConnectionState() == mqtt.ConnectionStates.Connected,
 			EventSet:          *appConn.EventSet,
 		}
 	}
@@ -96,7 +96,7 @@ func (a *App) NewConnection() (*Connection, error) {
 	if err != nil {
 		return nil, err
 	}
-	a.AppConnections[conn.ID] = appConnection
+	a.setAppConnection(conn.ID, appConnection)
 	return &Connection{
 		ConnectionDetails: conn,
 		IsConnected:       false,
@@ -105,7 +105,7 @@ func (a *App) NewConnection() (*Connection, error) {
 }
 
 func (a *App) UpdateConnection(conn *models.Connection) error {
-	appConnection, ok := a.AppConnections[conn.ID]
+	appConnection, ok := a.appConnection(conn.ID)
 	if !ok {
 		return fmt.Errorf("connection not found")
 	}
@@ -181,7 +181,7 @@ func (a *App) DeleteConnection(id uint) error {
 	// Release the pages freed by a potentially huge history delete (no-op
 	// unless auto_vacuum is INCREMENTAL).
 	a.Db.Exec("PRAGMA incremental_vacuum")
-	delete(a.AppConnections, id)
+	a.removeAppConnection(id)
 	if a.Mode != AppModes.Test {
 		a.EventRuntime.EventsEmit(string(events.ConnectionDeleted), id)
 	}

--- a/backend/app/connections_test.go
+++ b/backend/app/connections_test.go
@@ -12,8 +12,8 @@ func TestNewConnectionsAreCreatedWhenNoneExist(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if len(app.AppConnections) != 1 {
-		t.Errorf("Expected 1 connection, got %v", len(app.AppConnections))
+	if app.appConnectionCount() != 1 {
+		t.Errorf("Expected 1 connection, got %v", app.appConnectionCount())
 	}
 	if newConnection.IsConnected == true {
 		t.Errorf("Expected connection to be disconnected, got connected")
@@ -22,13 +22,13 @@ func TestNewConnectionsAreCreatedWhenNoneExist(t *testing.T) {
 
 func TestNewConnectionsAreCreatedWhenSomeExist(t *testing.T) {
 	app := getSeededTestApp(t)
-	oldLen := len(app.AppConnections)
+	oldLen := app.appConnectionCount()
 	newConnection, err := app.NewConnection()
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if len(app.AppConnections) != oldLen+1 {
-		t.Errorf("Expected 6 connections, got %v", len(app.AppConnections))
+	if app.appConnectionCount() != oldLen+1 {
+		t.Errorf("Expected 6 connections, got %v", app.appConnectionCount())
 	}
 	if newConnection.IsConnected == true {
 		t.Errorf("Expected connection to be disconnected, got connected")
@@ -123,7 +123,7 @@ func TestConnectionsWithAllNullColumnsLoadOnStartup(t *testing.T) {
 }
 
 // Documents the intended behaviour: GetAllConnections is driven by the
-// in-memory AppConnections map built at startup, so rows written straight to
+// in-memory appConnections map built at startup, so rows written straight to
 // the database are not picked up until the app restarts.
 func TestGetAllConnectionsIgnoresRowsInsertedWithoutRestart(t *testing.T) {
 	app := getTestApp(t)
@@ -242,7 +242,7 @@ func TestDeleteConnectionRemovesAllConnectionScopedRows(t *testing.T) {
 		t.Errorf("expected surviving connection row to exist, got %d", survivingConn)
 	}
 
-	if _, ok := app.AppConnections[firstID]; ok {
-		t.Errorf("expected deleted connection removed from AppConnections")
+	if _, ok := app.appConnection(firstID); ok {
+		t.Errorf("expected deleted connection removed from appConnections")
 	}
 }

--- a/backend/app/export.go
+++ b/backend/app/export.go
@@ -23,7 +23,7 @@ type exportedMessage struct {
 }
 
 func (a *App) ExportTopicMessages(connId uint, topic string) (string, error) {
-	appConnection, ok := a.AppConnections[connId]
+	appConnection, ok := a.appConnection(connId)
 	if !ok {
 		return "", fmt.Errorf("connection not found")
 	}
@@ -37,7 +37,7 @@ func (a *App) ExportTopicMessages(connId uint, topic string) (string, error) {
 }
 
 func (a *App) ExportAllMessages(connId uint) (string, error) {
-	appConnection, ok := a.AppConnections[connId]
+	appConnection, ok := a.appConnection(connId)
 	if !ok {
 		return "", fmt.Errorf("connection not found")
 	}

--- a/backend/app/mqtt.go
+++ b/backend/app/mqtt.go
@@ -16,7 +16,7 @@ const MQTT_BUFFER_EMIT_INTERVAL = 300 * time.Millisecond
 
 func (a *App) ConnectMqtt(connId uint) error {
 	var err error
-	appConnection, ok := a.AppConnections[connId]
+	appConnection, ok := a.appConnection(connId)
 	if !ok {
 		return fmt.Errorf("connection not found (%d)", connId)
 	}
@@ -36,15 +36,18 @@ func (a *App) ConnectMqtt(connId uint) error {
 	// Always reload the sub matcher / proto matcher, subscriptions may have changed
 	appConnection.SubscriptionMatcher = topicmatching.NewSubscriptionMatcher(subscriptions)
 
-	// Add protobuf middlewares if enabled
-	if connection.IsProtoEnabled != nil && *connection.IsProtoEnabled && a.ProtoRegistry != nil {
+	// Add protobuf middlewares if enabled. Load the registry once: it is
+	// populated by a background goroutine at startup, so re-reading it could
+	// hand the encode and decode middleware different registries.
+	protoRegistry := a.protoRegistry()
+	if connection.IsProtoEnabled != nil && *connection.IsProtoEnabled && protoRegistry != nil {
 		// TODO: load sparkplug proto registry
 		appConnection.MqttManager.UseMiddleware(mqtt.MqttMiddlewares{
 			BeforePublish: []mqtt.Middleware[mqtt.MqttPublishParams]{
-				mqttmiddleware.NewProtoEncodeMiddleware(a.ProtoRegistry).Middleware,
+				mqttmiddleware.NewProtoEncodeMiddleware(protoRegistry).Middleware,
 			},
 			BeforeAddToHistory: []mqtt.Middleware[mqtt.MqttMessage]{
-				mqttmiddleware.NewProtoDecodeMiddleware(a.ProtoRegistry).Middleware,
+				mqttmiddleware.NewProtoDecodeMiddleware(protoRegistry).Middleware,
 			},
 		})
 	} else {
@@ -74,7 +77,7 @@ func (a *App) ConnectMqtt(connId uint) error {
 }
 
 func (a *App) DisconnectMqtt(connId uint) error {
-	appConnection, ok := a.AppConnections[connId]
+	appConnection, ok := a.appConnection(connId)
 	if !ok {
 		return fmt.Errorf("connection not found (%d)", connId)
 	}
@@ -83,7 +86,7 @@ func (a *App) DisconnectMqtt(connId uint) error {
 }
 
 func (a *App) GetMessageHistory(connId uint, topic string) ([]mqtt.MqttMessage, error) {
-	appConnection, ok := a.AppConnections[connId]
+	appConnection, ok := a.appConnection(connId)
 	if !ok {
 		return nil, fmt.Errorf("connection not found (%d)", connId)
 	}
@@ -98,7 +101,7 @@ func (a *App) GetMessageHistory(connId uint, topic string) ([]mqtt.MqttMessage, 
 // connection, flattened across topics and sorted by arrival time, so a
 // broker-status window opened mid-session starts populated.
 func (a *App) GetSysMessageHistory(connId uint) ([]mqtt.MqttMessage, error) {
-	appConnection, ok := a.AppConnections[connId]
+	appConnection, ok := a.appConnection(connId)
 	if !ok {
 		return nil, fmt.Errorf("connection not found (%d)", connId)
 	}
@@ -119,7 +122,7 @@ func sortMessagesByTimeAsc(messages []mqtt.MqttMessage) {
 }
 
 func (a *App) ClearConnectionHistory(connId uint) error {
-	appConnection, ok := a.AppConnections[connId]
+	appConnection, ok := a.appConnection(connId)
 	if !ok {
 		return fmt.Errorf("connection not found (%d)", connId)
 	}
@@ -197,11 +200,11 @@ func (a *App) GetMatchingSubscriptionForTopic(connId uint, topic string) (*model
 }
 
 func getConnectedConnection(app *App, connId uint) (*AppConnection, error) {
-	conn, ok := app.AppConnections[connId]
+	conn, ok := app.appConnection(connId)
 	if !ok {
 		return nil, fmt.Errorf("connection not found")
 	}
-	if conn.MqttManager.ConnectionState != mqtt.ConnectionStates.Connected {
+	if conn.MqttManager.GetConnectionState() != mqtt.ConnectionStates.Connected {
 		return nil, fmt.Errorf("specified connection not connected")
 	}
 	return conn, nil

--- a/backend/app/mqtt_test.go
+++ b/backend/app/mqtt_test.go
@@ -153,7 +153,7 @@ func MqttPubAndSubIntegrationTest(t *testing.T, mqttVersion string, publishPrope
 	})
 	connId := localConnection.ConnectionId
 
-	appConnection := app.AppConnections[connId]
+	appConnection, _ := app.appConnection(connId)
 
 	err := app.ConnectMqtt(connId)
 	if err != nil {
@@ -270,7 +270,7 @@ func getNewConnectionWithCustomProperties(app *App, customDetails *models.Connec
 		}
 	}
 
-	appConnection := app.AppConnections[newConnection.ConnectionDetails.ID]
+	appConnection, _ := app.appConnection(newConnection.ConnectionDetails.ID)
 	// Override onConnectUp and onConnectDown handlers to avoid wails runtime errors
 	appConnection.MqttManager.SetConnectionCallbacks(mqtt.MqttConnectionCallbacks{
 		OnConnecting: func() {

--- a/backend/app/settings.go
+++ b/backend/app/settings.go
@@ -95,7 +95,7 @@ func (a *App) applyMemoryBudgetToAllConnections(budget int64) {
 	if budget <= 0 {
 		budget = mqtt.DefaultMemoryBudgetBytes
 	}
-	for _, conn := range a.AppConnections {
+	for _, conn := range a.appConnectionsSnapshot() {
 		if conn != nil && conn.MqttManager != nil {
 			conn.MqttManager.SetMessageMemoryBudget(budget)
 		}

--- a/backend/app/startup.go
+++ b/backend/app/startup.go
@@ -126,7 +126,7 @@ func (a *App) Startup(ctx context.Context, options *StartupOptions) {
 			slog.ErrorContext(a.ctx, fmt.Sprintf("error loading proto registry: %v", err))
 			return
 		}
-		a.ProtoRegistry = registry
+		a.setProtoRegistry(registry)
 	}()
 
 	if a.Mode != AppModes.Test {
@@ -153,7 +153,7 @@ func (a *App) buildAppConnections() error {
 		}
 		appConnections[conn.ID] = appConnection
 	}
-	a.AppConnections = appConnections
+	a.replaceAppConnections(appConnections)
 	return nil
 }
 

--- a/backend/app/startup_test.go
+++ b/backend/app/startup_test.go
@@ -103,8 +103,8 @@ func TestGetSeededTestApp(t *testing.T) {
 	if app == nil {
 		t.Errorf("Expected app, got nil")
 	}
-	if len(app.AppConnections) != 5 {
-		t.Errorf("Expected 5 connections, got %v", len(app.AppConnections))
+	if app.appConnectionCount() != 5 {
+		t.Errorf("Expected 5 connections, got %v", app.appConnectionCount())
 	}
 }
 
@@ -122,7 +122,7 @@ func TestGetSavedConnectionsReturnsAllConnections(t *testing.T) {
 
 func TestAppConnectionIdMapIsBuiltCorrectly(t *testing.T) {
 	app := getSeededTestApp(t)
-	for id, conn := range app.AppConnections {
+	for id, conn := range app.appConnectionsSnapshot() {
 		if conn.ConnectionId != uint(id) {
 			t.Errorf("Expected connection id %v, got %v", id+1, conn.ConnectionId)
 		}

--- a/backend/app/stats.go
+++ b/backend/app/stats.go
@@ -14,7 +14,7 @@ func (a *App) GetMqttStats() (MqttStats, error) {
 	stats := MqttStats{
 		StatsByConnection: make(map[uint]mqtt.ConnectionStats),
 	}
-	for _, c := range a.AppConnections {
+	for _, c := range a.appConnectionsSnapshot() {
 		connStats := c.MqttManager.GetStats()
 		stats.StatsByConnection[c.ConnectionId] = connStats
 		stats.TotalMessagesReceived += connStats.MessagesReceived

--- a/backend/mqtt/connect.go
+++ b/backend/mqtt/connect.go
@@ -38,17 +38,17 @@ func (mm *MqttManager) Connect(connectionDetails MqttConnectionDetails, subscrip
 		return newMqttConnectError(fmt.Errorf("please set connection callbacks before attempting connection"))
 	}
 
-	if mm.ConnectionState == ConnectionStates.Connected {
+	if mm.GetConnectionState() == ConnectionStates.Connected {
 		slog.WarnContext(mm.ctx, "attempted connection while already connected")
 		return nil
 	}
 
-	if mm.ConnectionState == ConnectionStates.Connecting {
+	if mm.GetConnectionState() == ConnectionStates.Connecting {
 		slog.WarnContext(mm.ctx, "attempted connection while already connecting")
 		return nil
 	}
 
-	if mm.ConnectionState == ConnectionStates.Reconnecting {
+	if mm.GetConnectionState() == ConnectionStates.Reconnecting {
 		slog.WarnContext(mm.ctx, "attempted connection while reconnecting")
 		return nil
 	}
@@ -160,7 +160,7 @@ func (mm *MqttManager) connectV5(ctx context.Context, connectionDetails MqttConn
 				}},
 			OnClientError: func(err error) {
 				err = errors.New("client error: " + err.Error())
-				if mm.ConnectionState == ConnectionStates.Connected {
+				if mm.GetConnectionState() == ConnectionStates.Connected {
 					mm.SetConnectionState(ConnectionStates.Reconnecting, &err)
 				}
 			},
@@ -168,7 +168,7 @@ func (mm *MqttManager) connectV5(ctx context.Context, connectionDetails MqttConn
 
 				errString := "server disconnected: " + d.Properties.ReasonString
 				err := errors.New(errString)
-				if mm.ConnectionState == ConnectionStates.Connected {
+				if mm.GetConnectionState() == ConnectionStates.Connected {
 					mm.SetConnectionState(ConnectionStates.Reconnecting, &err)
 				}
 			},
@@ -231,7 +231,7 @@ func (mm *MqttManager) connectV3(ctx context.Context, connectionDetails MqttConn
 	opts.SetConnectRetry(false)
 	opts.SetOrderMatters(false)
 	opts.SetConnectionLostHandler(func(c mqttV3.Client, err error) {
-		if mm.ConnectionState == ConnectionStates.Connected {
+		if mm.GetConnectionState() == ConnectionStates.Connected {
 			mm.SetConnectionState(ConnectionStates.Reconnecting, &err)
 		}
 	})

--- a/backend/mqtt/manager.go
+++ b/backend/mqtt/manager.go
@@ -4,20 +4,25 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 
 	mqttV5Auto "github.com/eclipse/paho.golang/autopaho"
 	mqttV3 "github.com/eclipse/paho.mqtt.golang"
 )
 
 type MqttManager struct {
-	ctx                 context.Context
-	ConnectionState     ConnectionState
+	ctx context.Context
+	// paho's callbacks fire on their own goroutines while binding calls read
+	// the state, so this is atomic rather than a plain field: ConnectionState
+	// is a string, and a torn read can hand out a corrupt one. Reach it through
+	// GetConnectionState / SetConnectionState.
+	connectionState     atomic.Pointer[ConnectionState]
 	MessageBuffer       *MessageBuffer
 	MessageHistory      *MessageHistory
 	connectionCallbacks *MqttConnectionCallbacks
 	connection          *mqttActiveConnection
 	middleware          *MqttMiddlewares
-	stats               *ConnectionStats
+	stats               *connectionStats
 	pinger              *PingerV5
 	onNewLatencyMs      func(int32)
 }
@@ -40,16 +45,29 @@ type mqttActiveConnection struct {
 }
 
 func NewMqttManager(ctx context.Context, onNewLatencyMs func(int32)) *MqttManager {
-	return &MqttManager{
-		ctx:             ctx,
-		ConnectionState: ConnectionStates.Disconnected,
-		MessageBuffer:   newMessageBuffer(),
-		MessageHistory:  newMessageHistory(),
-		connection:      nil,
-		middleware:      newMiddleware(),
-		stats:           newStats(),
-		onNewLatencyMs:  onNewLatencyMs,
+	m := &MqttManager{
+		ctx:            ctx,
+		MessageBuffer:  newMessageBuffer(),
+		MessageHistory: newMessageHistory(),
+		connection:     nil,
+		middleware:     newMiddleware(),
+		stats:          newStats(),
+		onNewLatencyMs: onNewLatencyMs,
 	}
+	m.storeConnectionState(ConnectionStates.Disconnected)
+	return m
+}
+
+// GetConnectionState reports the current lifecycle state.
+func (m *MqttManager) GetConnectionState() ConnectionState {
+	if state := m.connectionState.Load(); state != nil {
+		return *state
+	}
+	return ConnectionStates.Disconnected
+}
+
+func (m *MqttManager) storeConnectionState(state ConnectionState) {
+	m.connectionState.Store(&state)
 }
 
 func (m *MqttManager) SetConnectionCallbacks(callbacks MqttConnectionCallbacks) {
@@ -66,15 +84,18 @@ func (m *MqttManager) SetMessageMemoryBudget(budgetBytes int64) {
 }
 
 func (m *MqttManager) SetConnectionState(state ConnectionState, reason *error) {
-	if m.ConnectionState == state {
+	// Read once so the log lines and the store all describe the same
+	// transition, even if another callback goroutine is setting state too.
+	previous := m.GetConnectionState()
+	if previous == state {
 		slog.DebugContext(m.ctx, fmt.Sprintf("connection state already %s", state))
 	}
 	if reason != nil {
-		slog.ErrorContext(m.ctx, fmt.Sprintf("connection state changed from %s to %s: %s", m.ConnectionState, state, (*reason).Error()))
+		slog.ErrorContext(m.ctx, fmt.Sprintf("connection state changed from %s to %s: %s", previous, state, (*reason).Error()))
 	} else {
-		slog.InfoContext(m.ctx, fmt.Sprintf("connection state changed from %s to %s", m.ConnectionState, state))
+		slog.InfoContext(m.ctx, fmt.Sprintf("connection state changed from %s to %s", previous, state))
 	}
-	m.ConnectionState = state
+	m.storeConnectionState(state)
 	switch state {
 	case ConnectionStates.Connecting:
 		if m.connectionCallbacks.OnConnecting != nil {
@@ -100,6 +121,5 @@ func (m *MqttManager) UseMiddleware(middleware MqttMiddlewares) {
 }
 
 func (m *MqttManager) GetStats() ConnectionStats {
-	stats := *m.stats
-	return stats
+	return m.stats.snapshot()
 }

--- a/backend/mqtt/manager_test.go
+++ b/backend/mqtt/manager_test.go
@@ -147,7 +147,7 @@ func getTestMqttManager(t *testing.T) *MqttManager {
 		},
 	})
 	t.Cleanup(func() {
-		if m.ConnectionState != ConnectionStates.Disconnected {
+		if m.GetConnectionState() != ConnectionStates.Disconnected {
 			m.Disconnect(nil)
 		}
 	})

--- a/backend/mqtt/publish.go
+++ b/backend/mqtt/publish.go
@@ -19,7 +19,7 @@ type MqttPublishParams struct {
 
 func (mm *MqttManager) Publish(message MqttPublishParams) error {
 	slog.DebugContext(mm.ctx, "publishing message", slog.String("topic", message.Topic))
-	if mm.ConnectionState != ConnectionStates.Connected ||
+	if mm.GetConnectionState() != ConnectionStates.Connected ||
 		mm.connection == nil {
 		return fmt.Errorf("no connection to broker")
 	}
@@ -43,7 +43,7 @@ func (mm *MqttManager) Publish(message MqttPublishParams) error {
 		return newPublishError(err)
 	}
 
-	mm.stats.SendMessageToStats(message)
+	mm.stats.sendMessageToStats(message)
 
 	if len(mm.middleware.AfterPublish) > 0 {
 		err := handlePublishMiddleware(&message, mm.middleware.AfterPublish)

--- a/backend/mqtt/receive.go
+++ b/backend/mqtt/receive.go
@@ -15,7 +15,7 @@ func (mm *MqttManager) receiveMessage(m *MqttMessage) error {
 	mm.MessageHistory.addMessageToHistory(*m)
 	mm.MessageBuffer.addMessageToBuffer(*m)
 
-	mm.stats.ReceiveMessageToStats(*m)
+	mm.stats.receiveMessageToStats(*m)
 	err = handleReceiveMiddleware(m, mm.middleware.AfterAddToHistory)
 	if err != nil {
 		return fmt.Errorf("after add to history: %w", err)

--- a/backend/mqtt/reconnect_integration_test.go
+++ b/backend/mqtt/reconnect_integration_test.go
@@ -77,20 +77,20 @@ func testReconnect(t *testing.T, mqttVersion, down, up string) {
 		// The client must notice the broker is gone. With the socket left open
 		// this can only come from the keepalive, so allow for the ping timeout.
 		if !waitForState(t, m, ConnectionStates.Reconnecting, 45*time.Second) {
-			t.Fatalf("client never noticed the broker was gone (state=%s)", m.ConnectionState)
+			t.Fatalf("client never noticed the broker was gone (state=%s)", m.GetConnectionState())
 		}
 		logf("noticed the broker was gone")
 
 		// Stay down long enough that any give-up-after-N-attempts behaviour
 		// would have taken effect.
 		time.Sleep(60 * time.Second)
-		if m.ConnectionState != ConnectionStates.Reconnecting {
-			t.Fatalf("expected to still be retrying after 60s down, got %s", m.ConnectionState)
+		if m.GetConnectionState() != ConnectionStates.Reconnecting {
+			t.Fatalf("expected to still be retrying after 60s down, got %s", m.GetConnectionState())
 		}
 
 		docker(t, up, reconnectBrokerName)
 		if !waitForState(t, m, ConnectionStates.Connected, 45*time.Second) {
-			t.Fatalf("did not reconnect after the broker came back (state=%s)", m.ConnectionState)
+			t.Fatalf("did not reconnect after the broker came back (state=%s)", m.GetConnectionState())
 		}
 		logf("reconnected")
 	})
@@ -135,7 +135,7 @@ func waitForState(t *testing.T, m *MqttManager, want ConnectionState, timeout ti
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if m.ConnectionState == want {
+		if m.GetConnectionState() == want {
 			return true
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/backend/mqtt/stats.go
+++ b/backend/mqtt/stats.go
@@ -1,5 +1,10 @@
 package mqtt
 
+import "sync/atomic"
+
+// ConnectionStats is the snapshot handed to the frontend by GetStats. It is a
+// plain value type so the counters can never be read while a message is
+// updating them.
 type ConnectionStats struct {
 	MessagesReceived int `json:"messagesReceived"`
 	MessagesSent     int `json:"messagesSent"`
@@ -7,16 +12,39 @@ type ConnectionStats struct {
 	BytesSent        int `json:"bytesSent"`
 }
 
-func newStats() *ConnectionStats {
-	return &ConnectionStats{}
+// connectionStats holds the live counters. The paho v3 router dispatches every
+// incoming message on its own goroutine (order=false), so receives land here
+// concurrently. Atomics rather than a mutex: this sits on the receive hot path
+// and the four counters never need to move as one consistent set.
+type connectionStats struct {
+	messagesReceived atomic.Int64
+	messagesSent     atomic.Int64
+	bytesReceived    atomic.Int64
+	bytesSent        atomic.Int64
 }
 
-func (s *ConnectionStats) ReceiveMessageToStats(message MqttMessage) {
-	s.MessagesReceived++
-	s.BytesReceived += len(message.Payload)
+func newStats() *connectionStats {
+	return &connectionStats{}
 }
 
-func (s *ConnectionStats) SendMessageToStats(message MqttPublishParams) {
-	s.MessagesSent++
-	s.BytesSent += len(message.Payload)
+func (s *connectionStats) receiveMessageToStats(message MqttMessage) {
+	s.messagesReceived.Add(1)
+	s.bytesReceived.Add(int64(len(message.Payload)))
+}
+
+func (s *connectionStats) sendMessageToStats(message MqttPublishParams) {
+	s.messagesSent.Add(1)
+	s.bytesSent.Add(int64(len(message.Payload)))
+}
+
+// snapshot reads the counters for the 1s frontend poll. The loads are four
+// separate atomic reads, not one atomic set, so a snapshot taken mid-message
+// can carry the message count without its bytes; the next poll corrects it.
+func (s *connectionStats) snapshot() ConnectionStats {
+	return ConnectionStats{
+		MessagesReceived: int(s.messagesReceived.Load()),
+		MessagesSent:     int(s.messagesSent.Load()),
+		BytesReceived:    int(s.bytesReceived.Load()),
+		BytesSent:        int(s.bytesSent.Load()),
+	}
 }

--- a/backend/mqtt/stats_test.go
+++ b/backend/mqtt/stats_test.go
@@ -1,0 +1,83 @@
+package mqtt
+
+import (
+	"sync"
+	"testing"
+)
+
+// Receives arrive one goroutine per message from the paho v3 router, so the
+// counters have to survive concurrent updates. Unsynchronised increments lose
+// updates here even without the race detector.
+func TestStatsCountEveryConcurrentMessage(t *testing.T) {
+	const goroutines = 8
+	const perGoroutine = 500
+	const payloadBytes = 4
+
+	stats := newStats()
+	message := MqttMessage{Payload: make([]byte, payloadBytes)}
+	publish := MqttPublishParams{Payload: make([]byte, payloadBytes)}
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				stats.receiveMessageToStats(message)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				stats.sendMessageToStats(publish)
+			}
+		}()
+	}
+	wg.Wait()
+
+	wantMessages := goroutines * perGoroutine
+	wantBytes := wantMessages * payloadBytes
+	got := stats.snapshot()
+	if got.MessagesReceived != wantMessages {
+		t.Errorf("MessagesReceived = %d, want %d", got.MessagesReceived, wantMessages)
+	}
+	if got.MessagesSent != wantMessages {
+		t.Errorf("MessagesSent = %d, want %d", got.MessagesSent, wantMessages)
+	}
+	if got.BytesReceived != wantBytes {
+		t.Errorf("BytesReceived = %d, want %d", got.BytesReceived, wantBytes)
+	}
+	if got.BytesSent != wantBytes {
+		t.Errorf("BytesSent = %d, want %d", got.BytesSent, wantBytes)
+	}
+}
+
+// The 1s frontend poll reads the counters while messages are still landing.
+func TestStatsSnapshotWhileCounting(t *testing.T) {
+	stats := newStats()
+	message := MqttMessage{Payload: []byte("payload")}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			stats.receiveMessageToStats(message)
+		}
+		close(done)
+	}()
+
+	for {
+		select {
+		case <-done:
+			wg.Wait()
+			if got := stats.snapshot(); got.MessagesReceived != 2000 {
+				t.Errorf("MessagesReceived = %d, want 2000", got.MessagesReceived)
+			}
+			return
+		default:
+			stats.snapshot()
+		}
+	}
+}

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -169,6 +169,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Deleting a connection works again",
         body: "Deleting a connection could fail and quietly roll back if you'd ever used publish or filter history on it. It now removes everything that belongs to the connection, and clearing out a large message history no longer freezes the app while it works.",
       },
+      {
+        title: "Steadier message counts, and a crash that can no longer happen",
+        body: "The received and sent counters dropped messages on a busy broker because several arriving at once could overwrite each other's tally. They now count every message, and adding or removing a connection while those numbers are on screen can no longer bring the app down.",
+      },
     ],
   },
   {

--- a/scripts/test-broker.sh
+++ b/scripts/test-broker.sh
@@ -11,7 +11,10 @@
 set -eu
 
 name=mqtt-test-broker
-conf_dir="${TMPDIR:-/tmp}/$name"
+# Under $HOME, not $TMPDIR: on macOS $TMPDIR is /var/folders/... which Docker
+# Desktop does not share, so bind-mounting the config from there fails with
+# "not a directory".
+conf_dir="${XDG_CACHE_HOME:-$HOME/.cache}/$name"
 
 up() {
   if docker ps --format '{{.Names}}' | grep -qx "$name"; then
@@ -19,9 +22,13 @@ up() {
     return
   fi
   if docker ps -a --format '{{.Names}}' | grep -qx "$name"; then
-    docker start "$name" >/dev/null
-    echo "$name started"
-    return
+    if docker start "$name" >/dev/null 2>&1; then
+      echo "$name started"
+      return
+    fi
+    # A container left over from a failed create can never start; rebuild it.
+    echo "$name could not start, recreating"
+    docker rm -f "$name" >/dev/null 2>&1 || true
   fi
   mkdir -p "$conf_dir"
   cat >"$conf_dir/mosquitto.conf" <<'EOF'


### PR DESCRIPTION
Fixes the two data races flagged in review, plus two more of the same class that `go test -race ./backend/...` surfaced while verifying them. All four are pre-existing.

Rebased onto develop after [76bba20](https://github.com/mqtt-viewer/mqtt-viewer/commit/76bba20). That commit made the receive path synchronous, which removes one *trigger* for the stats race but not the race itself, so all four fixes still apply. Re-measured against current develop rather than trusting the earlier numbers.

## Evidence

`go test -race`, current develop vs this branch:

| | data race warnings |
| --- | --- |
| `origin/develop` (76bba20) | **8** |
| this branch | **0** |

Develop's warnings still include `ConnectionStats.ReceiveMessageToStats` reached from `connectV3.func3`, and `App.ConnectMqtt` reading the proto registry. Full suite green on this branch, `-race` included.

## What is racing

**1. `ConnectionStats` counters.** Unsynchronised `MessagesReceived++` / `BytesReceived +=`. Counters are now atomic `int64` on an unexported `connectionStats`; `ConnectionStats` stays the plain value snapshot `GetStats` hands the frontend, so the JSON shape and generated bindings are unchanged.

Worth being precise about why this survived 76bba20: the v3 client still sets `SetOrderMatters(false)`, so paho dispatches each incoming message on its own goroutine and the counters are still written concurrently. Making our own path synchronous only fixed the v5 side. ([#149](https://github.com/mqtt-viewer/mqtt-viewer/pull/149) removes that dispatch concurrency for ordering reasons, which would narrow this further, but not close it: `GetStats` still reads all four counters unsynchronised from the 1 s poll.)

**2. `App.AppConnections`.** Written by `NewConnection` / `DeleteConnection`, iterated unlocked by `GetMqttStats` (polled every 1 s) and `GetAllConnections`. Wails runs each binding call on its own goroutine, so an add or delete concurrent with a poll is a fatal `concurrent map read and map write` that no recover can catch. The map is now unexported behind an `RWMutex` with a small set of helpers, so the compiler keeps every access on the locked path. Iterating callers take a snapshot rather than holding the lock across DB queries.

76bba20's new `connectedConnCount` is an `atomic.Int64` and does not touch the map, so it needed no changes here.

**3. `App.ProtoRegistry`.** Written by the background loader goroutine in `Startup`, read by `ConnectMqtt`. Now an `atomic.Pointer`, loaded once per connect so the encode and decode middleware cannot be handed different registries.

**4. `MqttManager.ConnectionState`.** Written from paho's callback goroutines, read by `Publish` and by the connection list. It is a `string`, so a torn read can yield a corrupt one. Now an `atomic.Pointer` behind `GetConnectionState()`.

## Rebase note

The `*m` copy hoist that was in `receive.go` here is gone: 76bba20 removed the goroutine it was guarding, so the race it addressed no longer exists. Resolved in favour of develop's synchronous writes.

## Tests

- `just test`: green (87 in `backend/app`, 32 in `backend/mqtt`).
- `go test -race ./backend/...`: green, zero race warnings.
- New: concurrency tests for the stats counters and the connection-map helpers. Both are broker-free, and the stats one fails on lost updates even without `-race`.

## Performance

The stats counters sit on the receive hot path: 3.1 ns/op before, 7.4 ns uncontended after, ~65 ns fully contended across 8 cores. At the 2 x 2000 msg/s bar that worst case is under 0.03% of one core. The map lock is on binding calls, not the message path.

## Also fixed

`scripts/test-broker.sh` kept its mosquitto config under `$TMPDIR`, which on macOS is `/var/folders/...` and is not shared with Docker Desktop, so `up` could not mount it and a half-created container then blocked every later run. Config now lives under `$HOME`, and a container that cannot start is recreated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)