### PR TITLE
Bound the latest-per-topic cache with the memory budget

### DIFF
--- a/.claude/skills/perf-check/SKILL.md
+++ b/.claude/skills/perf-check/SKILL.md
@@ -49,6 +49,15 @@ scripts/.venv/bin/python scripts/mqtt-flood.py --port 1883 --rate 2000
 scripts/.venv/bin/python scripts/mqtt-flood.py --port 1884 --rate 2000
 ```
 
+A single flood process tops out around 1,700 msg/s on this machine
+(paho's python client is the ceiling, not the broker). To hold a true
+2,000, run two floods per broker at `--rate 1000` rather than trusting
+the target.
+
+Add `--topics 200000` to one of them when the change touches history,
+the topic tree or memory: high topic cardinality is a separate axis from
+throughput and several bounds only bite there.
+
 Then run the app (`just dev`), connect to both brokers
 (localhost:1883 and localhost:1884), and exercise it for at least a few
 minutes.

--- a/backend/app/memory.go
+++ b/backend/app/memory.go
@@ -1,0 +1,24 @@
+package app
+
+import "mqtt-viewer/backend/mqtt"
+
+type MemoryStats struct {
+	HistoryBytes      int64 `json:"historyBytes"`
+	ActiveConnections int   `json:"activeConnections"`
+}
+
+// GetMemoryStats reports how much estimated memory in-RAM message history is
+// using across all connections. A disconnected connection still holds its
+// history against the budget, so it counts as active while it has any.
+func (a *App) GetMemoryStats() MemoryStats {
+	stats := MemoryStats{}
+	for _, c := range a.AppConnections {
+		historyBytes := c.MqttManager.HistoryBytes()
+		stats.HistoryBytes += historyBytes
+		if c.MqttManager.ConnectionState == mqtt.ConnectionStates.Connected ||
+			historyBytes > 0 {
+			stats.ActiveConnections++
+		}
+	}
+	return stats
+}

--- a/backend/mqtt/history.go
+++ b/backend/mqtt/history.go
@@ -30,19 +30,38 @@ const latestBudgetDivisor = 4
 // latest-map entry: the map bucket slot and key header (~35 B at Go's load
 // factor) plus the latestEntry struct itself (48 B). The topic string's bytes
 // are shared with the message's Topic field, so they are not counted twice.
+//
+// Only pinned entries carry this charge. An unpinned entry's overhead rides
+// free, which undercounts by at most ~19% of the budget in the pathological
+// case where every message in the recent window is on its own topic. That is
+// covered by estimatedBytes, which measures ~1.4x real heap.
 const latestEntryOverhead = 96
+
+// sysTopicPrefix marks broker-published metadata. These topics are few, are
+// what the broker status window reads, and some (a broker's version, say) are
+// published once as retained and never again — exactly the value the latest
+// map exists to hold, and exactly the entry a plain LRU would drop first on a
+// busy broker. Up to maxProtectedSysTopics of them are kept out of the LRU
+// list so they survive; the cap keeps a broker that publishes a huge $SYS
+// tree from turning the exemption into a hole in the budget.
+const (
+	sysTopicPrefix        = "$SYS/"
+	maxProtectedSysTopics = 1024
+)
 
 // latestEntry is the latest-per-topic slot for one topic.
 //
 // While the entry's message is still inside the recent window it is unpinned
 // and costs nothing extra: those bytes are already charged to recentBytes.
 // Once the message is evicted from `recent` the entry becomes the only thing
-// keeping it alive, so it is pinned, charged to latestBytes, and linked into
-// the LRU list so it can be dropped under budget pressure.
+// keeping it alive, so it is pinned and charged to latestBytes. A pinned entry
+// is either linked into the LRU list, or protected (a $SYS topic within the
+// cap) and so not evictable at all.
 type latestEntry struct {
 	msg        *MqttMessage
 	topic      string
 	pinned     bool
+	protected  bool
 	prev, next *latestEntry
 }
 
@@ -73,8 +92,11 @@ type MessageHistory struct {
 	// updated topic and the first to be dropped. Unpinned entries are not
 	// listed; their topics are all newer than every pinned one, because a
 	// topic pins exactly when its newest message leaves the recent window.
+	// Protected entries are not listed either, so they cannot be picked.
 	lruOldest *latestEntry
 	lruNewest *latestEntry
+	// protectedSysTopics counts pinned $SYS entries held out of the LRU list.
+	protectedSysTopics int
 	// droppedTopics counts latest entries discarded under budget pressure.
 	droppedTopics int64
 }
@@ -120,6 +142,7 @@ func (m *MessageHistory) Clear() {
 	m.latestBytes = 0
 	m.lruOldest = nil
 	m.lruNewest = nil
+	m.protectedSysTopics = 0
 }
 
 func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
@@ -133,8 +156,7 @@ func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
 			// The previous newest message was held only by this map; replacing
 			// it releases those bytes and makes the topic recent again.
 			m.latestBytes -= pinnedCost(entry.msg)
-			m.unlinkLocked(entry)
-			entry.pinned = false
+			m.unpinLocked(entry)
 		}
 		entry.msg = p
 	} else {
@@ -158,6 +180,10 @@ func pinnedCost(msg *MqttMessage) int64 {
 // the oldest recent message, and only once the recent window is drained fall
 // back to trimming latest below its share. Each iteration either frees bytes
 // or moves a message's charge from recent to latest, so the loop terminates.
+//
+// Protected $SYS entries are never dropped, so the store can sit above budget
+// by at most maxProtectedSysTopics entries' worth (a few hundred KB) if a
+// broker's $SYS tree alone exceeds it.
 func (m *MessageHistory) evictLocked() {
 	latestBudget := m.budgetBytes / latestBudgetDivisor
 	for m.recentBytes+m.latestBytes > m.budgetBytes {
@@ -189,11 +215,40 @@ func (m *MessageHistory) evictOldestRecentLocked() {
 	m.recent[m.head] = nil // release for GC
 	m.head++
 	m.recentBytes -= int64(old.estimatedBytes())
-	if entry, ok := m.latest[old.Topic]; ok && entry.msg == old {
-		entry.pinned = true
-		m.latestBytes += pinnedCost(old)
-		m.linkNewestLocked(entry)
+	entry, ok := m.latest[old.Topic]
+	if !ok || entry.msg != old {
+		return
 	}
+	cost := pinnedCost(old)
+	if cost > m.budgetBytes/latestBudgetDivisor {
+		// One message too big for the whole last-value share would evict every
+		// other topic to make room for itself. Let it go instead: the topic
+		// loses the value that did not fit, rather than every topic losing
+		// theirs.
+		delete(m.latest, old.Topic)
+		m.droppedTopics++
+		return
+	}
+	entry.pinned = true
+	m.latestBytes += cost
+	if strings.HasPrefix(entry.topic, sysTopicPrefix) && m.protectedSysTopics < maxProtectedSysTopics {
+		entry.protected = true
+		m.protectedSysTopics++
+		return
+	}
+	m.linkNewestLocked(entry)
+}
+
+// unpinLocked releases a pinned entry back to unpinned state, taking it out of
+// whichever structure was holding it. The caller adjusts latestBytes.
+func (m *MessageHistory) unpinLocked(entry *latestEntry) {
+	if entry.protected {
+		entry.protected = false
+		m.protectedSysTopics--
+	} else {
+		m.unlinkLocked(entry)
+	}
+	entry.pinned = false
 }
 
 // dropOldestLatestLocked discards the least recently updated pinned topic.
@@ -202,7 +257,7 @@ func (m *MessageHistory) evictOldestRecentLocked() {
 func (m *MessageHistory) dropOldestLatestLocked() {
 	entry := m.lruOldest
 	m.latestBytes -= pinnedCost(entry.msg)
-	m.unlinkLocked(entry)
+	m.unpinLocked(entry)
 	delete(m.latest, entry.topic)
 	entry.msg = nil
 	m.droppedTopics++

--- a/backend/mqtt/history.go
+++ b/backend/mqtt/history.go
@@ -50,6 +50,14 @@ func (m *MessageHistory) SetBudgetBytes(budget int64) {
 	m.evictLocked()
 }
 
+// TotalBytes returns the estimated bytes of message history currently held
+// in memory.
+func (m *MessageHistory) TotalBytes() int64 {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.totalBytes
+}
+
 // Clear empties the store but preserves the configured budget.
 func (m *MessageHistory) Clear() {
 	m.mutex.Lock()

--- a/backend/mqtt/history.go
+++ b/backend/mqtt/history.go
@@ -28,6 +28,10 @@ type MessageHistory struct {
 	latest      map[string]*MqttMessage
 	totalBytes  int64
 	budgetBytes int64
+	// latestExtraBytes tracks the bytes of newest-per-topic messages that have
+	// been evicted from the recent window but are still pinned by the latest
+	// map. Counted in TotalBytes only; never part of budget eviction.
+	latestExtraBytes int64
 }
 
 func newMessageHistory() *MessageHistory {
@@ -51,11 +55,13 @@ func (m *MessageHistory) SetBudgetBytes(budget int64) {
 }
 
 // TotalBytes returns the estimated bytes of message history currently held
-// in memory.
+// in memory. Budget eviction still uses recent-slice bytes only (totalBytes);
+// latestExtraBytes is the newest-per-topic messages retained after eviction,
+// added here so the readout reflects what is genuinely held.
 func (m *MessageHistory) TotalBytes() int64 {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	return m.totalBytes
+	return m.totalBytes + m.latestExtraBytes
 }
 
 // Clear empties the store but preserves the configured budget.
@@ -66,6 +72,7 @@ func (m *MessageHistory) Clear() {
 	m.head = 0
 	m.latest = make(map[string]*MqttMessage)
 	m.totalBytes = 0
+	m.latestExtraBytes = 0
 }
 
 func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
@@ -73,6 +80,11 @@ func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	p := &msg
+	if prev, ok := m.latest[p.Topic]; ok && prev.evictedFromRecent {
+		// The previous latest was pinned outside the recent window; it is now
+		// released, so stop counting it.
+		m.latestExtraBytes -= int64(prev.estimatedBytes())
+	}
 	m.latest[p.Topic] = p
 	m.recent = append(m.recent, p)
 	m.totalBytes += int64(p.estimatedBytes())
@@ -86,6 +98,12 @@ func (m *MessageHistory) evictLocked() {
 		m.recent[m.head] = nil // release for GC
 		m.head++
 		m.totalBytes -= int64(old.estimatedBytes())
+		if m.latest[old.Topic] == old {
+			// Still the newest message for its topic, so the latest map pins it
+			// in memory; count it towards the readout.
+			old.evictedFromRecent = true
+			m.latestExtraBytes += int64(old.estimatedBytes())
+		}
 	}
 	// Compact the backing array once head has consumed half of it, so the
 	// dead prefix is reclaimed rather than growing unbounded.

--- a/backend/mqtt/history.go
+++ b/backend/mqtt/history.go
@@ -13,31 +13,76 @@ import (
 // separately by opt-in disk recording.
 const DefaultMemoryBudgetBytes int64 = 512 * 1024 * 1024 // 512 MB
 
+// latestBudgetDivisor caps the share of the memory budget the latest-per-topic
+// map may hold: 1/4, leaving 3/4 for the recent window.
+//
+// The two stores compete for the same budget but serve different things:
+// `recent` gives back-scroll depth on the selected topic, `latest` gives
+// breadth (a last value for every topic in the tree, however quiet). A pinned
+// latest entry is always older than every message still in `recent` — its
+// newest message is what aged out — so a plain oldest-first policy would drop
+// the entire latest map before touching a single recent message, and clicking
+// a quiet topic would go blank the moment the connection went over budget.
+// Reserving a share for `latest` keeps that breadth while still bounding it.
+const latestBudgetDivisor = 4
+
+// latestEntryOverhead approximates the non-message heap cost of one
+// latest-map entry: the map bucket slot and key header (~35 B at Go's load
+// factor) plus the latestEntry struct itself (48 B). The topic string's bytes
+// are shared with the message's Topic field, so they are not counted twice.
+const latestEntryOverhead = 96
+
+// latestEntry is the latest-per-topic slot for one topic.
+//
+// While the entry's message is still inside the recent window it is unpinned
+// and costs nothing extra: those bytes are already charged to recentBytes.
+// Once the message is evicted from `recent` the entry becomes the only thing
+// keeping it alive, so it is pinned, charged to latestBytes, and linked into
+// the LRU list so it can be dropped under budget pressure.
+type latestEntry struct {
+	msg        *MqttMessage
+	topic      string
+	pinned     bool
+	prev, next *latestEntry
+}
+
 // MessageHistory is a bounded, in-memory store of recently received messages.
 //
 //   - recent: every retained message in global insertion order. The live slice
 //     is recent[head:]; head advances on eviction so we don't reslice on every
 //     drop. Oldest is at recent[head].
 //   - latest: the newest message per topic, kept even after it falls out of
-//     the recent window, so selecting a topic in the tree always shows at least
-//     its current value. Bounded by topic cardinality, not message volume.
+//     the recent window, so selecting a topic in the tree normally shows at
+//     least its current value. Bounded by its share of the memory budget:
+//     on a broker with hundreds of thousands of topics the least recently
+//     updated topics are dropped from it (see latestBudgetDivisor).
+//
+// Every retained message is charged exactly once: to recentBytes while it is
+// in the recent window, then to latestBytes if the latest map pins it after
+// eviction. recentBytes + latestBytes is what the budget bounds.
 type MessageHistory struct {
 	mutex       sync.Mutex
 	recent      []*MqttMessage
 	head        int
-	latest      map[string]*MqttMessage
-	totalBytes  int64
+	latest      map[string]*latestEntry
+	recentBytes int64
+	latestBytes int64
 	budgetBytes int64
-	// latestExtraBytes tracks the bytes of newest-per-topic messages that have
-	// been evicted from the recent window but are still pinned by the latest
-	// map. Counted in TotalBytes only; never part of budget eviction.
-	latestExtraBytes int64
+	// lruOldest/lruNewest bound the list of pinned latest entries, ordered by
+	// when each topic last received a message: lruOldest is the least recently
+	// updated topic and the first to be dropped. Unpinned entries are not
+	// listed; their topics are all newer than every pinned one, because a
+	// topic pins exactly when its newest message leaves the recent window.
+	lruOldest *latestEntry
+	lruNewest *latestEntry
+	// droppedTopics counts latest entries discarded under budget pressure.
+	droppedTopics int64
 }
 
 func newMessageHistory() *MessageHistory {
 	return &MessageHistory{
 		recent:      make([]*MqttMessage, 0, 1024),
-		latest:      make(map[string]*MqttMessage),
+		latest:      make(map[string]*latestEntry),
 		budgetBytes: DefaultMemoryBudgetBytes,
 	}
 }
@@ -54,14 +99,14 @@ func (m *MessageHistory) SetBudgetBytes(budget int64) {
 	m.evictLocked()
 }
 
-// TotalBytes returns the estimated bytes of message history currently held
-// in memory. Budget eviction still uses recent-slice bytes only (totalBytes);
-// latestExtraBytes is the newest-per-topic messages retained after eviction,
-// added here so the readout reflects what is genuinely held.
+// TotalBytes returns the estimated bytes of message history currently held in
+// memory: the recent window plus the newest-per-topic messages pinned outside
+// it. This is the figure the budget bounds, so the settings readout and the
+// budget describe the same thing.
 func (m *MessageHistory) TotalBytes() int64 {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	return m.totalBytes + m.latestExtraBytes
+	return m.recentBytes + m.latestBytes
 }
 
 // Clear empties the store but preserves the configured budget.
@@ -70,9 +115,11 @@ func (m *MessageHistory) Clear() {
 	defer m.mutex.Unlock()
 	m.recent = m.recent[:0]
 	m.head = 0
-	m.latest = make(map[string]*MqttMessage)
-	m.totalBytes = 0
-	m.latestExtraBytes = 0
+	m.latest = make(map[string]*latestEntry)
+	m.recentBytes = 0
+	m.latestBytes = 0
+	m.lruOldest = nil
+	m.lruNewest = nil
 }
 
 func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
@@ -80,33 +127,117 @@ func (m *MessageHistory) addMessageToHistory(message MqttMessage) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	p := &msg
-	if prev, ok := m.latest[p.Topic]; ok && prev.evictedFromRecent {
-		// The previous latest was pinned outside the recent window; it is now
-		// released, so stop counting it.
-		m.latestExtraBytes -= int64(prev.estimatedBytes())
+	entry, ok := m.latest[p.Topic]
+	if ok {
+		if entry.pinned {
+			// The previous newest message was held only by this map; replacing
+			// it releases those bytes and makes the topic recent again.
+			m.latestBytes -= pinnedCost(entry.msg)
+			m.unlinkLocked(entry)
+			entry.pinned = false
+		}
+		entry.msg = p
+	} else {
+		m.latest[p.Topic] = &latestEntry{msg: p, topic: p.Topic}
 	}
-	m.latest[p.Topic] = p
 	m.recent = append(m.recent, p)
-	m.totalBytes += int64(p.estimatedBytes())
+	m.recentBytes += int64(p.estimatedBytes())
 	m.evictLocked()
 }
 
-// evictLocked drops oldest messages until under budget. Caller holds mutex.
+// pinnedCost is what a latest entry costs once it is the sole holder of its
+// message.
+func pinnedCost(msg *MqttMessage) int64 {
+	return int64(msg.estimatedBytes()) + latestEntryOverhead
+}
+
+// evictLocked drops retained data until the store is back under budget.
+// Caller holds mutex.
+//
+// Priority: trim the latest map first if it is over its share, otherwise drop
+// the oldest recent message, and only once the recent window is drained fall
+// back to trimming latest below its share. Each iteration either frees bytes
+// or moves a message's charge from recent to latest, so the loop terminates.
 func (m *MessageHistory) evictLocked() {
-	for m.totalBytes > m.budgetBytes && m.head < len(m.recent) {
-		old := m.recent[m.head]
-		m.recent[m.head] = nil // release for GC
-		m.head++
-		m.totalBytes -= int64(old.estimatedBytes())
-		if m.latest[old.Topic] == old {
-			// Still the newest message for its topic, so the latest map pins it
-			// in memory; count it towards the readout.
-			old.evictedFromRecent = true
-			m.latestExtraBytes += int64(old.estimatedBytes())
+	latestBudget := m.budgetBytes / latestBudgetDivisor
+	for m.recentBytes+m.latestBytes > m.budgetBytes {
+		if m.latestBytes > latestBudget && m.lruOldest != nil {
+			m.dropOldestLatestLocked()
+			continue
 		}
+		if m.head < len(m.recent) {
+			m.evictOldestRecentLocked()
+			continue
+		}
+		if m.lruOldest != nil {
+			m.dropOldestLatestLocked()
+			continue
+		}
+		// Nothing retained left to drop: a single message larger than the
+		// whole budget. Keep it rather than spin.
+		break
 	}
-	// Compact the backing array once head has consumed half of it, so the
-	// dead prefix is reclaimed rather than growing unbounded.
+	m.compactLocked()
+}
+
+// evictOldestRecentLocked drops recent[head]. If that message is still the
+// newest for its topic the latest map becomes its only holder, so the entry is
+// pinned: its bytes move from recentBytes to latestBytes and it joins the LRU
+// list as the most recently updated pinned topic.
+func (m *MessageHistory) evictOldestRecentLocked() {
+	old := m.recent[m.head]
+	m.recent[m.head] = nil // release for GC
+	m.head++
+	m.recentBytes -= int64(old.estimatedBytes())
+	if entry, ok := m.latest[old.Topic]; ok && entry.msg == old {
+		entry.pinned = true
+		m.latestBytes += pinnedCost(old)
+		m.linkNewestLocked(entry)
+	}
+}
+
+// dropOldestLatestLocked discards the least recently updated pinned topic.
+// That topic's last value is gone from memory: selecting it in the tree falls
+// back to whatever the frontend already holds.
+func (m *MessageHistory) dropOldestLatestLocked() {
+	entry := m.lruOldest
+	m.latestBytes -= pinnedCost(entry.msg)
+	m.unlinkLocked(entry)
+	delete(m.latest, entry.topic)
+	entry.msg = nil
+	m.droppedTopics++
+}
+
+func (m *MessageHistory) linkNewestLocked(entry *latestEntry) {
+	entry.prev = m.lruNewest
+	entry.next = nil
+	if m.lruNewest != nil {
+		m.lruNewest.next = entry
+	}
+	m.lruNewest = entry
+	if m.lruOldest == nil {
+		m.lruOldest = entry
+	}
+}
+
+func (m *MessageHistory) unlinkLocked(entry *latestEntry) {
+	if entry.prev != nil {
+		entry.prev.next = entry.next
+	} else if m.lruOldest == entry {
+		m.lruOldest = entry.next
+	}
+	if entry.next != nil {
+		entry.next.prev = entry.prev
+	} else if m.lruNewest == entry {
+		m.lruNewest = entry.prev
+	}
+	entry.prev = nil
+	entry.next = nil
+}
+
+// compactLocked reclaims the dead prefix of the recent backing array once head
+// has consumed half of it, rather than letting it grow unbounded.
+func (m *MessageHistory) compactLocked() {
 	if m.head > 0 && m.head*2 >= len(m.recent) {
 		n := copy(m.recent, m.recent[m.head:])
 		for i := n; i < len(m.recent); i++ {
@@ -119,7 +250,9 @@ func (m *MessageHistory) evictLocked() {
 
 // GetTopicHistory returns the retained messages for a topic in arrival order.
 // If the topic's messages have all aged out of the recent window, its latest
-// value is still returned so a tree-click is never empty.
+// value is still returned so a tree-click is never empty — unless the topic
+// was also dropped from the latest map under budget pressure, which only
+// happens at extreme topic cardinality.
 func (m *MessageHistory) GetTopicHistory(topic string) ([]MqttMessage, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -130,8 +263,8 @@ func (m *MessageHistory) GetTopicHistory(topic string) ([]MqttMessage, error) {
 		}
 	}
 	if len(result) == 0 {
-		if latest, ok := m.latest[topic]; ok {
-			return []MqttMessage{*latest}, nil
+		if entry, ok := m.latest[topic]; ok {
+			return []MqttMessage{*entry.msg}, nil
 		}
 		return nil, fmt.Errorf("topic not found in message history")
 	}
@@ -156,9 +289,9 @@ func (m *MessageHistory) GetHistoryByTopicPrefix(prefix string) []MqttMessage {
 			inWindow[m.recent[i].Topic] = true
 		}
 	}
-	for topic, latest := range m.latest {
+	for topic, entry := range m.latest {
 		if strings.HasPrefix(topic, prefix) && !inWindow[topic] {
-			result = append(result, *latest)
+			result = append(result, *entry.msg)
 		}
 	}
 	return result
@@ -174,9 +307,9 @@ func (m *MessageHistory) GetAllHistory() map[string][]MqttMessage {
 		msg := *m.recent[i]
 		out[msg.Topic] = append(out[msg.Topic], msg)
 	}
-	for topic, latest := range m.latest {
+	for topic, entry := range m.latest {
 		if _, ok := out[topic]; !ok {
-			out[topic] = []MqttMessage{*latest}
+			out[topic] = []MqttMessage{*entry.msg}
 		}
 	}
 	return out

--- a/backend/mqtt/history_calibration_test.go
+++ b/backend/mqtt/history_calibration_test.go
@@ -43,7 +43,7 @@ func TestHistoryCalibration(t *testing.T) {
 	runtime.ReadMemStats(&after)
 
 	realBytes := float64(after.HeapAlloc - before.HeapAlloc)
-	accounted := float64(h.totalBytes)
+	accounted := float64(h.TotalBytes())
 	ratio := realBytes / accounted
 
 	if ratio < 0.3 || ratio > 1.5 {

--- a/backend/mqtt/history_test.go
+++ b/backend/mqtt/history_test.go
@@ -172,6 +172,40 @@ func TestHistoryClearPreservesBudget(t *testing.T) {
 	}
 }
 
+func TestHistoryTotalBytesCountsPinnedLatest(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := estBytes(msg("topic/00", 1024))
+	// Budget for ~3 messages, then one message on each of many distinct topics
+	// so most age out of the recent window but stay pinned in the latest map.
+	h.SetBudgetBytes(int64(perMsg * 3))
+	const topics = 20
+	for i := 0; i < topics; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("topic/%02d", i), 1024))
+	}
+
+	if h.TotalBytes() <= h.budgetBytes {
+		t.Errorf("expected TotalBytes %d to exceed budget %d (pinned latest messages counted)", h.TotalBytes(), h.budgetBytes)
+	}
+
+	// Republishing to topics whose latest was evicted-and-pinned must not grow
+	// latestExtraBytes unboundedly: each replacement decrements the old pin, so
+	// the extra term stays bounded by topic cardinality.
+	for i := 0; i < 100; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("topic/%02d", i%topics), 1024))
+	}
+	if max := int64(topics * perMsg); h.latestExtraBytes > max {
+		t.Errorf("latestExtraBytes %d exceeds topic-cardinality bound %d", h.latestExtraBytes, max)
+	}
+	if h.latestExtraBytes < 0 {
+		t.Errorf("latestExtraBytes went negative: %d", h.latestExtraBytes)
+	}
+
+	h.Clear()
+	if h.TotalBytes() != 0 {
+		t.Errorf("expected TotalBytes 0 after clear, got %d", h.TotalBytes())
+	}
+}
+
 func TestHistoryUnknownTopic(t *testing.T) {
 	h := newMessageHistory()
 	if _, err := h.GetTopicHistory("nope"); err == nil {

--- a/backend/mqtt/history_test.go
+++ b/backend/mqtt/history_test.go
@@ -51,21 +51,22 @@ func TestHistoryEvictsOldestOverBudget(t *testing.T) {
 	if len(got) == 0 || len(got) > 6 {
 		t.Errorf("expected ~5 retained under budget, got %d", len(got))
 	}
-	if h.totalBytes > h.budgetBytes {
-		t.Errorf("totalBytes %d exceeds budget %d after eviction", h.totalBytes, h.budgetBytes)
+	if h.TotalBytes() > h.budgetBytes {
+		t.Errorf("retained bytes %d exceed budget %d after eviction", h.TotalBytes(), h.budgetBytes)
 	}
 }
 
 func TestHistoryKeepsLatestPerTopicAfterEviction(t *testing.T) {
 	h := newMessageHistory()
 	perMsg := estBytes(msg("x", 1024))
-	// Budget for ~3 messages.
-	h.SetBudgetBytes(int64(perMsg * 3))
+	// Budget for ~12 messages, so the latest map's quarter share comfortably
+	// holds the one quiet topic.
+	h.SetBudgetBytes(int64(perMsg * 12))
 
 	// One message on a low-traffic topic, then flood a different topic so the
 	// low-traffic topic's only message ages out of the recent window.
 	h.addMessageToHistory(msg("low/traffic", 1024))
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 50; i++ {
 		h.addMessageToHistory(msg("busy/topic", 1024))
 	}
 
@@ -82,10 +83,10 @@ func TestHistoryKeepsLatestPerTopicAfterEviction(t *testing.T) {
 func TestHistoryGetAllIncludesEvictedTopicLatest(t *testing.T) {
 	h := newMessageHistory()
 	perMsg := estBytes(msg("x", 1024))
-	h.SetBudgetBytes(int64(perMsg * 3))
+	h.SetBudgetBytes(int64(perMsg * 12))
 
 	h.addMessageToHistory(msg("topic/a", 1024))
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 50; i++ {
 		h.addMessageToHistory(msg("topic/b", 1024))
 	}
 
@@ -123,12 +124,12 @@ func TestHistoryGetByTopicPrefixFiltersAndOrders(t *testing.T) {
 func TestHistoryGetByTopicPrefixIncludesEvictedLatest(t *testing.T) {
 	h := newMessageHistory()
 	perMsg := estBytes(msg("x", 1024))
-	h.SetBudgetBytes(int64(perMsg * 3))
+	h.SetBudgetBytes(int64(perMsg * 12))
 
 	// One $SYS message, then flood a different $SYS topic so the first ages out
 	// of the recent window; its latest value must still be returned.
 	h.addMessageToHistory(msg("$SYS/broker/uptime", 1024))
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 50; i++ {
 		h.addMessageToHistory(msg("$SYS/broker/load", 1024))
 	}
 
@@ -161,8 +162,11 @@ func TestHistoryClearPreservesBudget(t *testing.T) {
 		h.addMessageToHistory(msg("a", 100))
 	}
 	h.Clear()
-	if h.totalBytes != 0 || len(h.recent) != 0 || h.head != 0 {
-		t.Errorf("expected empty after clear, got bytes=%d recent=%d head=%d", h.totalBytes, len(h.recent), h.head)
+	if h.TotalBytes() != 0 || len(h.recent) != 0 || h.head != 0 {
+		t.Errorf("expected empty after clear, got bytes=%d recent=%d head=%d", h.TotalBytes(), len(h.recent), h.head)
+	}
+	if h.lruOldest != nil || h.lruNewest != nil {
+		t.Error("expected empty latest LRU list after clear")
 	}
 	if h.budgetBytes != 123456 {
 		t.Errorf("expected budget preserved after clear, got %d", h.budgetBytes)
@@ -175,35 +179,181 @@ func TestHistoryClearPreservesBudget(t *testing.T) {
 func TestHistoryTotalBytesCountsPinnedLatest(t *testing.T) {
 	h := newMessageHistory()
 	perMsg := estBytes(msg("topic/00", 1024))
-	// Budget for ~3 messages, then one message on each of many distinct topics
-	// so most age out of the recent window but stay pinned in the latest map.
-	h.SetBudgetBytes(int64(perMsg * 3))
+	// Budget for ~12 messages, then one message on each of a few distinct
+	// topics so most age out of the recent window but stay pinned in the
+	// latest map. Their bytes must show up in the readout.
+	h.SetBudgetBytes(int64(perMsg * 12))
 	const topics = 20
 	for i := 0; i < topics; i++ {
 		h.addMessageToHistory(msg(fmt.Sprintf("topic/%02d", i), 1024))
 	}
 
-	if h.TotalBytes() <= h.budgetBytes {
-		t.Errorf("expected TotalBytes %d to exceed budget %d (pinned latest messages counted)", h.TotalBytes(), h.budgetBytes)
+	if h.latestBytes == 0 {
+		t.Error("expected pinned latest messages to be charged to latestBytes")
+	}
+	if h.TotalBytes() != h.recentBytes+h.latestBytes {
+		t.Errorf("TotalBytes %d does not match recent %d + latest %d", h.TotalBytes(), h.recentBytes, h.latestBytes)
 	}
 
-	// Republishing to topics whose latest was evicted-and-pinned must not grow
-	// latestExtraBytes unboundedly: each replacement decrements the old pin, so
-	// the extra term stays bounded by topic cardinality.
-	for i := 0; i < 100; i++ {
+	// Republishing to topics whose latest was pinned must not grow latestBytes
+	// unboundedly: each replacement releases the old pin.
+	for i := 0; i < 500; i++ {
 		h.addMessageToHistory(msg(fmt.Sprintf("topic/%02d", i%topics), 1024))
 	}
-	if max := int64(topics * perMsg); h.latestExtraBytes > max {
-		t.Errorf("latestExtraBytes %d exceeds topic-cardinality bound %d", h.latestExtraBytes, max)
+	if max := int64(topics * (perMsg + latestEntryOverhead)); h.latestBytes > max {
+		t.Errorf("latestBytes %d exceeds topic-cardinality bound %d", h.latestBytes, max)
 	}
-	if h.latestExtraBytes < 0 {
-		t.Errorf("latestExtraBytes went negative: %d", h.latestExtraBytes)
+	if h.latestBytes < 0 || h.recentBytes < 0 {
+		t.Errorf("byte counters went negative: recent=%d latest=%d", h.recentBytes, h.latestBytes)
 	}
+	assertHistoryAccounting(t, h)
 
 	h.Clear()
 	if h.TotalBytes() != 0 {
 		t.Errorf("expected TotalBytes 0 after clear, got %d", h.TotalBytes())
 	}
+}
+
+// assertHistoryAccounting recomputes both byte counters from scratch and
+// checks the pinned-entry invariants, so a bookkeeping slip in eviction can't
+// pass unnoticed.
+func assertHistoryAccounting(t *testing.T, h *MessageHistory) {
+	t.Helper()
+	var wantRecent, wantLatest int64
+	inWindow := map[*MqttMessage]bool{}
+	for i := h.head; i < len(h.recent); i++ {
+		wantRecent += int64(h.recent[i].estimatedBytes())
+		inWindow[h.recent[i]] = true
+	}
+	pinned := 0
+	for topic, entry := range h.latest {
+		if entry.topic != topic {
+			t.Errorf("latest entry key %q does not match entry topic %q", topic, entry.topic)
+		}
+		if entry.pinned == inWindow[entry.msg] {
+			t.Errorf("topic %q: pinned=%v but inRecentWindow=%v", topic, entry.pinned, inWindow[entry.msg])
+		}
+		if entry.pinned {
+			pinned++
+			wantLatest += pinnedCost(entry.msg)
+		}
+	}
+	if wantRecent != h.recentBytes {
+		t.Errorf("recentBytes %d, recomputed %d", h.recentBytes, wantRecent)
+	}
+	if wantLatest != h.latestBytes {
+		t.Errorf("latestBytes %d, recomputed %d", h.latestBytes, wantLatest)
+	}
+	listed := 0
+	for e := h.lruOldest; e != nil; e = e.next {
+		listed++
+		if !e.pinned {
+			t.Errorf("unpinned topic %q is in the LRU list", e.topic)
+		}
+		if e.next != nil && e.next.prev != e {
+			t.Errorf("LRU list links are inconsistent at topic %q", e.topic)
+		}
+	}
+	if listed != pinned {
+		t.Errorf("LRU list holds %d entries, %d topics are pinned", listed, pinned)
+	}
+}
+
+func TestHistoryBoundsLatestMapAtHighCardinality(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := estBytes(msg("sensors/00000/temperature", 200))
+	// A budget worth ~500 messages against 50k distinct topics: without a
+	// bound the latest map alone would hold 50k messages regardless of it.
+	budget := int64(perMsg * 500)
+	h.SetBudgetBytes(budget)
+	const topics = 50000
+	for i := 0; i < topics; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("sensors/%05d/temperature", i), 200))
+	}
+
+	if h.TotalBytes() > budget {
+		t.Errorf("retained bytes %d exceed budget %d at %d topics", h.TotalBytes(), budget, topics)
+	}
+	if len(h.latest) >= topics {
+		t.Errorf("latest map kept %d of %d topics; expected it to be trimmed", len(h.latest), topics)
+	}
+	if h.droppedTopics == 0 {
+		t.Error("expected topics to be dropped from the latest map")
+	}
+	if latestBudget := budget / latestBudgetDivisor; h.latestBytes > latestBudget {
+		t.Errorf("latestBytes %d exceeds its %d share of the budget", h.latestBytes, latestBudget)
+	}
+	// The recent window must not have been starved by the latest map.
+	if h.recentBytes == 0 {
+		t.Error("expected the recent window to keep messages alongside the latest map")
+	}
+	assertHistoryAccounting(t, h)
+}
+
+func TestHistoryDropsLeastRecentlyUpdatedTopicFirst(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := estBytes(msg("t/000", 1024))
+	// Room for ~2 pinned latest entries (a quarter of ~12 messages).
+	h.SetBudgetBytes(int64(perMsg * 12))
+
+	// Three quiet topics in a known order, then enough traffic on a busy topic
+	// to push all three out of the recent window and over the latest share.
+	for _, topic := range []string{"quiet/a", "quiet/b", "quiet/c"} {
+		h.addMessageToHistory(msg(topic, 1024))
+	}
+	for i := 0; i < 50; i++ {
+		h.addMessageToHistory(msg("busy/topic", 1024))
+	}
+
+	if _, ok := h.latest["quiet/a"]; ok {
+		t.Error("expected the least recently updated topic (quiet/a) to be dropped first")
+	}
+	if _, ok := h.latest["quiet/c"]; !ok {
+		t.Error("expected the most recently updated quiet topic (quiet/c) to be kept")
+	}
+	assertHistoryAccounting(t, h)
+}
+
+func TestHistoryKeepsEveryTopicAtNormalCardinality(t *testing.T) {
+	h := newMessageHistory()
+	// A realistic broker: 5,000 topics, 200 B payloads, default budget. Every
+	// topic must still answer with its last value.
+	h.SetBudgetBytes(DefaultMemoryBudgetBytes)
+	const topics = 5000
+	for round := 0; round < 3; round++ {
+		for i := 0; i < topics; i++ {
+			h.addMessageToHistory(msg(fmt.Sprintf("factory/line%02d/sensor%03d", i%50, i/50), 200))
+		}
+	}
+
+	if h.droppedTopics != 0 {
+		t.Errorf("dropped %d topics at normal cardinality; the tree must keep them all", h.droppedTopics)
+	}
+	for i := 0; i < topics; i++ {
+		topic := fmt.Sprintf("factory/line%02d/sensor%03d", i%50, i/50)
+		if _, err := h.GetTopicHistory(topic); err != nil {
+			t.Fatalf("expected history for %s, got %v", topic, err)
+		}
+	}
+}
+
+func TestHistoryLoweringBudgetTrimsLatestMap(t *testing.T) {
+	h := newMessageHistory()
+	h.SetBudgetBytes(DefaultMemoryBudgetBytes)
+	const topics = 20000
+	for i := 0; i < topics; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("sensors/%05d", i), 200))
+	}
+	if h.droppedTopics != 0 {
+		t.Fatalf("expected no drops under the default budget, got %d", h.droppedTopics)
+	}
+
+	tightened := int64(64 * 1024)
+	h.SetBudgetBytes(tightened)
+	if h.TotalBytes() > tightened {
+		t.Errorf("retained bytes %d exceed the tightened budget %d", h.TotalBytes(), tightened)
+	}
+	assertHistoryAccounting(t, h)
 }
 
 func TestHistoryUnknownTopic(t *testing.T) {

--- a/backend/mqtt/history_test.go
+++ b/backend/mqtt/history_test.go
@@ -225,7 +225,7 @@ func assertHistoryAccounting(t *testing.T, h *MessageHistory) {
 		wantRecent += int64(h.recent[i].estimatedBytes())
 		inWindow[h.recent[i]] = true
 	}
-	pinned := 0
+	pinned, protected := 0, 0
 	for topic, entry := range h.latest {
 		if entry.topic != topic {
 			t.Errorf("latest entry key %q does not match entry topic %q", topic, entry.topic)
@@ -233,10 +233,19 @@ func assertHistoryAccounting(t *testing.T, h *MessageHistory) {
 		if entry.pinned == inWindow[entry.msg] {
 			t.Errorf("topic %q: pinned=%v but inRecentWindow=%v", topic, entry.pinned, inWindow[entry.msg])
 		}
+		if entry.protected && !entry.pinned {
+			t.Errorf("topic %q is protected but not pinned", topic)
+		}
 		if entry.pinned {
 			pinned++
 			wantLatest += pinnedCost(entry.msg)
 		}
+		if entry.protected {
+			protected++
+		}
+	}
+	if protected != h.protectedSysTopics {
+		t.Errorf("protectedSysTopics %d, recomputed %d", h.protectedSysTopics, protected)
 	}
 	if wantRecent != h.recentBytes {
 		t.Errorf("recentBytes %d, recomputed %d", h.recentBytes, wantRecent)
@@ -254,9 +263,109 @@ func assertHistoryAccounting(t *testing.T, h *MessageHistory) {
 			t.Errorf("LRU list links are inconsistent at topic %q", e.topic)
 		}
 	}
-	if listed != pinned {
-		t.Errorf("LRU list holds %d entries, %d topics are pinned", listed, pinned)
+	if listed != pinned-protected {
+		t.Errorf("LRU list holds %d entries, %d topics are pinned and evictable", listed, pinned-protected)
 	}
+}
+
+func TestHistoryKeepsSysTopicsWhenTrimmingLatest(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := estBytes(msg("sensors/00000", 200))
+	h.SetBudgetBytes(int64(perMsg * 500))
+
+	// A $SYS value published once at connect, the way a broker announces its
+	// version, then enough traffic across enough topics to force the latest
+	// map to trim. The $SYS value is the oldest of all, so a plain LRU would
+	// drop it first, and the broker status window would lose it for good.
+	h.addMessageToHistory(msg("$SYS/broker/version", 200))
+	for i := 0; i < 50000; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("sensors/%05d", i), 200))
+	}
+
+	if h.droppedTopics == 0 {
+		t.Fatal("expected the latest map to be trimmed in this scenario")
+	}
+	got, err := h.GetTopicHistory("$SYS/broker/version")
+	if err != nil {
+		t.Fatalf("expected the $SYS value to survive trimming, got %v", err)
+	}
+	if len(got) != 1 || got[0].Topic != "$SYS/broker/version" {
+		t.Errorf("unexpected $SYS history: %+v", got)
+	}
+	assertHistoryAccounting(t, h)
+}
+
+func TestHistoryCapsProtectedSysTopics(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := estBytes(msg("$SYS/broker/000000", 200))
+	h.SetBudgetBytes(int64(perMsg * 8000))
+
+	// More $SYS topics than the protection cap, then traffic to age them all
+	// out and force trimming. Protection must stop at the cap so a broker with
+	// a huge $SYS tree cannot pin unbounded memory.
+	for i := 0; i < maxProtectedSysTopics*2; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("$SYS/broker/%06d", i), 200))
+	}
+	for i := 0; i < 50000; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("sensors/%05d", i), 200))
+	}
+
+	if h.protectedSysTopics > maxProtectedSysTopics {
+		t.Errorf("protected %d $SYS topics, cap is %d", h.protectedSysTopics, maxProtectedSysTopics)
+	}
+	if h.TotalBytes() > h.budgetBytes+int64(maxProtectedSysTopics)*(int64(perMsg)+latestEntryOverhead) {
+		t.Errorf("retained bytes %d exceed budget %d by more than the protected allowance", h.TotalBytes(), h.budgetBytes)
+	}
+	assertHistoryAccounting(t, h)
+}
+
+func TestHistoryOversizedMessageDoesNotClearLatestMap(t *testing.T) {
+	h := newMessageHistory()
+	perMsg := estBytes(msg("quiet/000", 200))
+	budget := int64(perMsg * 400)
+	h.SetBudgetBytes(budget)
+
+	// Fill the latest map with quiet topics that have aged out.
+	for i := 0; i < 200; i++ {
+		h.addMessageToHistory(msg(fmt.Sprintf("quiet/%03d", i), 200))
+	}
+	for i := 0; i < 400; i++ {
+		h.addMessageToHistory(msg("busy/topic", 200))
+	}
+	pinnedBefore := 0
+	for _, entry := range h.latest {
+		if entry.pinned {
+			pinnedBefore++
+		}
+	}
+	if pinnedBefore == 0 {
+		t.Fatal("expected quiet topics to be pinned before the oversized message")
+	}
+
+	// One message larger than the whole latest share, then enough traffic to
+	// age it out of the recent window. Pinning it at that point would evict
+	// every other topic to make room for a single value.
+	h.addMessageToHistory(msg("huge/topic", int(budget/latestBudgetDivisor)+1))
+	for i := 0; i < 400; i++ {
+		h.addMessageToHistory(msg("busy/topic", 200))
+	}
+
+	pinnedAfter := 0
+	for _, entry := range h.latest {
+		if entry.pinned {
+			pinnedAfter++
+		}
+	}
+	if pinnedAfter == 0 {
+		t.Error("an oversized message wiped every pinned topic from the latest map")
+	}
+	if _, ok := h.latest["huge/topic"]; ok {
+		t.Error("expected the oversized message to be dropped rather than pinned")
+	}
+	if h.TotalBytes() > h.budgetBytes {
+		t.Errorf("retained bytes %d exceed budget %d", h.TotalBytes(), h.budgetBytes)
+	}
+	assertHistoryAccounting(t, h)
 }
 
 func TestHistoryBoundsLatestMapAtHighCardinality(t *testing.T) {

--- a/backend/mqtt/latest_map_calibration_test.go
+++ b/backend/mqtt/latest_map_calibration_test.go
@@ -1,0 +1,69 @@
+package mqtt
+
+// Guards the relationship between what a pinned latest-per-topic entry is
+// charged (message bytes + latestEntryOverhead) and what it actually costs on
+// the heap, so the topic-cardinality bound doesn't silently drift from real
+// memory use.
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestLatestMapCalibration(t *testing.T) {
+	const topics = 20000
+	h := newMessageHistory()
+	h.SetBudgetBytes(1 << 40) // effectively unbounded; we drive eviction by hand
+
+	runtime.GC()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	now := time.Now()
+	for i := 0; i < topics; i++ {
+		h.addMessageToHistory(MqttMessage{
+			Id:      uuid.NewString(),
+			Topic:   fmt.Sprintf("telemetry/group-%03d/device-%06d/temperature", i%50, i),
+			Payload: []byte(fmt.Sprintf(`{"value": %d.%03d, "unit": "C"}`, i%100, i%1000)),
+			TimeMs:  now.UnixMilli() + int64(i),
+			Time:    now,
+		})
+	}
+
+	// Age every message out of the recent window so the latest map is the sole
+	// holder, then drop the window itself. What survives the GC below is the
+	// latest map and nothing else, which is exactly what latestBytes claims.
+	for h.head < len(h.recent) {
+		h.evictOldestRecentLocked()
+	}
+	h.recent = nil
+	h.head = 0
+	h.recentBytes = 0
+	if len(h.latest) != topics {
+		t.Fatalf("expected %d pinned topics, got %d", topics, len(h.latest))
+	}
+
+	runtime.GC()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	realBytes := float64(after.HeapAlloc - before.HeapAlloc)
+	accounted := float64(h.latestBytes)
+	ratio := realBytes / accounted
+
+	t.Logf("latest map: %d topics, real %.0f B/topic, accounted %.0f B/topic (ratio %.2f)",
+		topics, realBytes/topics, accounted/topics, ratio)
+
+	if ratio < 0.3 || ratio > 1.5 {
+		t.Fatalf(
+			"latest-map accounting has drifted from real heap cost: real/accounted ratio %.2f (real %.0f B/topic, accounted %.0f B/topic) is outside the expected [0.3, 1.5] band — recalibrate latestEntryOverhead in history.go",
+			ratio, realBytes/topics, accounted/topics,
+		)
+	}
+}

--- a/backend/mqtt/manager.go
+++ b/backend/mqtt/manager.go
@@ -60,6 +60,12 @@ func (m *MqttManager) ClearConnectionHistory() {
 	m.MessageHistory.Clear()
 }
 
+// HistoryBytes returns the estimated bytes of in-RAM message history this
+// connection currently holds.
+func (m *MqttManager) HistoryBytes() int64 {
+	return m.MessageHistory.TotalBytes()
+}
+
 // SetMessageMemoryBudget bounds the in-RAM message history for this connection.
 func (m *MqttManager) SetMessageMemoryBudget(budgetBytes int64) {
 	m.MessageHistory.SetBudgetBytes(budgetBytes)

--- a/backend/mqtt/message.go
+++ b/backend/mqtt/message.go
@@ -18,6 +18,11 @@ type MqttMessage struct {
 	TimeMs               int64              `json:"timeMs"`
 	MiddlewareProperties *map[string]any    `json:"middlewareProperties,omitempty"`
 	Time                 time.Time
+
+	// evictedFromRecent marks a message that has been evicted from the history's
+	// recent window but is still pinned by the latest-per-topic map. Unexported
+	// so it never serialises; only read/written under the history mutex.
+	evictedFromRecent bool
 }
 
 // estimatedBytes approximates the heap cost of retaining this message, used to
@@ -28,8 +33,7 @@ type MqttMessage struct {
 // heap (ratio 0.70), i.e. deliberately conservative — see
 // history_calibration_test.go.
 func (m *MqttMessage) estimatedBytes() int {
-	// Fixed per-message overhead: struct fields, id/uuid, time.Time, and the
-	// always-allocated property/middleware map headers for v5 messages.
+	// Fixed per-message overhead: struct fields, id/uuid and time.Time.
 	const baseOverhead = 256
 	n := baseOverhead + len(m.Topic) + len(m.Payload) + len(m.Id)
 	if m.Properties != nil {

--- a/backend/mqtt/message.go
+++ b/backend/mqtt/message.go
@@ -18,11 +18,6 @@ type MqttMessage struct {
 	TimeMs               int64              `json:"timeMs"`
 	MiddlewareProperties *map[string]any    `json:"middlewareProperties,omitempty"`
 	Time                 time.Time
-
-	// evictedFromRecent marks a message that has been evicted from the history's
-	// recent window but is still pinned by the latest-per-topic map. Unexported
-	// so it never serialises; only read/written under the history mutex.
-	evictedFromRecent bool
 }
 
 // estimatedBytes approximates the heap cost of retaining this message, used to

--- a/backend/mqtt/message.go
+++ b/backend/mqtt/message.go
@@ -33,6 +33,10 @@ func (m *MqttMessage) estimatedBytes() int {
 	const baseOverhead = 256
 	n := baseOverhead + len(m.Topic) + len(m.Payload) + len(m.Id)
 	if m.Properties != nil {
+		// v5 always allocates the properties struct plus the UserProperties and
+		// MiddlewareProperties maps, measured at ~450 B beyond the counted strings.
+		const v5Overhead = 448
+		n += v5Overhead
 		n += len(m.Properties.CorrelationData) +
 			len(m.Properties.ContentType) +
 			len(m.Properties.ResponseTopic)

--- a/docs/specs/bounded-message-memory.md
+++ b/docs/specs/bounded-message-memory.md
@@ -47,6 +47,11 @@ the memory budget:
 
 - **Latest-per-topic** map kept always (tiny, bounded by topic count) — feeds
   the live tree (already how the frontend works).
+
+  Correction (measured, 2026-08): this map is not counted against the budget
+  and costs roughly 430 B of heap per distinct topic, so very high topic
+  cardinality grows memory beyond the cap. A bound for this cache is future
+  work.
 - **Recent ring** of full `MqttMessage`s, evicting **oldest globally** when the
   estimated retained bytes exceed the memory budget. Byte estimate =
   Σ(payload len + topic len + fixed per-message overhead). Maintain a running

--- a/docs/specs/bounded-message-memory.md
+++ b/docs/specs/bounded-message-memory.md
@@ -71,6 +71,17 @@ the memory budget:
   broker never reaches the share: at 5,000 topics the map costs ~2 MB against
   a 512 MB default.
 
+  Two carve-outs, both found by reviewing the eviction policy adversarially:
+
+  - **`$SYS/` topics are protected** (up to 1,024 of them) and never picked
+    for eviction. Some are published once as retained and never again (a
+    broker's version), which makes them the oldest entries in the map and so
+    the first a plain LRU would drop, taking the broker status window's
+    backfill with them. The cap keeps the exemption bounded.
+  - **A message too big for the whole latest share is never pinned.** It
+    would evict every other topic to make room for one value. The topic
+    loses the value that did not fit instead.
+
   Consequence: at extreme cardinality a topic can appear in the tree (the
   frontend keeps its own latest-per-topic) with no history left in the
   backend, so `GetMessageHistory` rejects. The frontend treats that as an

--- a/docs/specs/bounded-message-memory.md
+++ b/docs/specs/bounded-message-memory.md
@@ -45,14 +45,36 @@ So the only consumers of full per-topic history are the selected-topic
 Replace the unbounded per-connection map with a **bounded store** governed by
 the memory budget:
 
-- **Latest-per-topic** map kept always (tiny, bounded by topic count) — feeds
-  the live tree (already how the frontend works).
+- **Latest-per-topic** map kept always — feeds the tree's last-value display
+  for topics whose messages have aged out of the recent ring.
 
-  Correction (measured, 2026-08): this map is not counted against the budget
+  Correction (measured, 2026-08): this map was not counted against the budget
   and retains each topic's newest message in full, payload included, after it
-  ages out of the recent window, so very high topic cardinality grows memory
-  beyond the cap. The roughly 430 B of heap per distinct topic measured here
-  was with ~200 B payloads. A bound for this cache is future work.
+  ages out of the recent window, so very high topic cardinality grew memory
+  beyond the cap regardless of the setting. Measured at roughly 430 B of heap
+  per distinct topic with ~200 B payloads; at 200k topics that is ~86 MB
+  outside the budget.
+
+  Bounded (2026-08): every retained message is now charged exactly once —
+  to the recent ring while it is in the window, then to the latest map once
+  the map is its only holder. The budget bounds the sum, and the latest map
+  may take at most a **quarter** of the budget. Over that share, the least
+  recently updated topics are dropped from it, oldest first.
+
+  The quarter share exists because the two stores serve different things and a
+  plain oldest-first policy would starve one of them: a pinned latest entry is
+  always older than every message still in the ring (its newest message is
+  what aged out), so oldest-first would drop the whole latest map before
+  touching the ring, and clicking a quiet topic would go blank the moment a
+  connection went over budget. Reserving a share keeps breadth (a last value
+  per topic) alongside depth (back-scroll on the selected topic). A normal
+  broker never reaches the share: at 5,000 topics the map costs ~2 MB against
+  a 512 MB default.
+
+  Consequence: at extreme cardinality a topic can appear in the tree (the
+  frontend keeps its own latest-per-topic) with no history left in the
+  backend, so `GetMessageHistory` rejects. The frontend treats that as an
+  empty timeline rather than a failed selection.
 - **Recent ring** of full `MqttMessage`s, evicting **oldest globally** when the
   estimated retained bytes exceed the memory budget. Byte estimate =
   Σ(payload len + topic len + fixed per-message overhead). Maintain a running

--- a/docs/specs/bounded-message-memory.md
+++ b/docs/specs/bounded-message-memory.md
@@ -49,9 +49,10 @@ the memory budget:
   the live tree (already how the frontend works).
 
   Correction (measured, 2026-08): this map is not counted against the budget
-  and costs roughly 430 B of heap per distinct topic, so very high topic
-  cardinality grows memory beyond the cap. A bound for this cache is future
-  work.
+  and retains each topic's newest message in full, payload included, after it
+  ages out of the recent window, so very high topic cardinality grows memory
+  beyond the cap. The roughly 430 B of heap per distinct topic measured here
+  was with ~200 B payloads. A bound for this cache is future work.
 - **Recent ring** of full `MqttMessage`s, evicting **oldest globally** when the
   estimated retained bytes exceed the memory budget. Byte estimate =
   Σ(payload len + topic len + fixed per-message overhead). Maintain a running

--- a/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/app.ts
+++ b/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/app.ts
@@ -425,6 +425,13 @@ export async function GetReceivedMessageCount(
   return mockMqttMessages.length;
 }
 
+export async function GetMemoryStats(): Promise<app.MemoryStats> {
+  return new app.MemoryStats({
+    historyBytes: 34 * 1024 * 1024,
+    activeConnections: 1,
+  });
+}
+
 export async function GetMqttStats(): Promise<app.MqttStats> {
   return new app.MqttStats({
     totalMessagesReceived: 128,

--- a/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/models.ts
+++ b/frontend/.storybook/mocks/bindings/mqtt-viewer/backend/app/models.ts
@@ -47,6 +47,19 @@ export class EnvInfo {
   }
 }
 
+export class MemoryStats {
+  historyBytes = 0;
+  activeConnections = 0;
+
+  static createFrom(source: any = {}) {
+    return new MemoryStats(source);
+  }
+
+  constructor(source: any = {}) {
+    assign(this, source);
+  }
+}
+
 export class MqttStats {
   totalMessagesReceived = 128;
   totalMessagesSent = 42;

--- a/frontend/bindings/mqtt-viewer/backend/app/app.ts
+++ b/frontend/bindings/mqtt-viewer/backend/app/app.ts
@@ -204,27 +204,38 @@ export function GetMatchingSubscriptionForTopic(connId: number, topic: string): 
     });
 }
 
+/**
+ * GetMemoryStats reports how much estimated memory in-RAM message history is
+ * using across all connections. A disconnected connection still holds its
+ * history against the budget, so it counts as active while it has any.
+ */
+export function GetMemoryStats(): $CancellablePromise<$models.MemoryStats> {
+    return $Call.ByID(3870247942).then(($result: any) => {
+        return $$createType16($result);
+    });
+}
+
 export function GetMessageHistory(connId: number, topic: string): $CancellablePromise<mqtt$0.MqttMessage[]> {
     return $Call.ByID(3700437937, connId, topic).then(($result: any) => {
-        return $$createType17($result);
+        return $$createType18($result);
     });
 }
 
 export function GetMqttStats(): $CancellablePromise<$models.MqttStats> {
     return $Call.ByID(2888945465).then(($result: any) => {
-        return $$createType18($result);
+        return $$createType19($result);
     });
 }
 
 export function GetPanelSizes(): $CancellablePromise<models$0.PanelSize[]> {
     return $Call.ByID(3836927596).then(($result: any) => {
-        return $$createType20($result);
+        return $$createType21($result);
     });
 }
 
 export function GetPublishHistoriesForConnection(connectionID: number): $CancellablePromise<models$0.PublishHistory[]> {
     return $Call.ByID(3102818020, connectionID).then(($result: any) => {
-        return $$createType22($result);
+        return $$createType23($result);
     });
 }
 
@@ -249,13 +260,13 @@ export function GetReceivedMessageCount(connectionID: number, topic: string): $C
  */
 export function GetReceivedMessageWindow(connectionID: number, topic: string, beforeID: number, afterID: number, limit: number): $CancellablePromise<mqtt$0.MqttMessage[]> {
     return $Call.ByID(2230097254, connectionID, topic, beforeID, afterID, limit).then(($result: any) => {
-        return $$createType17($result);
+        return $$createType18($result);
     });
 }
 
 export function GetSortStates(): $CancellablePromise<models$0.SortState[]> {
     return $Call.ByID(2748919454).then(($result: any) => {
-        return $$createType24($result);
+        return $$createType25($result);
     });
 }
 
@@ -266,19 +277,19 @@ export function GetSortStates(): $CancellablePromise<models$0.SortState[]> {
  */
 export function GetSysMessageHistory(connId: number): $CancellablePromise<mqtt$0.MqttMessage[]> {
     return $Call.ByID(2117163184, connId).then(($result: any) => {
-        return $$createType17($result);
+        return $$createType18($result);
     });
 }
 
 export function GetSysMetricMappingsByConnectionId(connId: number): $CancellablePromise<models$0.SysMetricMapping[]> {
     return $Call.ByID(1443899974, connId).then(($result: any) => {
-        return $$createType25($result);
+        return $$createType26($result);
     });
 }
 
 export function LoadOpenTabs(): $CancellablePromise<models$0.Tab[]> {
     return $Call.ByID(2526018972).then(($result: any) => {
-        return $$createType27($result);
+        return $$createType28($result);
     });
 }
 
@@ -290,7 +301,7 @@ export function MoveCollectionMessage(id: number, targetCollectionID: number): $
 
 export function NewConnection(): $CancellablePromise<$models.Connection | null> {
     return $Call.ByID(3098702478).then(($result: any) => {
-        return $$createType29($result);
+        return $$createType30($result);
     });
 }
 
@@ -342,7 +353,7 @@ export function SaveFilterHistoryEntry(connectionId: number, text: string): $Can
 
 export function SavePublishHistoryEntry(params: $models.SavePublishHistoryEntryParams): $CancellablePromise<models$0.PublishHistory> {
     return $Call.ByID(3794014424, params).then(($result: any) => {
-        return $$createType21($result);
+        return $$createType22($result);
     });
 }
 
@@ -405,17 +416,18 @@ const $$createType12 = $Create.Array($$createType7);
 const $$createType13 = $models.EnvInfo.createFrom;
 const $$createType14 = models$0.FilterHistory.createFrom;
 const $$createType15 = $Create.Array($$createType14);
-const $$createType16 = mqtt$0.MqttMessage.createFrom;
-const $$createType17 = $Create.Array($$createType16);
-const $$createType18 = $models.MqttStats.createFrom;
-const $$createType19 = models$0.PanelSize.createFrom;
-const $$createType20 = $Create.Array($$createType19);
-const $$createType21 = models$0.PublishHistory.createFrom;
-const $$createType22 = $Create.Array($$createType21);
-const $$createType23 = models$0.SortState.createFrom;
-const $$createType24 = $Create.Array($$createType23);
-const $$createType25 = $Create.Array($$createType3);
-const $$createType26 = models$0.Tab.createFrom;
-const $$createType27 = $Create.Array($$createType26);
-const $$createType28 = $models.Connection.createFrom;
-const $$createType29 = $Create.Nullable($$createType28);
+const $$createType16 = $models.MemoryStats.createFrom;
+const $$createType17 = mqtt$0.MqttMessage.createFrom;
+const $$createType18 = $Create.Array($$createType17);
+const $$createType19 = $models.MqttStats.createFrom;
+const $$createType20 = models$0.PanelSize.createFrom;
+const $$createType21 = $Create.Array($$createType20);
+const $$createType22 = models$0.PublishHistory.createFrom;
+const $$createType23 = $Create.Array($$createType22);
+const $$createType24 = models$0.SortState.createFrom;
+const $$createType25 = $Create.Array($$createType24);
+const $$createType26 = $Create.Array($$createType3);
+const $$createType27 = models$0.Tab.createFrom;
+const $$createType28 = $Create.Array($$createType27);
+const $$createType29 = $models.Connection.createFrom;
+const $$createType30 = $Create.Nullable($$createType29);

--- a/frontend/bindings/mqtt-viewer/backend/app/index.ts
+++ b/frontend/bindings/mqtt-viewer/backend/app/index.ts
@@ -11,6 +11,7 @@ export {
     Connections,
     CreateCollectionParams,
     EnvInfo,
+    MemoryStats,
     MqttStats,
     OpenChartWindowParams,
     PublishParams,

--- a/frontend/bindings/mqtt-viewer/backend/app/models.ts
+++ b/frontend/bindings/mqtt-viewer/backend/app/models.ts
@@ -141,6 +141,31 @@ export class EnvInfo {
     }
 }
 
+export class MemoryStats {
+    "historyBytes": number;
+    "activeConnections": number;
+
+    /** Creates a new MemoryStats instance. */
+    constructor($$source: Partial<MemoryStats> = {}) {
+        if (!("historyBytes" in $$source)) {
+            this["historyBytes"] = 0;
+        }
+        if (!("activeConnections" in $$source)) {
+            this["activeConnections"] = 0;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new MemoryStats instance from a string or object.
+     */
+    static createFrom($$source: any = {}): MemoryStats {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new MemoryStats($$parsedSource as Partial<MemoryStats>);
+    }
+}
+
 export class MqttStats {
     "totalMessagesReceived": number;
     "totalMessagesSent": number;

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -171,7 +171,7 @@ export const CHANGELOG: ChangelogEntry[] = [
       },
       {
         title: "Clearer memory settings",
-        body: "The settings dialog now shows how much memory history is using and estimates the app's total use from your budget.",
+        body: "The settings dialog now shows how much memory message history is using and estimates the app's total use from your budget.",
       },
     ],
   },

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -169,6 +169,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Deleting a connection works again",
         body: "Deleting a connection could fail and quietly roll back if you'd ever used publish or filter history on it. It now removes everything that belongs to the connection, and clearing out a large message history no longer freezes the app while it works.",
       },
+      {
+        title: "Clearer memory settings",
+        body: "The settings dialog now shows how much memory history is using and estimates the app's total use from your budget.",
+      },
     ],
   },
   {

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -173,6 +173,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Clearer memory settings",
         body: "The settings dialog now shows how much memory message history is using and estimates the app's total use from your budget.",
       },
+      {
+        title: "The memory budget now covers every topic",
+        body: "On brokers with hundreds of thousands of topics, the last value I keep for each topic sat outside your memory budget, so memory kept growing however low you set it. It is now counted, and if it ever gets large I trim the topics you have heard from least recently. Normal brokers are nowhere near that, so the topic tree is unchanged.",
+      },
     ],
   },
   {

--- a/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
+++ b/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
@@ -9,7 +9,6 @@
   import {
     GetAppSettings,
     UpdateAppSettings,
-    GetMemoryStats,
   } from "bindings/mqtt-viewer/backend/app/app";
   import { firstRunGateCleared } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
   import {
@@ -25,23 +24,14 @@
   let memoryBudgetMb = 512;
   let recordingEnabled = false;
   let diskBudgetGb = 1;
-  let activeConnections = 1;
   let isSaving = false;
 
   const recordingChecked = writable(false);
 
-  $: memoryBelowMin =
-    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
-  $: shownConnections = Math.max(1, activeConnections);
+  // A cleared Svelte number input binds null, which is also invalid.
+  $: memoryBelowMin = memoryBudgetMb == null || memoryBudgetMb < MIN_MEMORY_MB;
 
   onMount(async () => {
-    try {
-      const stats = await GetMemoryStats();
-      activeConnections = stats.activeConnections;
-    } catch (e) {
-      console.error("Failed to read memory stats", e);
-      activeConnections = 1;
-    }
     try {
       const settings = await GetAppSettings();
       if (!settings.hasSeenHistoryPrompt) {
@@ -125,23 +115,16 @@
           name="prompt-memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
-          class={memoryBelowMin ? "mb-[17px]" : ""}
+          class="mb-[17px]"
           hasError={memoryBelowMin}
           errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
         />
         <p class="text-sm text-secondary-text">
-          Caps the message history I keep in memory for each connection. The
-          newest message per topic is kept outside the cap so the topic tree
-          always has a value.
-        </p>
-        <p class="text-sm text-secondary-text">
-          Expect about {formatBytes(
-            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
-          )} in total with {shownConnections} connection{shownConnections === 1
-            ? ""
-            : "s"} active. That's this budget for each connection plus around
-          300 MB for the interface and runtime.
+          Expect up to about {formatBytes(
+            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, 1)
+          )} in total with one connection. That's this budget for each
+          connection plus around 300 MB for the interface and runtime.
         </p>
       </div>
 
@@ -170,7 +153,11 @@
       <Button variant="text" disabled={isSaving} on:click={onNotNow}
         >Not now</Button
       >
-      <Button variant="primary" disabled={isSaving} on:click={onSave}>
+      <Button
+        variant="primary"
+        disabled={isSaving || memoryBelowMin}
+        on:click={onSave}
+      >
         {isSaving ? "Saving…" : "Save"}
       </Button>
     </div>

--- a/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
+++ b/frontend/src/components/HistoryRetentionPrompt/HistoryRetentionPrompt.svelte
@@ -9,23 +9,39 @@
   import {
     GetAppSettings,
     UpdateAppSettings,
+    GetMemoryStats,
   } from "bindings/mqtt-viewer/backend/app/app";
   import { firstRunGateCleared } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
-
-  const MB = 1024 * 1024;
-  const GB = 1024 * 1024 * 1024;
-  const MIN_MEMORY_MB = 64;
+  import {
+    MB,
+    GB,
+    MIN_MEMORY_MB,
+    formatBytes,
+    estimateTotalBytes,
+  } from "@/util/memory-budget";
 
   const isOpen = writable(false);
 
   let memoryBudgetMb = 512;
   let recordingEnabled = false;
   let diskBudgetGb = 1;
+  let activeConnections = 1;
   let isSaving = false;
 
   const recordingChecked = writable(false);
 
+  $: memoryBelowMin =
+    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
+  $: shownConnections = Math.max(1, activeConnections);
+
   onMount(async () => {
+    try {
+      const stats = await GetMemoryStats();
+      activeConnections = stats.activeConnections;
+    } catch (e) {
+      console.error("Failed to read memory stats", e);
+      activeConnections = 1;
+    }
     try {
       const settings = await GetAppSettings();
       if (!settings.hasSeenHistoryPrompt) {
@@ -98,9 +114,9 @@
 <Dialog title="Message history retention" {isOpen} showCloseButton={false}>
   <div class="flex flex-col gap-5 mt-3 w-[440px]">
     <p class="text-secondary-text">
-      MQTT Viewer now bounds how much message history it keeps in memory so long
-      subscriptions don't grow RAM. You can also record history to disk so it
-      survives restarts.
+      I cap how much message history I keep in memory so long sessions don't
+      eat your RAM. You can also record history to disk so it survives
+      restarts.
     </p>
 
     <div class="flex flex-col gap-4">
@@ -109,8 +125,24 @@
           name="prompt-memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
+          class={memoryBelowMin ? "mb-[17px]" : ""}
+          hasError={memoryBelowMin}
+          errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
         />
+        <p class="text-sm text-secondary-text">
+          Caps the message history I keep in memory for each connection. The
+          newest message per topic is kept outside the cap so the topic tree
+          always has a value.
+        </p>
+        <p class="text-sm text-secondary-text">
+          Expect about {formatBytes(
+            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
+          )} in total with {shownConnections} connection{shownConnections === 1
+            ? ""
+            : "s"} active. That's this budget for each connection plus around
+          300 MB for the interface and runtime.
+        </p>
       </div>
 
       <div class="flex flex-col gap-2">

--- a/frontend/src/components/SettingsDialog/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog/SettingsDialog.svelte
@@ -4,45 +4,64 @@
   import BaseNumberInput from "@/components/InputFields/BaseNumberInput.svelte";
   import Switch from "@/components/InputFields/Switch.svelte";
   import { addToast } from "@/components/Toast/Toast.svelte";
+  import { onDestroy } from "svelte";
   import { writable } from "svelte/store";
   import {
     GetAppSettings,
     UpdateAppSettings,
     GetDatabaseSizeBytes,
     ClearReceivedMessages,
+    GetMemoryStats,
   } from "bindings/mqtt-viewer/backend/app/app";
   import env from "@/stores/env";
   import { whatsNewOpen } from "@/components/WhatsNewDialog/WhatsNewDialog.svelte";
+  import {
+    MB,
+    GB,
+    MIN_MEMORY_MB,
+    formatBytes,
+    estimateTotalBytes,
+  } from "@/util/memory-budget";
 
   export let open = writable(false);
-
-  const MB = 1024 * 1024;
-  const GB = 1024 * 1024 * 1024;
-  const MIN_MEMORY_MB = 64;
 
   let memoryBudgetMb = 512;
   let recordingEnabled = false;
   let diskBudgetGb = 1;
   let dbSizeBytes: number | undefined = undefined;
+  let historyBytes: number | undefined = undefined;
+  let activeConnections = 1;
   let isSaving = false;
   let isClearing = false;
 
   const recordingChecked = writable(false);
 
-  // Human-readable byte formatting (e.g. "240 MB", "1.2 GB").
-  const formatBytes = (bytes: number | undefined): string => {
-    if (bytes === undefined) return "…";
-    if (bytes < 1024) return `${bytes} B`;
-    const units = ["KB", "MB", "GB", "TB"];
-    let value = bytes / 1024;
-    let unitIndex = 0;
-    while (value >= 1024 && unitIndex < units.length - 1) {
-      value /= 1024;
-      unitIndex += 1;
+  const refreshMemoryStats = async () => {
+    try {
+      const stats = await GetMemoryStats();
+      historyBytes = stats.historyBytes;
+      activeConnections = stats.activeConnections;
+    } catch (e) {
+      console.error("Failed to read memory stats", e);
+      historyBytes = undefined;
+      activeConnections = 1;
     }
-    const rounded = value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
-    return `${rounded} ${units[unitIndex]}`;
   };
+
+  // Poll memory stats while the dialog is open so the readout stays live.
+  let memoryPollInterval: ReturnType<typeof setInterval> | undefined;
+  const startMemoryPolling = () => {
+    if (memoryPollInterval !== undefined) return;
+    refreshMemoryStats();
+    memoryPollInterval = setInterval(refreshMemoryStats, 2000);
+  };
+  const stopMemoryPolling = () => {
+    if (memoryPollInterval !== undefined) {
+      clearInterval(memoryPollInterval);
+      memoryPollInterval = undefined;
+    }
+  };
+  onDestroy(stopMemoryPolling);
 
   const refreshDbSize = async () => {
     try {
@@ -76,11 +95,19 @@
     }
   };
 
-  // Load fresh settings + db size whenever the dialog opens.
+  // Load fresh settings + db size whenever the dialog opens, and poll memory
+  // stats only while it stays open.
   $: if ($open) {
     loadSettings();
     refreshDbSize();
+    startMemoryPolling();
+  } else {
+    stopMemoryPolling();
   }
+
+  $: memoryBelowMin =
+    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
+  $: shownConnections = Math.max(1, activeConnections);
 
   const onRecordingChange = (checked: boolean) => {
     recordingEnabled = checked;
@@ -154,11 +181,23 @@
           name="memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
+          class={memoryBelowMin ? "mb-[17px]" : ""}
+          hasError={memoryBelowMin}
+          errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
         />
         <p class="text-sm text-secondary-text">
-          Bounds in-memory message history so long subscriptions don't grow RAM
-          without limit. Always on.
+          Caps the message history I keep in memory for each connection. The
+          newest message per topic is kept outside the cap so the topic tree
+          always has a value.
+        </p>
+        <p class="text-sm text-secondary-text">
+          Expect about {formatBytes(
+            estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
+          )} in total with {shownConnections} connection{shownConnections === 1
+            ? ""
+            : "s"} active. That's this budget for each connection plus around
+          300 MB for the interface and runtime.
         </p>
       </div>
 
@@ -188,6 +227,11 @@
     </section>
 
     <section class="flex flex-col gap-3 border-t border-outline pt-4">
+      <div class="flex items-center justify-between">
+        <span class="text-secondary-text"
+          >History in memory: {formatBytes(historyBytes)}</span
+        >
+      </div>
       <div class="flex items-center justify-between">
         <span class="text-secondary-text"
           >Database size: {formatBytes(dbSizeBytes)}</span

--- a/frontend/src/components/SettingsDialog/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog/SettingsDialog.svelte
@@ -187,9 +187,8 @@
           bind:value={memoryBudgetMb}
         />
         <p class="text-sm text-secondary-text">
-          Caps the message history I keep in memory for each connection. The
-          newest message per topic is kept outside the cap so the topic tree
-          always has a value.
+          Caps the message history I keep in memory for each connection,
+          including the newest message per topic that the topic tree shows.
         </p>
         <p class="text-sm text-secondary-text">
           Expect up to about {formatBytes(

--- a/frontend/src/components/SettingsDialog/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog/SettingsDialog.svelte
@@ -105,8 +105,8 @@
     stopMemoryPolling();
   }
 
-  $: memoryBelowMin =
-    memoryBudgetMb !== undefined && memoryBudgetMb < MIN_MEMORY_MB;
+  // A cleared Svelte number input binds null, which is also invalid.
+  $: memoryBelowMin = memoryBudgetMb == null || memoryBudgetMb < MIN_MEMORY_MB;
   $: shownConnections = Math.max(1, activeConnections);
 
   const onRecordingChange = (checked: boolean) => {
@@ -181,7 +181,7 @@
           name="memory-budget"
           label="Memory budget (MB)"
           min={MIN_MEMORY_MB}
-          class={memoryBelowMin ? "mb-[17px]" : ""}
+          class="mb-[17px]"
           hasError={memoryBelowMin}
           errorMessage={memoryBelowMin ? "64 MB is the minimum" : undefined}
           bind:value={memoryBudgetMb}
@@ -192,12 +192,12 @@
           always has a value.
         </p>
         <p class="text-sm text-secondary-text">
-          Expect about {formatBytes(
+          Expect up to about {formatBytes(
             estimateTotalBytes(memoryBudgetMb ?? MIN_MEMORY_MB, activeConnections)
-          )} in total with {shownConnections} connection{shownConnections === 1
+          )} in total across {shownConnections} connection{shownConnections === 1
             ? ""
-            : "s"} active. That's this budget for each connection plus around
-          300 MB for the interface and runtime.
+            : "s"}. That's this budget for each connection plus around 300 MB
+          for the interface and runtime.
         </p>
       </div>
 
@@ -258,7 +258,11 @@
 
     <div class="flex gap-3 justify-end items-center">
       <Button variant="text" on:click={() => open.set(false)}>Cancel</Button>
-      <Button variant="primary" disabled={isSaving} on:click={onSave}>
+      <Button
+        variant="primary"
+        disabled={isSaving || memoryBelowMin}
+        on:click={onSave}
+      >
         {isSaving ? "Saving…" : "Save"}
       </Button>
     </div>

--- a/frontend/src/util/memory-budget.ts
+++ b/frontend/src/util/memory-budget.ts
@@ -1,0 +1,32 @@
+// Shared constants and helpers for the memory-budget setting, used by the
+// settings dialog and the first-run history retention prompt.
+
+export const MB = 1024 * 1024;
+export const GB = 1024 * 1024 * 1024;
+export const MIN_MEMORY_MB = 64;
+
+// Measured ~320 MB baseline on macOS (Go process + webview helpers) with no
+// history; rounded to a cross-platform figure.
+export const BASE_APP_BYTES = 300 * MB;
+
+// Human-readable byte formatting (e.g. "240 MB", "1.2 GB").
+export const formatBytes = (bytes: number | undefined): string => {
+  if (bytes === undefined) return "…";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const rounded = value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[unitIndex]}`;
+};
+
+// Rough total app memory: baseline plus the per-connection history budget for
+// each active connection (at least one, so an idle app still shows a figure).
+export const estimateTotalBytes = (
+  budgetMb: number,
+  activeConnections: number
+): number => BASE_APP_BYTES + budgetMb * MB * Math.max(1, activeConnections);

--- a/frontend/src/views/Connection/DataView/stores/selected-topic-store.test.ts
+++ b/frontend/src/views/Connection/DataView/stores/selected-topic-store.test.ts
@@ -1,0 +1,100 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+// --- Mocks (hoisted so the vi.mock factories can see them) --------------------
+
+const mocks = vi.hoisted(() => ({
+  getHist: vi.fn(),
+  getWindow: vi.fn(),
+  getCount: vi.fn(),
+  getSettings: vi.fn(),
+  handlers: new Map<string, Set<(e: any) => void>>(),
+}));
+
+vi.mock("@wailsio/runtime", () => ({
+  Events: {
+    On: (name: string, cb: (e: any) => void) => {
+      const set = mocks.handlers.get(name) ?? new Set();
+      set.add(cb);
+      mocks.handlers.set(name, set);
+      return () => mocks.handlers.get(name)?.delete(cb);
+    },
+  },
+}));
+
+vi.mock("bindings/mqtt-viewer/backend/app/app", () => ({
+  GetMessageHistory: mocks.getHist,
+  GetReceivedMessageWindow: mocks.getWindow,
+  GetReceivedMessageCount: mocks.getCount,
+  GetAppSettings: mocks.getSettings,
+}));
+
+import { createSelectedTopicStore } from "./selected-topic-store";
+
+const eventSet = {
+  mqttMessages: "msgs",
+  mqttClearHistory: "clear",
+} as any;
+
+const message = (topic: string, payloadB64: string) => ({
+  id: "1",
+  topic,
+  payload: payloadB64,
+  qos: 0,
+  retain: false,
+  timeMs: 1,
+});
+
+describe("selected-topic-store memory mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handlers.clear();
+    mocks.getSettings.mockResolvedValue({ recordingEnabled: false });
+  });
+
+  it("shows the in-memory history for a topic", async () => {
+    mocks.getHist.mockResolvedValue([message("factory/line1", "aGk=")]);
+    const store = createSelectedTopicStore(1, eventSet);
+    store.subscribe(() => {});
+
+    await store.selectTopic("factory/line1");
+
+    const state = get(store);
+    expect(state.selectedTopic).toBe("factory/line1");
+    expect(state.history).toHaveLength(1);
+    expect(state.history[0].payload).toBe("hi");
+  });
+
+  // At very high topic cardinality the backend trims its last-value cache, so
+  // a topic still listed in the tree can have no history left and the binding
+  // rejects with "topic not found in message history". Selecting it must show
+  // an empty timeline, not fail.
+  it("selects a topic with no retained history as an empty timeline", async () => {
+    mocks.getHist.mockRejectedValue(
+      new Error("topic not found in message history")
+    );
+    const store = createSelectedTopicStore(1, eventSet);
+    store.subscribe(() => {});
+
+    await expect(store.selectTopic("dropped/topic")).resolves.toBeUndefined();
+
+    const state = get(store);
+    expect(state.selectedTopic).toBe("dropped/topic");
+    expect(state.history).toEqual([]);
+    expect(state.totalCount).toBe(0);
+    expect(state.historySource).toBe("memory");
+  });
+
+  it("still appends live messages to a topic selected with no history", async () => {
+    mocks.getHist.mockRejectedValue(new Error("topic not found"));
+    const store = createSelectedTopicStore(1, eventSet);
+    store.subscribe(() => {});
+    await store.selectTopic("dropped/topic");
+
+    for (const cb of mocks.handlers.get("msgs") ?? []) {
+      cb({ data: [message("dropped/topic", "aGk=")] });
+    }
+
+    expect(get(store).history).toHaveLength(1);
+  });
+});

--- a/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
+++ b/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
@@ -198,8 +198,13 @@ export const createSelectedTopicStore = (
     let history: mqtt.MqttMessage[] = [];
     try {
       history = await GetMessageHistory(connectionId, topic);
-    } catch {
+    } catch (e) {
       history = [];
+      // "Not found" is the expected case above. Anything else is a real
+      // failure, so log it rather than let an empty timeline hide it.
+      if (!String(e).includes("not found")) {
+        console.error("Failed to load message history", e);
+      }
     }
     const decoded = history.map(decode);
     update((store) => ({

--- a/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
+++ b/frontend/src/views/Connection/DataView/stores/selected-topic-store.ts
@@ -191,7 +191,16 @@ export const createSelectedTopicStore = (
     }
 
     // Memory mode: the in-RAM history is already bounded by the memory budget.
-    const history = await GetMessageHistory(connectionId, topic);
+    // At very high topic cardinality the backend also trims its last-value
+    // cache, so a topic still shown in the tree can have no history left;
+    // that rejects, and an empty timeline is the right answer rather than a
+    // failed selection.
+    let history: mqtt.MqttMessage[] = [];
+    try {
+      history = await GetMessageHistory(connectionId, topic);
+    } catch {
+      history = [];
+    }
     const decoded = history.map(decode);
     update((store) => ({
       ...store,


### PR DESCRIPTION
## What

`MessageHistory.latest` kept each topic's newest message forever, outside the memory budget: once a message aged out of the recent window the latest map was its only holder and nothing charged those bytes. Measured at ~430 B of heap per distinct topic, so a broker with hundreds of thousands of topics grew RAM without bound however low "Memory budget (MB)" was set.

Every retained message is now charged exactly once: to the recent ring while it is in the window, then to the latest map once the map pins it. The budget bounds the sum. The latest map may take at most a **quarter** of the budget; over that share the least recently updated topics are dropped, oldest first.

### Why a quarter, not oldest-first

A pinned latest entry is always older than every message still in the ring (its newest message is what aged out), so a plain oldest-first policy would drop the whole latest map before touching the ring, and clicking a quiet topic would go blank the moment a connection went over budget. Reserving a share keeps breadth (a last value per topic) alongside depth (back-scroll on the selected topic). A normal broker never reaches the share: 5,000 topics cost ~2 MB against a 512 MB default, and `TestHistoryKeepsEveryTopicAtNormalCardinality` pins that.

### Changes

- `latest` is `map[string]*latestEntry` with an intrusive LRU list over pinned entries only, so eviction stays O(1) and the hot path stays bounded and enqueue-only (`docs/specs/bounded-message-memory.md`).
- `TotalBytes()` is now the figure the budget bounds, so the settings readout and the budget describe the same thing.
- `selectTopic` treats a rejected `GetMessageHistory` as an empty timeline: at extreme cardinality a topic can sit in the tree with no backend history left.
- `TestLatestMapCalibration` guards `latestEntryOverhead` against real heap cost, in the style of the existing history calibration test.
- Settings copy no longer promises the last value per topic sits outside the cap.

## Perf check

Two local brokers, both flooded (`scripts/mqtt-flood.py`): 11883 with 2,000 topics, 11884 with 200,000 topics, ~1,700 msg/s achieved on each (paho's ceiling, short of the 2,000 target). Memory budget set to the 64 MB minimum on both connections, so the cap is 128 MB. Ran the same scenario against this branch and against its parent.

| | Parent (995af49) | This branch |
| --- | --- | --- |
| History in memory | 233 MB (1.8x the 128 MB cap) | 128 MB, flat over 10 min |
| Process RSS | 208-986 MB, GC sawtooth | 374-1051 MB, GC sawtooth |
| CPU | 11-14% | 10-13% |

The parent plateaus at 233 MB because the flood cycles all 200k topics in ~2 min and then the map stops growing; the overshoot scales with topic count, not time, which is the reported bug. RSS is noisy in both and does not separate them: this base has no soft `GOMEMLIMIT` (that lands with the memlimit work), so the accounted history figure is the meaningful signal. UI stayed responsive throughout: tree expansion to 200k leaves, topic selection, live timeline updates, no console errors.

## Checks

`go build ./...`, `go vet ./...`, `just test`, `pnpm check` (0 errors), `pnpm test:run` (169/169), `pnpm build`, `pnpm ds:validate`, `pnpm test-storybook` (132/132).

## Note on #146

Branched off #146 rather than `develop`, because #146 introduced the `latestExtraBytes` accounting this builds on. Its commits appear here until it merges. This supersedes #146's read-only accounting: `latestExtraBytes` and `MqttMessage.evictedFromRecent` are replaced by the charged `latestBytes` and the `latestEntry` struct, so store bookkeeping no longer rides on the wire type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)