### PR TITLE
fix(mqtt): dispatch v3 messages in arrival order

### DIFF
--- a/.claude/skills/perf-check/SKILL.md
+++ b/.claude/skills/perf-check/SKILL.md
@@ -24,6 +24,12 @@ python3 -m venv scripts/.venv
 scripts/.venv/bin/pip install paho-mqtt
 ```
 
+`scripts/.venv` is gitignored, so it does not exist in an agent
+worktree. Either re-run those two lines there, or use the main
+checkout's copy at `~/git/mqtt-viewer/scripts/.venv/bin/python3`.
+Backgrounding the flood before checking the interpreter exists fails
+silently and looks like a broker with no traffic.
+
 ## Run
 
 Terminals 1 and 2, one broker each:
@@ -71,3 +77,46 @@ rather than throughput.
 
 Report concrete observations (achieved msg/s, where it stuttered, memory
 trend), not just "seems fine".
+
+## Reading memory correctly
+
+Two things make RSS misleading, so judge growth only while the floods
+are still running:
+
+- macOS compresses an idle process's pages. Once the floods stop, RSS
+  collapses (a run holding ~600 MB read as 34 MB) and tells you nothing.
+- In-RAM history is capped by `DefaultMemoryBudgetBytes`, 512 MB per
+  connection, so two connections climb toward ~1 GB of retained messages
+  by design. With Go's default GOGC the process sits well above that.
+  Rising toward the budget is the eviction working, not a leak. What
+  would be a leak is growth that keeps going after the budget is full.
+
+## Benchmarking the message path
+
+If the change is to ingest itself, a Go benchmark pins it down faster
+than watching the UI. Two traps:
+
+- `receiveMessage` debug-logs every message. That logging is off in
+  production builds (`backend/app/startup.go`), but on in tests, where
+  it costs roughly as much as the work itself: ingest measures ~700-800
+  ns per message with it off, ~1200 ns with it formatting to a discard
+  handler, and ~4000 ns writing to the console handler. Swap in a
+  discard handler with `slog.SetDefault` for the benchmark, or you are
+  timing the logger.
+- Work handed to another goroutine does not get counted. Measure to
+  completion: spin until the messages have actually landed in history
+  before `b.StopTimer()`, otherwise deferring work looks like a speedup.
+  `runtime.NumGoroutine()` sampled during the run is worth reporting
+  too, since a backlog shows up there first.
+
+## Driving the app headlessly
+
+`scripts/serve-browser.sh` runs the real backend and is drivable from
+the browser pane, which is usually easier than the native window. Two
+things to know: live message events need
+`<script src="/wails/custom.js"></script>` injected into the page (see
+`AGENTS.md`), and the process can panic on shutdown with `server
+shutdown error: context deadline exceeded`, seemingly when a client goes
+away with that WebSocket open. It is a dev-only path, but it will end a
+run mid-measurement, so take readings as you go rather than only at the
+end.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,27 @@ touches message handling, the topic tree, history, or the graph view.
 This bar exists because heavy public brokers (test.mosquitto.org) are a
 core use case.
 
+## Adversarial review
+
+"Adversarial review" here always means the same thing. Never review your
+own work in your own context; you will confirm what you already believe.
+
+1. Spawn a **fresh agent** with only the context it needs: the branch or
+   diff, the explicit claims being made, and how to run the tests. Do not
+   hand it your reasoning, your conclusions, or why you think the work is
+   right. Those are what it is meant to attack.
+2. Its job is to **disprove**, not to appraise. Brief it to falsify each
+   claim, run the tests and benchmarks itself rather than trusting the
+   numbers in the description, and hunt for the case that breaks the
+   change. "Looks good" is a failed review.
+3. **You then judge its findings.** It has less context than you and will
+   raise things that are wrong, out of scope, or already handled. Verify
+   each one against the code before acting, implement what genuinely
+   holds, and say plainly which you rejected and why.
+
+Use the session's top model for the reviewer. Review is judgment, and
+judgment is the one thing not worth delegating downward.
+
 ## Releases and the portal
 
 `docs/RELEASING.md` is the runbook; the `/release` skill drives it.

--- a/backend/mqtt/connect.go
+++ b/backend/mqtt/connect.go
@@ -229,7 +229,13 @@ func (mm *MqttManager) connectV3(ctx context.Context, connectionDetails MqttConn
 	opts.SetAutoReconnect(true)
 	opts.SetMaxReconnectInterval(30 * time.Second)
 	opts.SetConnectRetry(false)
-	opts.SetOrderMatters(false)
+	// With this false, paho hands every incoming message to its own goroutine,
+	// so messages reach the history and the timeline shuffled and even their
+	// arrival timestamps get stamped out of order. True makes paho dispatch
+	// sequentially from its reader goroutine, matching how the v5 client
+	// already behaves. See receiveMessage for what that goroutine now carries
+	// and why it is cheap enough.
+	opts.SetOrderMatters(true)
 	opts.SetConnectionLostHandler(func(c mqttV3.Client, err error) {
 		if mm.ConnectionState == ConnectionStates.Connected {
 			mm.SetConnectionState(ConnectionStates.Reconnecting, &err)

--- a/backend/mqtt/receive.go
+++ b/backend/mqtt/receive.go
@@ -12,6 +12,20 @@ func (mm *MqttManager) receiveMessage(m *MqttMessage) error {
 		return fmt.Errorf("before add to history: %w", err)
 	}
 
+	// Written on the caller's goroutine, in order. History and the buffer are
+	// append-ordered and the timeline renders them in that order, so handing
+	// each message to its own goroutine let them land shuffled. Both writes are
+	// a mutex and an append, so doing them here costs about a microsecond and
+	// saves spawning a goroutine per message.
+	//
+	// The trade-off: paho calls us from the goroutine reading the connection,
+	// so anything slow here is backpressure on that socket rather than a pile
+	// of queued goroutines. The one caller that can hold the history mutex for
+	// a noticeable stretch is ExportAllMessages via GetAllHistory, around
+	// 150ms with a full 512MB window. That is well inside the keepalive budget
+	// (20s keepalive plus a 10s ping timeout), so it stalls reading briefly and
+	// recovers. Keep it that way: work that could block for seconds does not
+	// belong on this path.
 	mm.MessageHistory.addMessageToHistory(*m)
 	mm.MessageBuffer.addMessageToBuffer(*m)
 

--- a/backend/mqtt/receive_order_integration_test.go
+++ b/backend/mqtt/receive_order_integration_test.go
@@ -1,0 +1,79 @@
+package mqtt
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Needs the local test broker (scripts/test-broker.sh up).
+//
+// Publishes a numbered run to one topic and checks the history comes back in
+// the order it was sent. This covers the whole receive path, including how the
+// paho client dispatches to us, which the unit tests in receive_test.go cannot
+// see.
+//
+// The broker is shared across worktrees, so both the topic and the client ID
+// are made unique per run. A shared topic makes a second run's messages show up
+// interleaved in this one, which fails with the exact "out of order" message
+// this test uses to report the real bug, and getUniqueClientId only has
+// second resolution, so two runs starting together evict each other's session.
+
+func TestV3PreservesPublishOrder(t *testing.T) { testPreservesPublishOrder(t, "3") }
+func TestV5PreservesPublishOrder(t *testing.T) { testPreservesPublishOrder(t, "5") }
+
+func testPreservesPublishOrder(t *testing.T, mqttVersion string) {
+	m := getTestMqttManager(t)
+	runID := uuid.NewString()
+	topic := fmt.Sprintf("%s/%d/%s", t.Name(), os.Getpid(), runID)
+	err := m.Connect(MqttConnectionDetails{
+		Host:        "localhost",
+		Port:        1883,
+		Protocol:    "mqtt",
+		MqttVersion: mqttVersion,
+		ClientId:    "mqtt-viewer-test-" + runID,
+	}, []SubscribeParams{{Topic: topic, QoS: 0}})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	const n = 500
+	for i := 0; i < n; i++ {
+		err := m.Publish(MqttPublishParams{
+			Topic:   topic,
+			Payload: []byte(strconv.Itoa(i)),
+			QoS:     0,
+		})
+		if err != nil {
+			t.Fatalf("publish %d: %v", i, err)
+		}
+	}
+
+	history := waitForBrokerHistory(t, m, topic, n)
+	for i, msg := range history {
+		want := strconv.Itoa(i)
+		if string(msg.Payload) != want {
+			t.Fatalf("message %d out of order: payload %q, want %q", i, msg.Payload, want)
+		}
+	}
+}
+
+func waitForBrokerHistory(t *testing.T, m *MqttManager, topic string, n int) []MqttMessage {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	var history []MqttMessage
+	for time.Now().Before(deadline) {
+		var err error
+		history, err = m.MessageHistory.GetTopicHistory(topic)
+		if err == nil && len(history) >= n {
+			return history
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d messages, got %d", n, len(history))
+	return nil
+}

--- a/backend/mqtt/receive_test.go
+++ b/backend/mqtt/receive_test.go
@@ -1,0 +1,88 @@
+package mqtt
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// receiveN feeds messages through receiveMessage the way the MQTT 5 client
+// does: one at a time, in arrival order, from a single goroutine.
+func receiveN(t *testing.T, mm *MqttManager, topic string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		m := &MqttMessage{
+			Topic:   topic,
+			Payload: []byte(fmt.Sprintf("%d", i)),
+			TimeMs:  int64(i),
+		}
+		if err := mm.receiveMessage(m); err != nil {
+			t.Fatalf("receiveMessage %d: %v", i, err)
+		}
+	}
+}
+
+// waitForHistory waits until the topic has n messages, so the test still works
+// if the writes are done asynchronously.
+func waitForHistory(t *testing.T, mm *MqttManager, topic string, n int) []MqttMessage {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		history, err := mm.MessageHistory.GetTopicHistory(topic)
+		if err == nil && len(history) >= n {
+			return history
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d messages, got %d (err=%v)", n, len(history), err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// The timeline and per-topic history are rendered in the order messages were
+// appended, so receiveMessage must not reorder them.
+func TestReceiveMessageKeepsHistoryInArrivalOrder(t *testing.T) {
+	mm := NewMqttManager(context.Background(), nil)
+	const n = 2000
+	const topic = "order/history"
+
+	receiveN(t, mm, topic, n)
+	history := waitForHistory(t, mm, topic, n)
+
+	if len(history) != n {
+		t.Fatalf("expected %d messages, got %d", n, len(history))
+	}
+	for i, msg := range history {
+		if msg.TimeMs != int64(i) {
+			t.Fatalf("message %d out of order: TimeMs = %d, want %d", i, msg.TimeMs, i)
+		}
+	}
+}
+
+// The buffer feeds the 300ms drain that emits to the frontend and persists to
+// disk, so it has to stay in arrival order too.
+func TestReceiveMessageKeepsBufferInArrivalOrder(t *testing.T) {
+	mm := NewMqttManager(context.Background(), nil)
+	const n = 2000
+	const topic = "order/buffer"
+
+	receiveN(t, mm, topic, n)
+	// Drain once the history shows every message, by which point the buffer
+	// writes for those messages have been made too.
+	waitForHistory(t, mm, topic, n)
+
+	var drained []MqttMessage
+	mm.MessageBuffer.useBufferContents(func(messages []MqttMessage) {
+		drained = messages
+	})
+
+	if len(drained) != n {
+		t.Fatalf("expected %d buffered messages, got %d", n, len(drained))
+	}
+	for i, msg := range drained {
+		if msg.TimeMs != int64(i) {
+			t.Fatalf("buffered message %d out of order: TimeMs = %d, want %d", i, msg.TimeMs, i)
+		}
+	}
+}

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -169,6 +169,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Deleting a connection works again",
         body: "Deleting a connection could fail and quietly roll back if you'd ever used publish or filter history on it. It now removes everything that belongs to the connection, and clearing out a large message history no longer freezes the app while it works.",
       },
+      {
+        title: "Messages stay in the order they arrived",
+        body: "On MQTT 3 connections the timeline and message history could show messages out of order, and stamp them with the wrong arrival time, because the client handed each one off separately as it came in. They are now recorded in the order they land, which is what MQTT 5 connections already did.",
+      },
     ],
   },
   {


### PR DESCRIPTION
Rebased onto develop after [76bba20](https://github.com/mqtt-viewer/mqtt-viewer/commit/76bba20), which landed the synchronous receive path. That fixed MQTT 5. **MQTT 3 is still reordering**, and that is what is left here.

## Why v5 is fixed and v3 is not

History and the message buffer are plain appends. Nothing sorts by `TimeMs`, and `GetTopicHistory` / `GetAllHistory` return slice order, so append order **is** what the timeline shows.

- **v5** delivers publishes one at a time: `routePublishPackets` is a single `for pb := range c.publishPackets` loop. Once the receive path stopped spawning a goroutine per message, v5 became ordered.
- **v3** sets `SetOrderMatters(false)`, and paho then hands each incoming message to its own goroutine before our code runs at all ([router.go:179-190](https://github.com/eclipse/paho.mqtt.golang/blob/v1.5.1/router.go#L179-L190), the default-handler branch, which is what we use). Making our own path synchronous cannot fix that. And because the arrival timestamp is stamped with `time.Now()` *inside* our handler, the timestamps get reordered too.

`SetOrderMatters(true)` makes paho dispatch sequentially from its reader goroutine, matching v5.

## The test that pins it

The integration test publishes a numbered run of 500 over both versions. Against develop as it stands today, with the synchronous receive path already in place:

- `TestV5PreservesPublishOrder` passes
- `TestV3PreservesPublishOrder` fails at message 1

That asymmetry is the whole argument for this change. The unit tests cover the other layer: they feed `receiveMessage` in order and assert history and buffer order, and fail within the first few of 2000 messages against a spawned-goroutine receive path, which is what guards 76bba20's fix from regressing.

Both integration tests use a per-run unique topic and client ID. The broker is shared across worktrees, and a fixed topic let a concurrent run's messages interleave into this one and fail with the exact "out of order" message the test uses to report the real bug.

## Cost of serialising v3

Everything now on that goroutine costs ~700-800 ns per message with production logging settings, about 1.3M msg/s on one core against a 2 x 2000 msg/s bar. Proto decode already ran inline before this change, so it is not newly serialised.

The trade-off worth knowing: paho calls us from the goroutine reading the connection, so slow work there is backpressure on the socket rather than queued goroutines. The one caller that can hold the history mutex for a noticeable stretch is `ExportAllMessages` via `GetAllHistory`, measured at ~150 ms with a full 512 MB window. That is well inside the keepalive budget (20 s keepalive plus a 10 s ping timeout), so it stalls reading briefly and recovers. The code comment says so, and says not to put anything slower on that path.

## Not in scope

This does not touch the data races in [#147](https://github.com/mqtt-viewer/mqtt-viewer/pull/147). Dispatching v3 sequentially does remove the concurrency that was triggering the `ConnectionStats` counter race, so `-race` gets quieter, but `GetStats` still reads those counters unsynchronised from the 1 s poll, and the connection-map, proto-registry and connection-state races are untouched.

## Also here

- `perf-check` skill: the traps found running it for real (RSS is meaningless once load stops, silence the per-message debug log before benchmarking, `scripts/.venv` is missing in worktrees, server mode can panic mid-run).
- `CLAUDE.md`: what an adversarial review means here, since running one on this branch found the test flaw above and disproved one of the benchmark claims originally made for it.

## Verified

`just test`, `go build ./...`, `go vet ./...`, `pnpm check` and the changelog tests all green on the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)