### PR TITLE
fix(mqtt): remove duplicate v3 subscribe, fix v5 index panic

### DIFF
--- a/backend/mqtt/manager_test.go
+++ b/backend/mqtt/manager_test.go
@@ -127,6 +127,117 @@ func testPubSub(t *testing.T, mqttVersion string) {
 	})
 }
 
+func TestV3MultiSubscribe(t *testing.T) {
+	testMultiSubscribe(t, "3")
+}
+
+func TestV5MultiSubscribe(t *testing.T) {
+	testMultiSubscribe(t, "5")
+}
+
+// testMultiSubscribe connects with several subscriptions, one of them a
+// wildcard, and checks every published message lands in history exactly once.
+// The filters are deliberately non-overlapping: a message matching more than
+// one filter may be delivered once per matching subscription, which is broker
+// dependent and would make the count assertion flaky.
+func testMultiSubscribe(t *testing.T, mqttVersion string) {
+	m := getTestMqttManager(t)
+	connDetails := MqttConnectionDetails{
+		Host:        "localhost",
+		Port:        1883,
+		Protocol:    "mqtt",
+		MqttVersion: mqttVersion,
+	}
+
+	first := fmt.Sprintf("%v/first", t.Name())
+	second := fmt.Sprintf("%v/second", t.Name())
+	wildcard := fmt.Sprintf("%v/wild/+", t.Name())
+	wildcardMatch := fmt.Sprintf("%v/wild/leaf", t.Name())
+
+	err := m.Connect(connDetails, []SubscribeParams{
+		{Topic: first, QoS: 0},
+		{Topic: second, QoS: 0},
+		{Topic: wildcard, QoS: 0},
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	for _, topic := range []string{first, second, wildcardMatch} {
+		err = m.Publish(MqttPublishParams{
+			Topic:   topic,
+			Payload: []byte("test"),
+			QoS:     0,
+			Retain:  false,
+		})
+		if err != nil {
+			t.Fatalf("Expected no error publishing to %v, got %v", topic, err)
+		}
+	}
+	// Give time to publish
+	time.Sleep(500 * time.Millisecond)
+
+	for _, topic := range []string{first, second, wildcardMatch} {
+		history, err := m.MessageHistory.GetTopicHistory(topic)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+			continue
+		}
+		if len(history) != 1 {
+			t.Errorf("Expected 1 message in history for %v, got %v", topic, len(history))
+		}
+	}
+}
+
+func TestV3SubscribeSkipsEmptyTopics(t *testing.T) {
+	testSubscribeSkipsEmptyTopics(t, "3")
+}
+
+func TestV5SubscribeSkipsEmptyTopics(t *testing.T) {
+	testSubscribeSkipsEmptyTopics(t, "5")
+}
+
+// testSubscribeSkipsEmptyTopics covers an empty topic sitting in front of a
+// real one. validateSubs only requires that one topic is non-empty, so this
+// shape reaches the subscribe path and must not panic or lose the real
+// subscription.
+func testSubscribeSkipsEmptyTopics(t *testing.T, mqttVersion string) {
+	m := getTestMqttManager(t)
+	connDetails := MqttConnectionDetails{
+		Host:        "localhost",
+		Port:        1883,
+		Protocol:    "mqtt",
+		MqttVersion: mqttVersion,
+	}
+	err := m.Connect(connDetails, []SubscribeParams{
+		{Topic: "", QoS: 0},
+		{Topic: t.Name(), QoS: 0},
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	err = m.Publish(MqttPublishParams{
+		Topic:   t.Name(),
+		Payload: []byte("test"),
+		QoS:     0,
+		Retain:  false,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	// Give time to publish
+	time.Sleep(500 * time.Millisecond)
+
+	history, err := m.MessageHistory.GetTopicHistory(t.Name())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if len(history) != 1 {
+		t.Errorf("Expected 1 message in history, got %v", len(history))
+	}
+}
+
 func getTestMqttManager(t *testing.T) *MqttManager {
 	m := NewMqttManager(context.Background(), func(int32) {})
 	m.SetConnectionCallbacks(MqttConnectionCallbacks{

--- a/backend/mqtt/subscribe.go
+++ b/backend/mqtt/subscribe.go
@@ -31,32 +31,26 @@ func subscribeV3(ctx context.Context, c mqttV3.Client, subs []SubscribeParams) e
 			if token.Error() != nil {
 				return newSubError(token.Error())
 			}
-
-			if token := c.Subscribe(sub.Topic, byte(sub.QoS), nil); token.Wait() && token.Error() != nil {
-				return newSubError(token.Error())
-			}
 		}
 	}
 	return nil
 }
 
 func subscribeV5(ctx context.Context, logCtx context.Context, cm *autopaho.ConnectionManager, subs []SubscribeParams) error {
-	var nonEmptySubCount = 0
+	var subscriptions = make([]mqttV5.SubscribeOptions, 0, len(subs))
 	for _, sub := range subs {
-		if sub.Topic != "" {
-			nonEmptySubCount++
+		if sub.Topic == "" {
+			continue
 		}
+		slog.InfoContext(logCtx, fmt.Sprintf("subscribing to topic %v with QoS %v", sub.Topic, sub.QoS))
+		subscriptions = append(subscriptions, mqttV5.SubscribeOptions{
+			Topic:             sub.Topic,
+			QoS:               byte(sub.QoS),
+			RetainAsPublished: true,
+		})
 	}
-	var subscriptions = make([]mqttV5.SubscribeOptions, nonEmptySubCount)
-	for i, sub := range subs {
-		if sub.Topic != "" {
-			slog.InfoContext(logCtx, fmt.Sprintf("subscribing to topic %v with QoS %v", sub.Topic, sub.QoS))
-			subscriptions[i] = mqttV5.SubscribeOptions{
-				Topic:             sub.Topic,
-				QoS:               byte(sub.QoS),
-				RetainAsPublished: true,
-			}
-		}
+	if len(subscriptions) == 0 {
+		return nil
 	}
 	res, err := cm.Subscribe(ctx, &mqttV5.Subscribe{
 		Subscriptions: subscriptions,


### PR DESCRIPTION
Spotted incidentally during an adversarial review of #149.

## The duplicate subscribe is real, but only on v3

`subscribeV3` sent a second `SUBSCRIBE` for every topic immediately after the first had been acknowledged. Harmless on the wire, since a repeat SUBSCRIBE for the same filter replaces the existing subscription rather than duplicating delivery, but it doubled the SUBACK round trips at connect time.

The v5 path was **not** doing this. It already batches every filter into a single `SUBSCRIBE` packet, so the review note's "both paths" framing does not hold.

Nothing suggests the second call was deliberate. There are no comments on it, and the history is squashed at the public repo migration (`ca1bb4e`) so there is no recorded intent. The leftover call also uses the older `token.Wait()` pattern that the first call's `WaitTimeout` plus error handling replaced, which reads like an incomplete edit.

## The v5 path had a worse bug

While confirming the above I found a crash. `subscribeV5` sized the options slice by the count of non-empty topics, then filled it using the index of the *unfiltered* slice:

```go
var subscriptions = make([]mqttV5.SubscribeOptions, nonEmptySubCount)
for i, sub := range subs {
    if sub.Topic != "" {
        subscriptions[i] = ...  // i indexes subs, not subscriptions
    }
}
```

An empty topic sitting in front of a real one panics with `index out of range`. This is reachable: `validateSubs` only requires that *at least one* topic is non-empty, so a mixed list gets through. Confirmed against the original code:

```
panic: runtime error: index out of range [1] with length 1
mqtt-viewer/backend/mqtt.subscribeV5(...)
	backend/mqtt/subscribe.go:54
```

Building the slice with `append` fixes it. I also added an early return when every topic is empty, so the function no longer depends on the caller having validated first, and never sends a malformed zero-subscription SUBSCRIBE.

## Verification

Against a local mosquitto broker with verbose logging, connecting v3 and v5 with three subscriptions each, one a wildcard:

| | SUBSCRIBE packets |
| --- | --- |
| Before | 7 (v3: 6, v5: 1) |
| After | 4 (v3: 3, v5: 1) |

New tests in `backend/mqtt/manager_test.go`, both run against v3 and v5:

- `TestV3/V5MultiSubscribe` connects with several subscriptions including a wildcard and asserts each published message lands in history exactly once. The filters are deliberately non-overlapping, because a message matching more than one filter may be delivered once per matching subscription, which is broker dependent and would make the assertion flaky.
- `TestV3/V5SubscribeSkipsEmptyTopics` covers the empty-topic-first shape. This panics on the old v5 code and passes now.

The existing `TestV3/V5PubSub` already asserted exactly-once delivery and still passes, which is the direct check that removing the second subscribe changed nothing about delivery.

`go build ./...`, `go vet ./...` and `just test` are green (`backend/mqtt`: 34 passed, 0 failed). Frontend is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)