### PR TITLE
fix(mqtt): give every connection its own client ID

### DIFF
--- a/backend/mqtt/client_id_test.go
+++ b/backend/mqtt/client_id_test.go
@@ -1,0 +1,119 @@
+package mqtt
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The ID used to be the Unix second, so every call inside the same second
+// returned the same string and two connections evicted each other's session.
+func TestGeneratedClientIdsAreUnique(t *testing.T) {
+	const runs = 1000
+	seen := make(map[string]bool, runs)
+	for i := 0; i < runs; i++ {
+		id := getUniqueClientId()
+		if seen[id] {
+			t.Fatalf("duplicate client ID after %d calls: %q", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+// Brokers are commonly configured with ACLs keyed on the prefix, and MQTT
+// 3.1.1 only obliges a broker to accept 23 bytes.
+func TestGeneratedClientIdShape(t *testing.T) {
+	id := getUniqueClientId()
+	if !strings.HasPrefix(id, clientIdPrefix) {
+		t.Errorf("client ID %q lost the %q prefix", id, clientIdPrefix)
+	}
+	if len(id) > maxGeneratedClientIdBytes {
+		t.Errorf("client ID %q is %d bytes, over the %d a broker must accept",
+			id, len(id), maxGeneratedClientIdBytes)
+	}
+	if id == clientIdPrefix {
+		t.Errorf("client ID %q has no unique suffix", id)
+	}
+}
+
+// Generating concurrently must not hand out the same ID either.
+func TestGeneratedClientIdsAreUniqueConcurrently(t *testing.T) {
+	const goroutines = 8
+	const perGoroutine = 200
+
+	var mu sync.Mutex
+	seen := make(map[string]bool, goroutines*perGoroutine)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				id := getUniqueClientId()
+				mu.Lock()
+				if seen[id] {
+					t.Errorf("duplicate client ID %q", id)
+				}
+				seen[id] = true
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// The behaviour that actually matters: two connections opened at the same
+// moment, as happens when the app reconnects several saved connections to one
+// broker, must both stay up rather than evicting each other. Needs the local
+// test broker (scripts/test-broker.sh up).
+func TestConcurrentConnectionsToOneBrokerBothSurvive(t *testing.T) {
+	const connections = 4
+
+	managers := make([]*MqttManager, connections)
+	for i := range managers {
+		managers[i] = getTestMqttManager(t)
+	}
+
+	// Connect them together so they land inside the same second.
+	var wg sync.WaitGroup
+	errs := make([]error, connections)
+	for i, m := range managers {
+		wg.Add(1)
+		go func(i int, m *MqttManager) {
+			defer wg.Done()
+			errs[i] = m.Connect(MqttConnectionDetails{
+				Host:        "localhost",
+				Port:        1883,
+				Protocol:    "mqtt",
+				MqttVersion: "5",
+			}, []SubscribeParams{{Topic: testTopic(t), QoS: 0}})
+		}(i, m)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("connection %d failed to connect: %v", i, err)
+		}
+	}
+
+	// Every client ID should be distinct, which is what stops the eviction.
+	seen := make(map[string]bool, connections)
+	for i, m := range managers {
+		id := m.connection.clientId
+		if seen[id] {
+			t.Fatalf("connection %d reused client ID %q", i, id)
+		}
+		seen[id] = true
+	}
+
+	// Give the broker a moment to drop anyone it decided to evict, then check
+	// they are all still connected.
+	time.Sleep(time.Second)
+	for i, m := range managers {
+		if state := m.ConnectionState; state != ConnectionStates.Connected {
+			t.Errorf("connection %d is %s, expected it to stay connected", i, state)
+		}
+	}
+}

--- a/backend/mqtt/connect.go
+++ b/backend/mqtt/connect.go
@@ -2,7 +2,9 @@ package mqtt
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -291,8 +293,36 @@ func (mm *MqttManager) connectV3(ctx context.Context, connectionDetails MqttConn
 	return &client, nil
 }
 
+// clientIdPrefix is kept stable because brokers are commonly configured with
+// ACLs or access rules that key on the client ID.
+const clientIdPrefix = "mqtt-viewer-"
+
+// maxGeneratedClientIdBytes is the length every MQTT 3.1.1 broker is required
+// to accept ([MQTT-3.1.3-5]: servers MUST accept 1 to 23 UTF-8 bytes, and may
+// accept more). Staying inside it means a strict or embedded broker cannot
+// reject us with "identifier rejected".
+const maxGeneratedClientIdBytes = 23
+
+// getUniqueClientId builds the client ID for connections where the user has
+// not set a custom one.
+//
+// The suffix is random rather than the Unix second it used to be. At second
+// resolution any two connections opened in the same second got an identical
+// ID, and a broker evicts the existing session when a new client presents an
+// ID already in use, so the two connections sat kicking each other off. That
+// hit anyone opening two connections to one broker at once, or running two
+// copies of the app, and it was the cause of flaky broker tests.
+//
+// Five random bytes give a 22 byte ID, the same length as before and one
+// under the limit. Sessions are always clean (v3 defaults to CleanSession,
+// v5 sets CleanStartOnInitialConnection), and the generated ID is never
+// persisted, so nothing depends on it staying the same between connects.
 func getUniqueClientId() string {
-	return fmt.Sprintf("mqtt-viewer-%d", time.Now().Unix())
+	suffix := make([]byte, 5)
+	// Never returns an error: since Go 1.24 crypto/rand.Read panics rather
+	// than failing.
+	_, _ = rand.Read(suffix)
+	return clientIdPrefix + hex.EncodeToString(suffix)
 }
 
 func validateConnectionDetails(connectionDetails MqttConnectionDetails) error {

--- a/backend/mqtt/manager_test.go
+++ b/backend/mqtt/manager_test.go
@@ -3,8 +3,11 @@ package mqtt
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestConnectV3(t *testing.T) {
@@ -17,6 +20,7 @@ func TestConnectV5(t *testing.T) {
 
 func testConnect(t *testing.T, mqttVersion string) {
 	m := getTestMqttManager(t)
+	topic := testTopic(t)
 	hasConnecting := false
 	hasConnected := false
 	connectionCallbacks := MqttConnectionCallbacks{
@@ -37,7 +41,7 @@ func testConnect(t *testing.T, mqttVersion string) {
 	}
 	err := m.Connect(connDetails, []SubscribeParams{
 		{
-			Topic: t.Name(),
+			Topic: topic,
 			QoS:   0,
 		},
 	})
@@ -58,6 +62,7 @@ func TestV3ConnectWs(t *testing.T) {
 
 func testConnectWithWs(t *testing.T, mqttVersion string) {
 	m := getTestMqttManager(t)
+	topic := testTopic(t)
 	connDetails := MqttConnectionDetails{
 		Host:        "localhost",
 		Port:        9001,
@@ -66,7 +71,7 @@ func testConnectWithWs(t *testing.T, mqttVersion string) {
 	}
 	err := m.Connect(connDetails, []SubscribeParams{
 		{
-			Topic: t.Name(),
+			Topic: topic,
 			QoS:   0,
 		},
 	})
@@ -85,6 +90,7 @@ func TestV5PubSub(t *testing.T) {
 
 func testPubSub(t *testing.T, mqttVersion string) {
 	m := getTestMqttManager(t)
+	topic := testTopic(t)
 	connDetails := MqttConnectionDetails{
 		Host:        "localhost",
 		Port:        1883,
@@ -93,7 +99,7 @@ func testPubSub(t *testing.T, mqttVersion string) {
 	}
 	err := m.Connect(connDetails, []SubscribeParams{
 		{
-			Topic: t.Name(),
+			Topic: topic,
 			QoS:   0,
 		},
 	})
@@ -102,7 +108,7 @@ func testPubSub(t *testing.T, mqttVersion string) {
 	}
 
 	publishParams := MqttPublishParams{
-		Topic:   t.Name(),
+		Topic:   topic,
 		Payload: []byte("test"),
 		QoS:     0,
 		Retain:  false,
@@ -113,7 +119,7 @@ func testPubSub(t *testing.T, mqttVersion string) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	history, err := m.MessageHistory.GetTopicHistory(t.Name())
+	history, err := m.MessageHistory.GetTopicHistory(topic)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -125,6 +131,14 @@ func testPubSub(t *testing.T, mqttVersion string) {
 			t.Errorf("Expected 1 message in buffer, got %v", len(buffer))
 		}
 	})
+}
+
+// testTopic gives each run its own topic. The test broker is shared across
+// worktrees, so a topic fixed to t.Name() means a concurrent run's messages
+// arrive here too, which shows up as "Expected 1 message in history, got 2".
+func testTopic(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("%s/%d/%s", t.Name(), os.Getpid(), uuid.NewString())
 }
 
 func getTestMqttManager(t *testing.T) *MqttManager {

--- a/backend/mqtt/reconnect_integration_test.go
+++ b/backend/mqtt/reconnect_integration_test.go
@@ -65,7 +65,7 @@ func testReconnect(t *testing.T, mqttVersion, down, up string) {
 			Port:        reconnectBrokerPort,
 			Protocol:    "mqtt",
 			MqttVersion: mqttVersion,
-		}, []SubscribeParams{{Topic: t.Name(), QoS: 0}})
+		}, []SubscribeParams{{Topic: testTopic(t), QoS: 0}})
 		if err != nil {
 			t.Fatalf("initial connect failed: %v", err)
 		}

--- a/frontend/src/changelog.ts
+++ b/frontend/src/changelog.ts
@@ -169,6 +169,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         title: "Deleting a connection works again",
         body: "Deleting a connection could fail and quietly roll back if you'd ever used publish or filter history on it. It now removes everything that belongs to the connection, and clearing out a large message history no longer freezes the app while it works.",
       },
+      {
+        title: "Two connections to the same broker no longer fight",
+        body: "Opening two connections to one broker in the same second, or running a second copy of the app, gave both the same client ID, so the broker kept dropping one to make room for the other and neither would settle. Each connection now gets its own ID.",
+      },
     ],
   },
   {


### PR DESCRIPTION
`getUniqueClientId()` built the client ID from `time.Now().Unix()`, so any two connections opened in the same second got the **same** ID. A broker evicts the existing session when a new client connects with an ID already in use, so the two connections sit kicking each other off indefinitely.

This is not only a test problem. It hits anyone opening two connections to one broker at once, or running a second copy of the app.

## The fix

Five random bytes instead of the timestamp.

**The ID stays 22 bytes, exactly as long as before.** That matters more than it looks: MQTT 3.1.1 only obliges a server to accept client IDs of 1 to 23 bytes ([MQTT-3.1.3-5]), and longer support is optional. A `uuid.NewString()` suffix would have made it 48 bytes and risked `identifier rejected` from strict or embedded brokers, which is a real target here given the Sparkplug and industrial use cases. The `mqtt-viewer-` prefix is unchanged, since brokers are commonly configured with ACLs that key on it.

## Nothing depended on the ID being stable

Checked before changing it:

- **Sessions are always clean.** v3 never calls `SetCleanSession`, and paho's default is `CleanSession: true` ([options.go:130](https://github.com/eclipse/paho.mqtt.golang/blob/v1.5.1/options.go#L130)). v5 sets `CleanStartOnInitialConnection: true`. So there is no server-side session state to resume.
- **It is never persisted.** The connection form stores `clientId: values.hasCustomClientId ? values.clientId : null`, so the DB column is null unless the user set a custom ID, and `getUniqueClientId` is only reached when it is empty.
- **It is never displayed.** It is written to `mqttActiveConnection.clientId` and nothing reads that field.
- **Reconnects keep the same ID.** It is generated once per `Connect()` and both clients reuse their options across auto-reconnect.
- Users who need a stable ID already have the "Use custom Client ID" toggle, which is untouched.

## Tests

Uniqueness, prefix and length are asserted directly. There is also an integration test that opens four connections to one broker simultaneously and checks they all stay connected.

On the old code, that integration test does not merely fail:

```
--- FAIL: TestConcurrentConnectionsToOneBrokerBothSurvive (20.00s)
    connection 0 failed to connect: connect: timeout while connecting to broker
```

A 20 second timeout, which is the eviction loop rather than a clean error. The unit tests fail immediately: `duplicate client ID after 1 calls: "mqtt-viewer-1785809451"`.

## Also: unique topics for the broker tests

Verifying the fix by running the mqtt package concurrently showed it was **not** the whole story. `TestV3PubSub` / `TestV5PubSub` still failed, with `Expected 1 message in history, got 2` — a second mechanism entirely. Those tests published to `t.Name()`, a fixed topic on a broker shared across worktrees, so a concurrent run's messages arrived in this one.

Broker-dependent tests now derive a unique topic per run (`t.Name()` plus PID plus a UUID).

**Result:** the mqtt package passes 4 concurrent runs. Before these two fixes, 2 of 3 concurrent runs failed. That is the flakiness that has been written off as "shared broker contention" for a while.

## Verified

- `just test` green (34 tests in `backend/mqtt`, 85 in `backend/app`).
- `go build ./...`, `go vet ./...` clean.
- `pnpm check` 0 errors, changelog tests pass.
- 4 concurrent runs of `./backend/mqtt` all green.

One thing this does **not** fix: running `./backend/app` concurrently can still fail with `panic: disk I/O error (1802)`, because `getTestApp(t)` uses a fixed `backend/app/_test/<TestName>` directory and `os.RemoveAll`s it on entry, so concurrent runs of the same test delete each other's SQLite database. Same family of problem, different resource, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)