### PR TITLE
test(app): stop concurrent runs deleting each other's database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,11 @@ Full pre-merge bar for `develop`: `go build ./...`, `go vet ./...`,
 - Database changes: edit the GORM model, register it in
   `loader/main.go` if new, then `just new-migration <name>`. Never
   hand-edit applied migrations.
-- Backend tests use `getTestApp(t)` with golden dirs under
-  `backend/app/_test/<TestName>/`; keep new tests in that pattern.
+- Backend tests use `getTestApp(t)`, which gives each test a scratch
+  resource dir at `backend/app/_test/<TestName>-<pid>/` (gitignored, not
+  golden data). Keep new tests in that pattern, and never derive that
+  path yourself: the PID keeps concurrent `go test` runs from deleting
+  each other's SQLite database.
 - Anything a user reads follows `docs/WRITING_STYLE.md`. Hard rules: no
   emojis, no em dashes, first person singular, British spelling, terse.
 - Changelog: every user-facing feature or fix MUST add a section to the

--- a/backend/app/startup_test.go
+++ b/backend/app/startup_test.go
@@ -27,8 +27,26 @@ func startTestAppAt(exPath string) *App {
 	return app
 }
 
+// getTestApp starts an App against a resource dir of its own.
+//
+// The dir name carries the PID because it used to be just
+// backend/app/_test/<TestName>, wiped with os.RemoveAll on entry. That path
+// has no per-run component, so two `go test` processes running the same test
+// deleted and recreated the directory underneath each other while SQLite had
+// the database open, and the run died with "disk I/O error (1802)". Agents and
+// worktrees share this machine and run the suite at the same time, so it hit
+// often enough to look like a real failure.
+//
+// Not t.TempDir: Startup writes the sparkplug proto files from a goroutine
+// that outlives the test, so it can still be creating files while the test
+// framework tears the directory down. t.TempDir treats that as a cleanup
+// error and fails the test; the RemoveAll below tolerates it, which is the
+// behaviour this suite has always relied on.
+//
+// _test is gitignored scratch, so a directory orphaned by a killed run is
+// harmless, and deleting the whole _test tree is always safe.
 func getTestApp(t *testing.T) *App {
-	exPath := filepath.Join(appDir, "_test", t.Name())
+	exPath := filepath.Join(appDir, "_test", fmt.Sprintf("%s-%d", t.Name(), os.Getpid()))
 	// Clean any old test db left over from a previous run before starting fresh.
 	os.RemoveAll(exPath)
 	os.MkdirAll(exPath, os.ModePerm)
@@ -43,8 +61,11 @@ func getTestApp(t *testing.T) *App {
 // reopenTestApp closes the app's DB connection and starts a new App against
 // the same on-disk resource dir, simulating an app restart that reloads
 // whatever was persisted rather than wiping and recreating the DB.
+//
+// It reads the path back off the app rather than recomputing it, so there is
+// only one place that decides where a test app lives.
 func reopenTestApp(t *testing.T, app *App) *App {
-	exPath := filepath.Join(appDir, "_test", t.Name())
+	exPath := app.Paths.ResourcePath
 	DB, err := app.Db.DB.DB()
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)


### PR DESCRIPTION
`getTestApp` built its resource dir as `backend/app/_test/<TestName>` and `os.RemoveAll`'d it on entry. That path has no per-run component, so two `go test ./backend/app/` processes running the same test wiped and recreated the directory underneath each other while SQLite had the database file open. The result is an unrecoverable `panic: disk I/O error (1802)` that takes the whole run down, in whichever test happened to be executing.

Several agents and worktrees share this machine and run the suite at once, so this has been surfacing as random failures.

## The fix

The directory name now carries the PID. `reopenTestApp` also reads the path back off the app rather than recomputing it, so only one place decides where a test app lives.

**Four concurrent runs, twice over: no disk I/O error, no panic.** Before, that reproduced reliably.

## Two things worth recording

**There are no golden fixtures under `backend/app/_test/`.** The whole directory is gitignored (`.gitignore:8`) and `git ls-files` returns nothing for it, so it is pure scratch. The committed proto fixtures that tests read live in `backend/protobuf/test-protos/` and `backend/app/test-protos/`, neither of which `getTestApp` touches. I checked this first because CLAUDE.md called them "golden dirs", which suggested there was something to preserve. There is not, and CLAUDE.md is corrected here.

**`t.TempDir()` is the obvious answer and it does not work.** `Startup` writes the sparkplug proto files from a goroutine that outlives the test, so files can still be appearing while the framework tears the directory down. `t.TempDir` treats that as a cleanup error and fails the test:

```
--- FAIL: TestConnectMqttUnknownConnection (0.01s)
    testing.go:1369: TempDir RemoveAll cleanup: unlinkat /var/folders/.../001/protobuf: directory not empty
```

The existing `os.RemoveAll` tolerates it, which is the behaviour this suite has always quietly relied on. I tried `t.TempDir`, hit that across many tests, and reverted. The comment in the code records why, so the next person does not repeat it.

## Scope

This does **not** make `./backend/app` fully concurrency-safe on its own. With the fixture collision fixed, the remaining concurrent failures are all the MQTT client ID eviction signature:

```
connect: subscribe: connection lost before Subscribe completed
connect: subscribe: not currently connected and ResumeSubs not set
```

That is the production `getUniqueClientId()` bug fixed in [#151](https://github.com/mqtt-viewer/mqtt-viewer/pull/151), which is not on develop yet. I verified the combination locally by merging this branch with #151: **eight concurrent runs of `./backend/app`, all green.** Either alone leaves the suite flaky under concurrency; together they fix it.

## Verified

- `just test` green.
- `go vet ./...` clean.
- 4 concurrent runs x 2 rounds: zero disk I/O errors, zero panics.
- Merged with #151: 4 concurrent runs x 2 rounds, all exit 0.

No changelog entry: test infrastructure only, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)